### PR TITLE
Ticket766 synoptic names

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/SaveSynopticDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/SaveSynopticDialog.java
@@ -30,7 +30,6 @@ public class SaveSynopticDialog extends TitleAreaDialog {
 	private Text txtName;
 	
 	private String newName = "";
-	private String currentName = "";
 	private List<String> existingSynoptics;
 	
 	public SaveSynopticDialog(
@@ -40,9 +39,6 @@ public class SaveSynopticDialog extends TitleAreaDialog {
 		super(parent);
 		setShellStyle(SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
 		this.existingSynoptics = new ArrayList<>(existingSynoptics);
-		if (currentName != null) {
-			this.currentName = currentName;
-		}
 	}
 	
 	public String getNewName() {


### PR DESCRIPTION
The changes in this pull request fix the prompt when overwriting an existing synoptic.

To test: if you have save a new/existing synoptic with the same name as a synoptic that exists, an appropriate warning and confirmation should be shown.

Other changes relating to this ticket are in the EPICS repository, commit 2948.
