### PR TITLE
The gui should not let you save a config with a blank name

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
@@ -68,7 +68,7 @@ public class EditConfigDialog extends TitleAreaDialog implements MessageDisplaye
 	
 	@Override
 	protected void createButtonsForButtonBar(Composite parent) {
-		if (isBlank == false){ 
+		if (isBlank == false && !this.config.getName().isEmpty()){ 
 			createButton(parent, IDialogConstants.OK_ID, "Save", true);
 		}
 		saveAsBtn = createButton(parent, IDialogConstants.CLIENT_ID + 1, "Save as ...", false);


### PR DESCRIPTION
Ticket754 = It is possible to save a config without a name via the GUI.

This fixes the GUI side, the BlockServer side will be done in SVN
