### PR TITLE
Sd port get/set val

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/sdtest/port.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/sdtest/port.opi
@@ -563,7 +563,7 @@ $(pv_value)</tooltip>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <format_type>4</format_type>
+    <format_type>0</format_type>
     <precision_from_pv>true</precision_from_pv>
     <transparent>false</transparent>
     <pv_name>$(P)$(PORT)GETVAL</pv_name>


### PR DESCRIPTION
Update GUI to show special "value" defined in configuration

SDTEST is configured via macros like (e.g. for an SMC100 stage)

SDTEST_01__PORT1=COM1
SDTEST_01__BAUD1=57600
SDTEST_01__SCAN1=.5 second
SDTEST_01__GETOUT1=1TP
SDTEST_01__GETIN1=1TP%f
SDTEST_01__SETOUTA1=1PA
SDTEST_01__SETFMT1=%f
SDTEST_01__SETREPLY1=%*s
