### PR TITLE
Bug renaming blocks

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -94,9 +94,6 @@ public class EditableConfiguration extends ModelObject {
 			oldBlock.setName(oldName);
 			blocksBeforeRename.add(oldBlock);
 			
-			//makeBlockUnavailable((EditableBlock) oldBlock);
-			//makeBlockAvailable((EditableBlock) renamed);
-			
 			firePropertyChange("blocks", blocksBeforeRename, getBlocks());
 		}
 	};


### PR DESCRIPTION
When editing a configuration if you change a block's name the table on the blocks tab does not reflect this change, but the name does update on the groups tab.
This fixes the blocks tab; the deleted methods don't actually need to be called as those lists are updated elsewhere. Also, they crash because down-casting a Block to an EditableBlock causes a runtime error.
