### PR TITLE
Ticket 822: Does not matter if read or write comes first for the synoptic

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/SaveSynopticDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/SaveSynopticDialog.java
@@ -134,7 +134,7 @@ public class SaveSynopticDialog extends TitleAreaDialog {
 	  protected void okPressed() {
 		if (validate(name())) {
 			newName = name();
-			//Warn about overwriting if already exists
+			// Warn about overwriting if already exists
 			if (isDuplicate(newName)) {
 				boolean userCancelled = askUserWhetherToOverwrite(newName);
 				if (userCancelled) {
@@ -152,7 +152,7 @@ public class SaveSynopticDialog extends TitleAreaDialog {
 		MessageBox box = new MessageBox(getShell(), SWT.ICON_WARNING | SWT.YES | SWT.NO);
 		box.setMessage("The synoptic \"" + newName + "\" already exists. \n Do you want to replace it?");
 		
-		//Message boxes return the ID of the button to close, so need to check that value..
+		// Message boxes return the ID of the button to close, so need to check that value..
 		return box.open() != SWT.YES;
 	}
 	
@@ -185,7 +185,7 @@ public class SaveSynopticDialog extends TitleAreaDialog {
 	}
 	
 	private Boolean validate(String name) {		
-		//Must start with a letter and contain no spaces	
+		// Must start with a letter and contain no spaces	
 		return name.matches("^[a-zA-Z][a-zA-Z0-9_]*$");
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/ComponentPropertiesView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/ComponentPropertiesView.java
@@ -19,6 +19,9 @@
 
 package uk.ac.stfc.isis.ibex.ui.synoptic.component;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.swt.SWT;
@@ -31,6 +34,10 @@ import uk.ac.stfc.isis.ibex.synoptic.model.ComponentProperty;
 import uk.ac.stfc.isis.ibex.synoptic.model.ReadableComponentProperty;
 import uk.ac.stfc.isis.ibex.synoptic.model.WritableComponentProperty;
 
+/**
+ * Displays the PVs on the synoptic.
+ *
+ */
 public class ComponentPropertiesView extends Composite {
 		
 	public ComponentPropertiesView(Composite parent, Component component) {
@@ -46,18 +53,45 @@ public class ComponentPropertiesView extends Composite {
 	}
 
 	private void createPropertyViews(Set<ComponentProperty> properties) {
-		String precedingPropertyName = null;
-		for (ComponentProperty property : properties) {
-			if (property instanceof WritableComponentProperty) {
-				// Avoid duplication of property names
-				boolean shouldDisplayPropertyName = !property.displayName().equals(precedingPropertyName); 
-				createWriter((WritableComponentProperty) property, shouldDisplayPropertyName); 
-			} else if (property instanceof ReadableComponentProperty) {
-				createReader((ReadableComponentProperty) property); 
+		// Create a list for easier navigation for pairs
+		List<ComponentProperty> props = new ArrayList<>();
+		props.addAll(properties);
+
+		for (int i = 0; i < props.size(); ++i) {
+			ComponentProperty property1 = props.get(i);
+			if (i < props.size() - 1) {
+				ComponentProperty property2 = props.get(i + 1);
+				if (property1.displayName().equals(property2.displayName())) {
+					// Same name, so if one is read and one is write create pair
+					if (property1 instanceof ReadableComponentProperty
+							&& property2 instanceof WritableComponentProperty) {
+						createReaderWriterPair((ReadableComponentProperty) property1,
+								(WritableComponentProperty) property2);
+						++i;
+						continue;
+					} else if (property1 instanceof WritableComponentProperty
+							&& property2 instanceof ReadableComponentProperty) {
+						createReaderWriterPair((ReadableComponentProperty) property2,
+								(WritableComponentProperty) property1);
+						++i;
+						continue;
+					}
+				}
 			}
-			
-			precedingPropertyName = property.displayName();
+
+			// Not paired, use on own
+			if (property1 instanceof WritableComponentProperty) {
+				createWriter((WritableComponentProperty) property1, true);
+			} else if (property1 instanceof ReadableComponentProperty) {
+				createReader((ReadableComponentProperty) property1);
+			}
+
 		}
+	}
+	
+	private void createReaderWriterPair(ReadableComponentProperty reader, WritableComponentProperty writer) {
+		createReader((ReadableComponentProperty) reader); 
+		createWriter((WritableComponentProperty) writer, false); 
 	}
 
 	private void createReader(ReadableComponentProperty property) {


### PR DESCRIPTION
As a user I would like to see items of the same name which I both read and write always combined.
