### PR TITLE
Databrowser error message in log

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser/plugin.xml
@@ -17,17 +17,6 @@
    </extension>
    <extension
          point="org.eclipse.ui.perspectiveExtensions">
-         <view
-               closeable="true"
-               id="org.csstudio.trends.databrowser.ploteditor.PlotEditor:*"
-               minimized="false"
-               ratio="0.1f"
-               relationship="right"
-               relative="uk.ac.stfc.isis.ibex.ui.perspectives.PerspectiveSwitcher"
-               showTitle="true"
-               standalone="true"
-               visible="true">
-         </view>
    </extension>
    <extension
          point="uk.ac.stfc.isis.ibex.ui.blocks.presentation">


### PR DESCRIPTION
When switching to the databrowser the following error appears in the
log:

id org.csstudio.trends.databrowser.ploteditor.PlotEditor:*:
Unknown extension tag found: view

By removing this reference from the Extensions the error goes away,
and everything still works.
