### PR TITLE
Added multiple selection to config editor dialog Blocks tab

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlocksTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlocksTest.java
@@ -19,6 +19,9 @@
 
 package uk.ac.stfc.isis.ibex.configserver.tests.editing;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 import org.junit.Test;
 
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableBlock;
@@ -56,6 +59,21 @@ public class BlocksTest extends EditableConfigurationTest {
 		// Act
 		EditableBlock gapx = getFirst(edited.getEditableBlocks());
 		edited.removeBlock(gapx);
+		
+		// Assert
+		assertEmpty(edited.asConfiguration().getBlocks());
+	}
+	
+	@Test
+	public void multiple_blocks_can_be_removed() {
+		// Arrange
+		blocks.add(GAPX);
+		blocks.add(GAPY);
+		EditableConfiguration edited = edit(config());
+		
+		// Act
+		Collection<EditableBlock> returnedBlocks = edited.getEditableBlocks();
+		edited.removeBlocks(new ArrayList<EditableBlock>(returnedBlocks));
 		
 		// Assert
 		assertEmpty(edited.asConfiguration().getBlocks());

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
@@ -51,6 +51,7 @@ public class EditableConfigurationTest implements IocDescriber {
 	
 	protected static final EditableIoc GALIL01 = new EditableIoc("GALIL_01");
 	protected static final Block GAPX = new Block("GAPX", "ADDRESS", true, true, null);
+	protected static final Block GAPY = new Block("GAPY", "ADDRESS", true, true, null);
 	protected static final Group JAWS = new Group("JAWS");
 	protected static final Group TEMPERATURE = new Group("TEMPERATURE");
 	protected static final Component MOTOR = new Component("MOTOR");

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -274,6 +274,15 @@ public class EditableConfiguration extends ModelObject {
 		firePropertyChange("blocks", blocksBefore, getBlocks());
 	}
 	
+	public void removeBlocks(List<EditableBlock> blocks) {
+		Collection<Block> blocksBefore = getBlocks();
+		for (EditableBlock block : blocks) {
+			editableBlocks.remove(block);
+			makeBlockUnavailable(block);			
+		}
+		firePropertyChange("blocks", blocksBefore, getBlocks());
+	}
+	
 	public EditableGroup addNewGroup() {
 		Collection<EditableGroup> editableGroupsBefore = getEditableGroups();
 		Collection<Group> groupsBefore = getGroups();


### PR DESCRIPTION
To test:
- Edit a configuration
- On the blocks tab select multiple blocks (Using either Ctrl + Click or Shift + Click)
- Confirm that, if all the selected blocks are editable, they can all be deleted but not edited
