### PR TITLE
Ticket937 wrong archive for historical pv data

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
@@ -209,5 +209,7 @@
 		<module>../uk.ac.stfc.isis.ibex.synoptic.tests</module>
 		<module>../uk.ac.stfc.isis.ibex.ui.statusbar</module>
 		<module>../uk.ac.stfc.isis.ibex.databases</module>
+		
+		<module>../uk.ac.stfc.isis.ibex.ui.databrowser.tests</module>
 	</modules>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/.classpath
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/.classpath
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/.project
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>uk.ac.stfc.isis.ibex.ui.databrowser.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/.settings/org.eclipse.jdt.core.prefs
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.8

--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tests
+Bundle-SymbolicName: uk.ac.stfc.isis.ibex.ui.databrowser.tests
+Bundle-Version: 1.0.0.qualifier
+Fragment-Host: uk.ac.stfc.isis.ibex.ui.databrowser;bundle-version="1.0.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.mockito;bundle-version="1.9.5",
+ org.junit4;bundle-version="4.8.1"

--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/build.properties
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>uk.ac.stfc.isis.ibex.ui.databrowser.tests</artifactId>
+  <packaging>eclipse-test-plugin</packaging>
+  <version>0.0.1-SNAPSHOT</version>
+  <parent>
+  	<groupId>CSS_ISIS</groupId>
+  	<artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
+  	<version>1.0.0-SNAPSHOT</version>
+  	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
+  </parent>
+</project>

--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/src/uk/ac/stfc/isis/ibex/ui/databrowser/tests/DataBrowserSettingsTests.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser.tests/src/uk/ac/stfc/isis/ibex/ui/databrowser/tests/DataBrowserSettingsTests.java
@@ -1,0 +1,212 @@
+
+/**
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2015 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+package uk.ac.stfc.isis.ibex.ui.databrowser.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.csstudio.trends.databrowser2.preferences.Preferences;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceStore;
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
+import uk.ac.stfc.isis.ibex.ui.databrowser.DataBrowserSettings;
+
+public class DataBrowserSettingsTests {
+
+    // These settings represent the defaults, as set in
+    // uk.ac.stfc.isis.ibex.product/plugin_customization.ini
+    private final static String DEFAULT_ARCHIVE_SETTINGS = "RDB|1|jdbc\\:mysql\\://localhost/archive*RDB|2|jdbc\\:mysql\\://130.246.39.152/archive";
+    private final static String DEFAULT_URLS_SETTINGS = "jdbc\\:mysql\\://localhost/archive*jdbc\\:mysql\\://130.246.39.152/archive";
+    private final static String LARMOR_ARCHIVE_SETTINGS = "RDB|1|jdbc\\:mysql\\://NDXLARMOR/archive*RDB|2|jdbc\\:mysql\\://130.246.39.152/archive";
+    private final static String LARMOR_URLS_SETTINGS = "jdbc\\:mysql\\://NDXLARMOR/archive*jdbc\\:mysql\\://130.246.39.152/archive";
+    private final static String DEMO_ARCHIVE_SETTINGS = "RDB|1|jdbc\\:mysql\\://NDXDEMO/archive*RDB|2|jdbc\\:mysql\\://130.246.39.152/archive";
+    private final static String DEMO_URLS_SETTINGS = "jdbc\\:mysql\\://NDXDEMO/archive*jdbc\\:mysql\\://130.246.39.152/archive";
+
+    private final static String LOCALHOST = "localhost";
+    private final static String NDXLARMOR = "NDXLARMOR";
+    private final static String NDXDEMO = "NDXDEMO";
+    private final static String NDXLARMOR_LOWERCASE = "ndxlarmor";
+    private final static String NOT_A_HOST_NAME = "JDBC";
+    private final static String IP_ADDRESS = "123.123.123.123";
+
+    private IPreferenceStore preferenceStore;
+    
+    private DataBrowserSettings dataBrowserSettings;
+
+    private InstrumentInfo mockLocalHost;
+    private InstrumentInfo mockLarmor;
+    private InstrumentInfo mockDemo;
+
+    @Before
+    public void setUp() {
+        // Arrange
+        preferenceStore = new PreferenceStore();
+        
+        preferenceStore.setValue(Preferences.ARCHIVES, DEFAULT_ARCHIVE_SETTINGS);
+        preferenceStore.setValue(Preferences.URLS, DEFAULT_URLS_SETTINGS);
+        
+        dataBrowserSettings = new DataBrowserSettings(preferenceStore);
+
+        mockLocalHost = mockInstrument(LOCALHOST);
+        mockLarmor = mockInstrument(NDXLARMOR);
+        mockDemo = mockInstrument(NDXDEMO);
+    }
+
+    private InstrumentInfo mockInstrument(String hostName) {
+        InstrumentInfo returnedInstrument = mock(InstrumentInfo.class);
+        when(returnedInstrument.hostName()).thenReturn(hostName);
+        return returnedInstrument;
+    }
+
+    @Test
+    public void default_archives_setting_is_set_correctly() {
+        // Assert
+        assertEquals(DEFAULT_ARCHIVE_SETTINGS, preferenceStore.getString(Preferences.ARCHIVES));
+    }
+
+    @Test
+    public void default_urls_setting_is_set_correctly() {
+        // Assert
+        assertEquals(DEFAULT_URLS_SETTINGS, preferenceStore.getString(Preferences.URLS));
+    }
+
+    @Test
+    public void swtiching_from_local_host_to_NDXLARMOR_updates_archives_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockLarmor);
+
+        // Assert
+        assertEquals(LARMOR_ARCHIVE_SETTINGS, preferenceStore.getString(Preferences.ARCHIVES));
+    }
+
+    @Test
+    public void swtiching_from_local_host_to_NDXLARMOR_updates_urls_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockLarmor);
+
+        // Assert
+        assertEquals(LARMOR_URLS_SETTINGS, preferenceStore.getString(Preferences.URLS));
+    }
+
+    @Test
+    public void swtiching_from_NDXLARMOR_to_NDXDEMO_updates_archives_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockLarmor);
+        dataBrowserSettings.setInstrument(mockDemo);
+
+        // Assert
+        assertEquals(DEMO_ARCHIVE_SETTINGS, preferenceStore.getString(Preferences.ARCHIVES));
+    }
+
+    @Test
+    public void swtiching_from_NDXLARMOR_to_NDXDEMO_updates_urls_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockLarmor);
+        dataBrowserSettings.setInstrument(mockDemo);
+
+        // Assert
+        assertEquals(DEMO_URLS_SETTINGS, preferenceStore.getString(Preferences.URLS));
+    }
+
+    @Test
+    public void swtiching_from_NDXLARMOR_to_local_host_updates_archives_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockLarmor);
+        dataBrowserSettings.setInstrument(mockLocalHost);
+
+        // Assert
+        assertEquals(DEFAULT_ARCHIVE_SETTINGS, preferenceStore.getString(Preferences.ARCHIVES));
+    }
+
+    @Test
+    public void swtiching_from_NDXLARMOR_to_local_host_updates_urls_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockLarmor);
+        dataBrowserSettings.setInstrument(mockLocalHost);
+
+        // Assert
+        assertEquals(DEFAULT_URLS_SETTINGS, preferenceStore.getString(Preferences.URLS));
+    }
+
+    @Test
+    public void switching_from_lowercase_ndxdemo_to_local_host_does_not_update_archives_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockInstrument(NDXLARMOR_LOWERCASE));
+        dataBrowserSettings.setInstrument(mockLocalHost);
+
+        // Assert
+        assertFalse(DEFAULT_ARCHIVE_SETTINGS.equals(preferenceStore.getString(Preferences.ARCHIVES)));
+    }
+
+    @Test
+    public void switching_from_lowercase_ndxdemo_to_local_host_does_not_update_urls_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockInstrument(NDXLARMOR_LOWERCASE));
+        dataBrowserSettings.setInstrument(mockLocalHost);
+
+        // Assert
+        assertFalse(DEFAULT_ARCHIVE_SETTINGS.equals(preferenceStore.getString(Preferences.ARCHIVES)));
+    }
+
+    @Test
+    public void switching_from_invalid_host_name_to_local_host_does_not_update_archives_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockInstrument(NOT_A_HOST_NAME));
+        dataBrowserSettings.setInstrument(mockLocalHost);
+
+        // Assert
+        assertFalse(DEFAULT_ARCHIVE_SETTINGS.equals(preferenceStore.getString(Preferences.ARCHIVES)));
+    }
+
+    @Test
+    public void switching_from_invalid_host_name_to_local_host_does_not_update_urls_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockInstrument(NOT_A_HOST_NAME));
+        dataBrowserSettings.setInstrument(mockLocalHost);
+
+        // Assert
+        assertFalse(DEFAULT_ARCHIVE_SETTINGS.equals(preferenceStore.getString(Preferences.ARCHIVES)));
+    }
+
+    @Test
+    public void switching_from_IP_host_name_to_local_host_does_not_update_archives_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockInstrument(IP_ADDRESS));
+        dataBrowserSettings.setInstrument(mockLocalHost);
+
+        // Assert
+        assertFalse(DEFAULT_ARCHIVE_SETTINGS.equals(preferenceStore.getString(Preferences.ARCHIVES)));
+    }
+
+    @Test
+    public void switching_from_IP_host_name_to_local_host_does_not_update_urls_settings() {
+        // Act
+        dataBrowserSettings.setInstrument(mockInstrument(IP_ADDRESS));
+        dataBrowserSettings.setInstrument(mockLocalHost);
+
+        // Assert
+        assertFalse(DEFAULT_ARCHIVE_SETTINGS.equals(preferenceStore.getString(Preferences.ARCHIVES)));
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.databrowser/src/uk/ac/stfc/isis/ibex/ui/databrowser/DataBrowserSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.databrowser/src/uk/ac/stfc/isis/ibex/ui/databrowser/DataBrowserSettings.java
@@ -28,14 +28,20 @@ import uk.ac.stfc.isis.ibex.instrument.InstrumentInfoReceiver;
 
 /**
  * This class is responsible for changing the settings for the DataBrowser when
- * the instrument is changed, or first set.
- *
+ * the instrument is changed, or first set. The archives and url settings get
+ * changed.
  */
 public class DataBrowserSettings implements InstrumentInfoReceiver {
 
-	private final static IPreferenceStore PREFERENCES = Activator.getDefault().getPreferenceStore();
-	private final static String DATABASE_URLS = PREFERENCES.getString(Preferences.URLS);
-	private final static String ARCHIVES = PREFERENCES.getString(Preferences.ARCHIVES);	
+    private IPreferenceStore preferences;
+	
+	public DataBrowserSettings() {
+        this(Activator.getDefault().getPreferenceStore());
+	}
+	
+	public DataBrowserSettings(IPreferenceStore preferences) {
+	    this.preferences = preferences;
+	}
 	
 	// Connect the databrowser to the archive engine.
 	@Override
@@ -45,11 +51,11 @@ public class DataBrowserSettings implements InstrumentInfoReceiver {
 	}
 
 	private void setURLs(String hostName) {
-		PREFERENCES.setValue(Preferences.URLS, updateHostName(hostName, DATABASE_URLS));
+        preferences.setValue(Preferences.URLS, updateHostName(hostName, getDatabaseUrls()));
 	}
 	
 	private void setArchives(String hostName) {
-        PREFERENCES.setValue(Preferences.ARCHIVES, updateHostName(hostName, ARCHIVES));
+        preferences.setValue(Preferences.ARCHIVES, updateHostName(hostName, getArchives()));
 	}
 	
     /**
@@ -63,8 +69,17 @@ public class DataBrowserSettings implements InstrumentInfoReceiver {
      * @return The preference string with the host name replace.
      */
 	private static String updateHostName(String hostName, String preference) {
+
         preference = preference.replaceAll("NDX[A-Z]+", hostName);
         preference = preference.replaceAll("localhost", hostName);
         return preference;
 	}
+
+    private String getDatabaseUrls() {
+        return preferences.getString(Preferences.URLS);
+    }
+
+    private String getArchives() {
+        return preferences.getString(Preferences.ARCHIVES);
+    }
 }


### PR DESCRIPTION
https://trac.isis.rl.ac.uk/ICP/ticket/937

To test this can right click on a block, Display Block History, then right click and open the Data Browser Perspective. This lets you check the URLs.

You should be able to see historic block data on instruments - check with Gareth if unsure if things are correct.

Please check unit tests run ok too.
