### PR TITLE
Ticket 924: GUI remembers previous size and location on startup

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.product/src/uk/ac/stfc/isis/ibex/product/ApplicationWorkbenchAdvisor.java
+++ b/base/uk.ac.stfc.isis.ibex.product/src/uk/ac/stfc/isis/ibex/product/ApplicationWorkbenchAdvisor.java
@@ -43,6 +43,12 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
 	}
 	
 	@Override
+	public void initialize(org.eclipse.ui.application.IWorkbenchConfigurer configurer) {
+	    super.initialize(configurer);
+	    configurer.setSaveAndRestore(true);
+	};
+	
+	@Override
 	public boolean preShutdown() {
 		Instrument.getInstance().setInitial();
 		

--- a/base/uk.ac.stfc.isis.ibex.product/src/uk/ac/stfc/isis/ibex/product/ApplicationWorkbenchWindowAdvisor.java
+++ b/base/uk.ac.stfc.isis.ibex.product/src/uk/ac/stfc/isis/ibex/product/ApplicationWorkbenchWindowAdvisor.java
@@ -19,8 +19,6 @@
 
 package uk.ac.stfc.isis.ibex.product;
 
-import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.application.ActionBarAdvisor;
 import org.eclipse.ui.application.IActionBarConfigurer;
@@ -41,7 +39,6 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
     @Override
     public void preWindowOpen() {
         IWorkbenchWindowConfigurer configurer = getWindowConfigurer();
-        configurer.setInitialSize(new Point(800, 600));
         
         configurer.setShowStatusLine(true);   
         configurer.setShowCoolBar(false);
@@ -53,14 +50,5 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
     	super.postWindowCreate();
         final Shell shell = getWindowConfigurer().getWindow().getShell();
         shell.setMinimumSize(1100, 800);   
-    }
-    
-    @Override
-    public void postWindowOpen() {
-    	Display display = Display.getCurrent();
-    	Shell shell = display.getActiveShell();
-    	
-    	shell.setMaximized(true);
-    	
     }
 }


### PR DESCRIPTION
To Test:
- Start IBEX, change it's size and location
- Restart IBEX, confirm that size/location is retained

Note:
- A side effect of this is that the GUI also remembers the perspective it was previously on, I did not try and correct this as it sounds like useful behaviour
