### PR TITLE
Uncommented the lookup for the pinhole icon

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/ComponentIcons.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/ComponentIcons.java
@@ -62,8 +62,8 @@ public final class ComponentIcons {
 				return icon("euro.png");
 			case GONIOMETER:
 				return icon("ALF Gonio.png");
-//			case PINHOLESELECTOR:
-//				return icon("pinhole_selector.png");
+			case PINHOLESELECTOR:
+				return icon("pinhole_selector.png");
 			case SINGLESTAGE:
 				return icon("single_stage.png");
 			default:


### PR DESCRIPTION
To test:
- Load a synoptic with the pinhole selector included, the icon should now be correct.
