### PR TITLE
Set parent when adding a new component

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/ComponentDescription.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/ComponentDescription.java
@@ -174,19 +174,23 @@ public class ComponentDescription implements SynopticParentDescription {
 		}
 	}
 	
-	public List<ComponentDescription> components() {
+	@Override
+    public List<ComponentDescription> components() {
 		return components;
 	}
 	
-	public void addComponent(ComponentDescription component) {
+	@Override
+    public void addComponent(ComponentDescription component) {
 		components.add(component);
 	}
 	
-	public void addComponent(ComponentDescription component, int index) {
+	@Override
+    public void addComponent(ComponentDescription component, int index) {
 		components.add(index, component);
 	}
 	
-	public void removeComponent(ComponentDescription component) {
+	@Override
+    public void removeComponent(ComponentDescription component) {
 		components.remove(component);
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/SynopticDescription.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/SynopticDescription.java
@@ -76,19 +76,23 @@ public class SynopticDescription implements SynopticParentDescription {
 		this.name = name;
 	}
 	
-	public List<ComponentDescription> components() {
+	@Override
+    public List<ComponentDescription> components() {
 		return components;
 	}
 	
-	public void addComponent(ComponentDescription component) {
+	@Override
+    public void addComponent(ComponentDescription component) {
 		components.add(component);
 	}
 	
-	public void addComponent(ComponentDescription component, int index) {
+	@Override
+    public void addComponent(ComponentDescription component, int index) {
 		components.add(index, component);
 	}
 	
-	public void removeComponent(ComponentDescription component) {
+	@Override
+    public void removeComponent(ComponentDescription component) {
 		components.remove(component);
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
@@ -113,6 +113,7 @@ public class SynopticViewModel {
 			SynopticParentDescription parent = getParent(lastComponent);
 			position = parent.components().indexOf(lastComponent) + 1;
 			parent.addComponent(component, position);
+            component.setParent(parent);
 		}
 
 		broadcastInstrumentUpdate(UpdateTypes.NEW_COMPONENT);


### PR DESCRIPTION
To test first check you can reproduce the bugs below. Then try out this branch and check the problems go away. Have a play around with the instrument tree with multiple components etc. to check no new bugs are introduced.

**_When moving a child component into another child component two new components are created**_
- Add 2 new components
- Make the second component a child of the first
- With the child component selected add a third component
- Drag the third component to the second, to make it a child of that component
- Now four components exist

**_Adding two child components in succession gives the second added component the wrong parent**_
- Add 2 new components
- Make the second component a child of the first
- With the second (child) component selected add two new child components
- The second child component will end up at the top of the list
