### PR TITLE
Reverted to using non-standard variable format due to reflection

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Block.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Block.java
@@ -23,6 +23,14 @@ import com.google.common.base.Strings;
 
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
+/**
+ * Class representing one block inside a BlockServer configuration.
+ * 
+ * Note: The values from this class are populated from the BlockServer JSON via
+ * reflection. Therefore variable names must reflect those expected from the
+ * JSON.
+ */
+@SuppressWarnings("checkstyle:membername")
 public class Block extends ModelObject {
 
 	private String name;
@@ -36,9 +44,9 @@ public class Block extends ModelObject {
     private float highlimit;
 
     // Logging configurations, default is no logging
-    private boolean logPeriodic = true;
-    private int logRate = 0;
-    private float logDeadband;
+    private boolean log_periodic = true;
+    private int log_rate = 0;
+    private float log_deadband;
 
     public Block(String name, String pv, boolean visible, boolean local) {
         this(name, pv, visible, local, null, 0.0f, 0.0f, false, false, 0, 0.0f);
@@ -54,14 +62,14 @@ public class Block extends ModelObject {
         this.lowlimit = lowlimit;
         this.highlimit = highlimit;
         this.runcontrol = runcontrol;
-        this.logDeadband = logDeadband;
-        this.logPeriodic = logPeriodic;
-        this.logRate = logRate;
+        this.log_deadband = logDeadband;
+        this.log_periodic = logPeriodic;
+        this.log_rate = logRate;
 	}
 	
 	public Block(Block other) {
         this(other.name, other.pv, other.visible, other.local, other.subconfig, other.lowlimit, other.highlimit,
-                other.runcontrol, other.logPeriodic, other.logRate, other.logDeadband);
+                other.runcontrol, other.log_periodic, other.log_rate, other.log_deadband);
 	}
 
 	public String getName() {
@@ -77,27 +85,27 @@ public class Block extends ModelObject {
 	}
 
     public void setLogPeriodic(boolean periodic) {
-        firePropertyChange("log_periodic", this.logPeriodic, this.logPeriodic = periodic);
+        firePropertyChange("log_periodic", this.log_periodic, this.log_periodic = periodic);
     }
 
     public boolean getLogPeriodic() {
-        return logPeriodic;
+        return log_periodic;
     }
 
     public void setLogRate(int rate) {
-        firePropertyChange("log_rate", this.logRate, this.logRate = rate);
+        firePropertyChange("log_rate", this.log_rate, this.log_rate = rate);
     }
 
     public int getLogRate() {
-        return logRate;
+        return log_rate;
     }
 
     public void setLogDeadband(float deadband) {
-        firePropertyChange("log_deadband", this.logDeadband, this.logDeadband = deadband);
+        firePropertyChange("log_deadband", this.log_deadband, this.log_deadband = deadband);
     }
 
     public float getLogDeadband() {
-        return logDeadband;
+        return log_deadband;
     }
 
 	public void setPV(String pv) {

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Component.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Component.java
@@ -22,6 +22,13 @@ package uk.ac.stfc.isis.ibex.configserver.configuration;
 
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
+/**
+ * Represents a component inside a configuration.
+ * 
+ * Note: The values from this class are populated from the BlockServer JSON via
+ * reflection. Therefore variable names must reflect those expected from the
+ * JSON.
+ */
 public class Component extends ModelObject implements Comparable<Component> {
 	
 	private final String name;

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Configuration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Configuration.java
@@ -26,6 +26,14 @@ import java.util.List;
 
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
+/**
+ * This is the base class that holds all information relating to a BlockServer
+ * configuration.
+ * 
+ * Note: The values from this class are populated from the BlockServer JSON via
+ * reflection. Therefore variable names must reflect those expected from the
+ * JSON.
+ */
 public class Configuration extends ModelObject {
 	
 	private String name;

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Group.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Group.java
@@ -24,10 +24,17 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import uk.ac.stfc.isis.ibex.model.ModelObject;
-
 import com.google.common.base.Strings;
 
+import uk.ac.stfc.isis.ibex.model.ModelObject;
+
+/**
+ * Represents a group of blocks within a configuration.
+ * 
+ * Note: The values from this class are populated from the BlockServer JSON via
+ * reflection. Therefore variable names must reflect those expected from the
+ * JSON.
+ */
 public class Group extends ModelObject {
 	
 	private String name;

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Ioc.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Ioc.java
@@ -22,16 +22,19 @@ package uk.ac.stfc.isis.ibex.configserver.configuration;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import uk.ac.stfc.isis.ibex.model.ModelObject;
-
 import com.google.common.base.Strings;
+
+import uk.ac.stfc.isis.ibex.model.ModelObject;
 
 /**
  * Holds an IOC, and notifies any listeners set to changes to this class.
  * 
- * Contains the IOC name, if it autostarts, auto-restarts and the simulation level. Contains lists
- * of PVsets, PVDefaultValues and set Macros.
+ * Contains the IOC name, if it autostarts, auto-restarts and the simulation
+ * level. Contains lists of PVsets, PVDefaultValues and set Macros.
  * 
+ * Note: The values from this class are populated from the BlockServer JSON via
+ * reflection. Therefore variable names must reflect those expected from the
+ * JSON.
  */
 public class Ioc extends ModelObject implements Comparable<Ioc> {
 


### PR DESCRIPTION
This fixes a bug introduced in #166 where some variable names were changed but shouldn't be due to being used in reflection from the blockserver JSON.

To test:
- On master create a new config with any block, save it back to the blockserver
- Confirm that the blockserver logs an error message about logPeriodic not being allowed
- Confirm that the block was not saved to the new config
- Repeat for this branch and confirm that behaviour is fixed 
