### PR TITLE
Fixed path expansion and current default EPICS location

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
+++ b/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
@@ -31,7 +31,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 public class PreferenceSupplier extends AbstractPreferenceInitializer {
 	
     public static final String EPICS_BASE_DIRECTORY = "epics_base_directory";
-    public static final String DEFAULT_EPICS_BASE_DIRECTORY = "c:\\Instrument\\Apps\\EPICS\\base\\3-14-12-2\\bin\\windows-x64";
+    public static final String DEFAULT_EPICS_BASE_DIRECTORY = "c:\\Instrument\\Apps\\EPICS\\base\\master\\bin\\windows-x64";
 
     public static final String PYTHON_INTERPRETER_PATH = "python_interpreter_path";
     public static final String DEFAULT_PYTHON_INTERPRETER_PATH = "C:\\Instrument\\Apps\\Python\\python.exe";

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PyDevAdditionalInterpreterSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PyDevAdditionalInterpreterSettings.java
@@ -59,7 +59,8 @@ public class PyDevAdditionalInterpreterSettings extends InterpreterNewCustomEntr
 	}
 	
 	private String epicsBasePath() {
-		return "PATH=" + toOSPath(PreferenceSupplier.epicsBase())  + ";" + toOSPath(PreferenceSupplier.epicsUtilsPath()) + ";${PATH}";
+        return "PATH=" + toOSPath(PreferenceSupplier.epicsBase()) + ";" + toOSPath(PreferenceSupplier.epicsUtilsPath())
+                + ";" + System.getenv("PATH");
 	}
 	
 	private String pyEpicsPath() {


### PR DESCRIPTION
To test load the changes and open up a scripting window. Then give the following a try:
- `os.getenv("PATH")` - might look a bit odd, but should contain the right information
-  `os.system("echo %PATH%")` - should look more sensible than the above, with the full system path prepended by paths for EPICS base and EPICS_UTIL
- Check something like `os.system("caget -t -S IN:DEMO:CS:BLOCKSERVER:SERVER_STATUS")`
- Check something else on your path works, e.g. `os.system("mvn")`

Note there is a new ticket for the Linux part of this https://trac.isis.rl.ac.uk/ICP/ticket/1060.
