### PR TITLE
Fixed issue with Eclipse not finding a dependency

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.dae/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.dae/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.core.runtime,
  uk.ac.stfc.isis.ibex.epics,
  uk.ac.stfc.isis.ibex.instrument,
  com.google.common;bundle-version="10.0.1",
- uk.ac.stfc.isis.ibex.epics.switching
+ uk.ac.stfc.isis.ibex.epics.switching,
+ org.eclipse.ui;bundle-version="3.8.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.dae,


### PR DESCRIPTION
To test - check Eclipse no longer gives the error "The type org.eclipse.ui.plugin.AbstractUIPlugin cannot be resolved. It is indirectly referenced from required .class files" in XMLBackedPerdiodSettings.
