### PR TITLE
Ticket1055 synoptic component name duplication

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/SynopticDescription.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/SynopticDescription.java
@@ -127,4 +127,30 @@ public class SynopticDescription implements SynopticParentDescription {
 
         return nameList;
     }
+
+    /**
+     * Provide a list of the component names, including children.
+     * 
+     * @return A list of the component names
+     */
+    public List<String> getComponentNameListWithChildren() {
+        ArrayList<String> nameList = new ArrayList<>();
+
+        for (ComponentDescription cd : components) {
+            nameList.add(cd.name());
+            getChildNames(cd, nameList);
+        }
+
+        return nameList;
+    }
+
+    private List<String> getChildNames(ComponentDescription component, List<String> nameList) {
+
+        for (ComponentDescription cd : component.components()) {
+            nameList.add(cd.name());
+            getChildNames(cd, nameList);
+        }
+
+        return nameList;
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/EditSynopticDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/EditSynopticDialog.java
@@ -41,7 +41,9 @@ import uk.ac.stfc.isis.ibex.synoptic.SynopticInfo;
 import uk.ac.stfc.isis.ibex.synoptic.model.desc.SynopticDescription;
 import uk.ac.stfc.isis.ibex.synoptic.xml.XMLUtil;
 import uk.ac.stfc.isis.ibex.ui.synoptic.editor.instrument.SynopticPreview;
+import uk.ac.stfc.isis.ibex.ui.synoptic.editor.model.IInstrumentUpdateListener;
 import uk.ac.stfc.isis.ibex.ui.synoptic.editor.model.SynopticViewModel;
+import uk.ac.stfc.isis.ibex.ui.synoptic.editor.model.UpdateTypes;
 
 /**
  * This class provides the dialog to edit the synoptic. While this class is responsible for
@@ -92,7 +94,7 @@ public class EditSynopticDialog extends Dialog {
         previewBtn.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
-                SynopticPreview previewDialog = new SynopticPreview(getShell(), synopticViewModel.getInstrument());
+                SynopticPreview previewDialog = new SynopticPreview(getShell(), synopticViewModel.getSynoptic());
                 previewDialog.open();
             }
 
@@ -141,6 +143,16 @@ public class EditSynopticDialog extends Dialog {
 				}
 			}
 		});
+		
+		synopticViewModel.addInstrumentUpdateListener(new IInstrumentUpdateListener() {
+            @Override
+            public void instrumentUpdated(UpdateTypes updateType) {
+                if (updateType == UpdateTypes.EDIT_COMPONENT) {
+                    saveAsBtn.setEnabled(!synopticViewModel.getHasDuplicatedName());
+                    saveBtn.setEnabled(!synopticViewModel.getHasDuplicatedName());
+                }
+            }
+        });
 		
 		createButton(parent, IDialogConstants.CANCEL_ID, "Cancel", false);
 	}	

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/instrument/InstrumentTreeView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/instrument/InstrumentTreeView.java
@@ -209,7 +209,7 @@ public class InstrumentTreeView extends Composite {
 	}
 
 	private void setTreeInput() {
-		treeViewer.setInput(synopticViewModel.getInstrument());
+		treeViewer.setInput(synopticViewModel.getSynoptic());
 		treeViewer.expandAll();
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
@@ -134,13 +134,20 @@ public class SynopticViewModel {
         }
 
     	List<ComponentDescription> componentCopies = new ArrayList<>();
+
+        List<String> allComponentNames = synoptic.getComponentNameListWithChildren();
         
         for (ComponentDescription selectedComponent : selectedComponents) {
 	        ComponentDescription componentCopy = new ComponentDescription(selectedComponent);
-	
+
 	        DefaultName namer = new DefaultName(selectedComponent.name(), " ", true);
-	        componentCopy.setName(namer.getUnique(synoptic.getComponentNameList()));
+            String uniqueName = namer.getUnique(allComponentNames);
+            allComponentNames.add(uniqueName);
+
+            componentCopy.setName(uniqueName);
 	        
+            setUniqueChildNames(componentCopy, allComponentNames);
+
 	        componentCopies.add(componentCopy);
         }
         
@@ -151,6 +158,17 @@ public class SynopticViewModel {
         broadcastInstrumentUpdate(UpdateTypes.COPY_COMPONENT);
         // Set selected component again here, so it is highlighted.
         setSelectedComponent(componentCopies);
+    }
+
+    private void setUniqueChildNames(ComponentDescription component, List<String> allComponentNames) {
+        for (ComponentDescription cd : component.components()) {
+            DefaultName namer = new DefaultName(cd.name(), " ", true);
+            String uniqueName = namer.getUnique(allComponentNames);
+            allComponentNames.add(uniqueName);
+            
+            cd.setName(uniqueName);
+            setUniqueChildNames(cd, allComponentNames);
+        }
     }
 
     private void addComponentsInCorrectLocation(List<ComponentDescription> componentCopies) {

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
@@ -105,7 +105,9 @@ public class SynopticViewModel {
 	 
 	public void addNewComponent() {
 		ComponentDescription component = new ComponentDescription();
-		component.setName("new component");
+
+        DefaultName namer = new DefaultName("New Component", " ", true);
+        component.setName(namer.getUnique(synoptic.getComponentNameList()));
 		component.setType(ComponentType.UNKNOWN);
 
 		int position = 0;

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
@@ -32,7 +32,9 @@ package uk.ac.stfc.isis.ibex.ui.synoptic.editor.model;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -91,7 +93,7 @@ public class SynopticViewModel {
 		broadcastInstrumentUpdate(UpdateTypes.NEW_INSTRUMENT);
 	}
 
-	public SynopticDescription getInstrument() {
+	public SynopticDescription getSynoptic() {
 		return synoptic;
 	}
 
@@ -107,7 +109,7 @@ public class SynopticViewModel {
 		ComponentDescription component = new ComponentDescription();
 
         DefaultName namer = new DefaultName("New Component", " ", true);
-        component.setName(namer.getUnique(synoptic.getComponentNameList()));
+        component.setName(namer.getUnique(synoptic.getComponentNameListWithChildren()));
 		component.setType(ComponentType.UNKNOWN);
 
 		int position = 0;
@@ -493,4 +495,14 @@ public class SynopticViewModel {
 		}
 		return true;
 	}
+
+    public boolean getHasDuplicatedName() {
+        List<String> comps = getSynoptic().getComponentNameListWithChildren();
+        return listHasDuplicates(comps);
+    }
+
+    private boolean listHasDuplicates(List<String> list) {
+        Set<String> set = new HashSet<String>(list);
+        return (set.size() < list.size());
+    }
 }


### PR DESCRIPTION
To test:
* Trying to create or edit a synoptic with duplicated components stops you from saving it, giving a clear error message
* Adding a synoptic gives the synoptic a unique name (try adding children as well as top level components)
* Copying components gives the copied component and all children unique names (try breaking it by doing things like selecting multiple components to copy)

Old synoptics should work as they did before, but will not be able to be saved until the unique names are removed. On Larmor for example 'Sample Stack' is duplicated.
