### PR TITLE
Client build on Linux

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
@@ -57,6 +57,18 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho.version}</version>
 				<configuration>
+					<environments>
+						<environment>
+							<os>win32</os>
+							<ws>win32</ws>
+							<arch>x86_64</arch>
+						</environment>
+					        <environment>
+					                <os>linux</os>
+					                <ws>gtk</ws>
+					                <arch>x86_64</arch>
+					        </environment>
+					</environments>
 					<target>
 						<artifact>
 							<groupId>${project.groupId}</groupId>
@@ -221,3 +233,4 @@
 		<module>../uk.ac.stfc.isis.ibex.validators.tests</module>
 	</modules>
 </project>
+

--- a/base/uk.ac.stfc.isis.ibex.opi.feature.eclipse/feature.xml
+++ b/base/uk.ac.stfc.isis.ibex.opi.feature.eclipse/feature.xml
@@ -228,6 +228,7 @@
 
    <plugin
          id="org.eclipse.equinox.security.win32.x86_64"
+         os="win32"
          download-size="0"
          install-size="0"
          version="0.0.0"

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+SCRIPT=$(readlink -f "${BASH_SOURCE[0]}")
+SCRIPTPATH="`dirname \"$SCRIPT\"`"
+TOPPATH="`dirname \"$SCRIPTPATH\"`"
+
+mvn --settings="$TOPPATH/mvn_user_settings.xml" \
+    -f "$TOPPATH/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml" \
+    -DforceContextQualifier="$BUILD_NUMBER" \
+    clean verify
+
+echo "Client built in $TOPPATH/base/uk.ac.stfc.isis.ibex.client.product/target/products/ibex.product/"

--- a/build/build.sh
+++ b/build/build.sh
@@ -11,3 +11,4 @@ mvn --settings="$TOPPATH/mvn_user_settings.xml" \
     clean verify
 
 echo "Client built in $TOPPATH/base/uk.ac.stfc.isis.ibex.client.product/target/products/ibex.product/"
+


### PR DESCRIPTION
See ISISComputingGroup/IBEX#1074

This makes Tycho build both a Win32 and a Linux client, regardless what platform the build is run on.

Also added a build.sh script to allow building directly on Linux. Works the same way build.bat does on Windows.