### PR TITLE
PVDetail View checks if selector changes have been confirmed before s…

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/blockselector/BlockSelector.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/blockselector/BlockSelector.java
@@ -39,6 +39,7 @@ public class BlockSelector extends ConfigHandler<Configuration> {
 	
 	private String blockName = "";
 	private String pvAddress = "";
+    private boolean confirmed = false;
 
 	public BlockSelector() {
 		super(SERVER.setCurrentConfig());
@@ -61,6 +62,7 @@ public class BlockSelector extends ConfigHandler<Configuration> {
 		if (dialog.open() == Window.OK) {
 			blockName = dialog.getBlockName();
 			pvAddress = dialog.getPVAddress();
+            confirmed = true;
 		}
 	}
 	
@@ -72,4 +74,7 @@ public class BlockSelector extends ConfigHandler<Configuration> {
 		return pvAddress;
 	}
 
+    public boolean isConfirmed() {
+        return confirmed;
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/pv/PvDetailView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/pv/PvDetailView.java
@@ -271,7 +271,10 @@ public class PvDetailView extends Composite {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-		txtAddress.setText(selectPV.getPvAddress());
+
+        if (selectPV.isConfirmed()) {
+            txtAddress.setText(selectPV.getPvAddress());
+        }
 	}
 	
 	private void openBlockDialog() {
@@ -281,7 +284,10 @@ public class PvDetailView extends Composite {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-		txtName.setText(selectPV.getBlockName());
-		txtAddress.setText(selectPV.getPvAddress());
+
+        if (selectPV.isConfirmed()) {
+            txtName.setText(selectPV.getBlockName());
+            txtAddress.setText(selectPV.getPvAddress());
+        }
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/pv/PvSelector.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/pv/PvSelector.java
@@ -39,6 +39,7 @@ import uk.ac.stfc.isis.ibex.ui.configserver.dialogs.PvSelectorDialog;
 public class PvSelector extends ConfigHandler<Configuration> {
 	
 	private String pvAddress = "";
+    private boolean confirmed = false;
 
 	public PvSelector() {
 		super(SERVER.setCurrentConfig());
@@ -60,6 +61,7 @@ public class PvSelector extends ConfigHandler<Configuration> {
 		PvSelectorDialog dialog = new PvSelectorDialog(null, config, "");	
 		if (dialog.open() == Window.OK) {
 			pvAddress = dialog.getPVAddress();
+            confirmed = true;
 		}
 	}
 	
@@ -67,4 +69,7 @@ public class PvSelector extends ConfigHandler<Configuration> {
 		return pvAddress;
 	}
 
+    public boolean isConfirmed() {
+        return confirmed;
+    }
 }


### PR DESCRIPTION
…etting the name and address text boxes content

In the Synoptic Editor, under PV Details, clicking Select Block and then Cancel does not clear the Name and Address fields. Same for Select PV (though this was only affecting the Name field).

