### PR TITLE
Removed hard-coded target names from source. They are now taken direc…

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/DescriptionsProviderTest.java
+++ b/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/DescriptionsProviderTest.java
@@ -12,6 +12,7 @@ import javax.xml.bind.JAXBException;
 import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXException;
+
 import uk.ac.stfc.isis.ibex.opis.DescriptionsProvider;
 import uk.ac.stfc.isis.ibex.opis.desc.Descriptions;
 import uk.ac.stfc.isis.ibex.opis.desc.MacroInfo;
@@ -20,6 +21,7 @@ import uk.ac.stfc.isis.ibex.opis.desc.OpiDescription;
 @SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:localvariablename", "checkstyle:methodname" })
 public class DescriptionsProviderTest {
 	
+    private String opiType1 = "Type1";
 	private String opiName1 = "Test Opi 1";
 	private String opiPath1 = "TestOpi1\\TestOpi1.opi";
 	private String opiDescription1 = "This is test OPI 1";
@@ -29,7 +31,7 @@ public class DescriptionsProviderTest {
 	public void setUp() throws JAXBException, SAXException {
 		List<MacroInfo> macros = new ArrayList<MacroInfo>();
 		
-		OpiDescription opi1 = new OpiDescription(opiPath1, opiDescription1, macros);
+        OpiDescription opi1 = new OpiDescription(opiType1, opiPath1, opiDescription1, macros);
 		//OpiDescription opi2 = new OpiDescription(opiPath2, opiDescription2, macros);
 
 		Map<String, OpiDescription> opis = new HashMap<String, OpiDescription>();

--- a/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlTest.java
+++ b/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlTest.java
@@ -1,6 +1,6 @@
 package uk.ac.stfc.isis.ibex.opis.tests.desc;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,9 +27,11 @@ public class XmlTest {
 	private String macroName2 = "M2";
 	private String macroDescription2 = "This is test macro 2";
 
+    private String opiType1 = "Type1";
 	private String opiPath1 = "TestOpi1.opi";
 	private String opiDescription1 = "This is test OPI 1";
 
+    private String opiType2 = "Type2";
 	private String opiPath2 = "TestOpi.opi";
 	private String opiDescription2 = "This is test OPI 2";
 
@@ -43,8 +45,8 @@ public class XmlTest {
 		macros.add(new MacroInfo(macroName1, macroDescription1));
 		macros.add(new MacroInfo(macroName2, macroDescription2));
 		
-		OpiDescription opi1 = new OpiDescription(opiPath1, opiDescription1, macros);
-		OpiDescription opi2 = new OpiDescription(opiPath2, opiDescription2, macros);
+        OpiDescription opi1 = new OpiDescription(opiType1, opiPath1, opiDescription1, macros);
+        OpiDescription opi2 = new OpiDescription(opiType2, opiPath2, opiDescription2, macros);
 
 		Map<String, OpiDescription> opis = new HashMap<String, OpiDescription>();
 		opis.put(opi1.getPath(), opi1);
@@ -62,6 +64,7 @@ public class XmlTest {
 		Descriptions desc = XmlUtil.fromXml(fullDescriptionsXml);
 
 		Map<String, OpiDescription> opis = desc.getOpis();
+        assertEquals(opis.get(opiPath1).getType(), opiType1);
 		assertEquals(opis.get(opiPath1).getPath(), opiPath1);
 		assertEquals(opis.get(opiPath1).getDescription(), opiDescription1);
 
@@ -71,6 +74,7 @@ public class XmlTest {
 		assertEquals(macros.get(1).getName(), macroName2);
 		assertEquals(macros.get(1).getDescription(), macroDescription2);
 
+        assertEquals(opis.get(opiPath2).getType(), opiType2);
 		assertEquals(opis.get(opiPath2).getPath(), opiPath2);
 		assertEquals(opis.get(opiPath2).getDescription(), opiDescription2);
 		macros = opis.get(opiPath2).getMacros();

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -370,6 +370,7 @@
 		<entry>
 			<key>LARMOR Spin Flipper</key>
 			<value>
+				<type>UNCONFIRMED</type>
 				<path>SpinFlipper306015.opi</path>
 				<description>The OPI for the LARMOR Spin Flipper.</description>
 				<macros>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -4,6 +4,7 @@
 		<entry>
 			<key>Analyser</key>
 			<value>
+				<type>ANALYSER</type>
 				<path>analyser.opi</path>
 				<description>The OPI for the analyser. No properties required.</description>
 				<macros>
@@ -13,6 +14,7 @@
 		<entry>
 			<key>Beam-stop</key>
 			<value>
+				<type>BEAMSTOP</type>
 				<path>beamstop.opi</path>
 				<description>Description required. No properties required.</description>
 				<macros>
@@ -22,6 +24,7 @@
 		<entry>
 			<key>Caen HV</key>
 			<value>
+				<type>CAEN</type>
 				<path>HV/HVMonitorSummaryDisplay.opi</path>
 				<description>Summary Display for Caens (Maintenance of list via the button on this OPI). No properties required.</description>
 				<macros>
@@ -30,7 +33,8 @@
 		</entry>
         <entry>
             <key>Double Monitor</key>		
-            <value>		
+            <value>	
+                <type>MONITOR</type>
                 <path>double_monitor.opi</path>		
                 <description>The OPI for a double fixed monitor.</description>		
                 <macros>		
@@ -60,6 +64,7 @@
  		<entry>
 			<key>Eurotherm</key>
 			<value>
+				<type>EUROTHERM</type>
 				<path>Eurotherm.opi</path>
 				<description>The OPI for the standard Eurotherm controller.</description>
                 <macros>
@@ -73,6 +78,7 @@
 		<entry>
 			<key>In Out Monitor</key>
 			<value>
+				<type>MOVINGMONITOR</type>
 				<path>inout_monitor.opi</path>
 				<description>Description required.</description>
 				<macros>
@@ -94,6 +100,7 @@
 		<entry>
 			<key>Jaws</key>
 			<value>
+				<type>UNCONFIRMED</type>
 				<path>Jaws.opi</path>
 				<description>Description required.</description>
 				<macros>
@@ -107,6 +114,7 @@
 		<entry>
 			<key>Julabo FL300</key>
 			<value>
+				<type>JULABO</type>
 				<path>JulaboFL300.opi</path>
 				<description>Description required. No properties required.</description>
 				<macros>
@@ -116,6 +124,7 @@
 		<entry>
 			<key>Julabo FP50</key>
 			<value>
+				<type>JULABO</type>
 				<path>JulaboFP50.opi</path>
 				<description>Description required.</description>
 				<macros>
@@ -129,6 +138,7 @@
 		<entry>
 			<key>Kepco</key>
 			<value>
+				<type>KEPCO</type>
 				<path>kepco.opi</path>
 				<description>Description required. No properties required.</description>
 				<macros>
@@ -138,6 +148,7 @@
 		<entry>
 			<key>Mk3 Chopper</key>
 			<value>
+				<type>CHOPPER</type>
 				<path>Mk3Chopper.opi</path>
 				<description>Description required. No properties required.</description>
 				<macros>
@@ -147,6 +158,7 @@
 		<entry>
 			<key>Monitor</key>
 			<value>
+				<type>MONITOR</type>
 				<path>monitor.opi</path>
 				<description>Description required.</description>
 				<macros>
@@ -172,6 +184,7 @@
 		<entry>
 			<key>Pinhole Selector</key>
 			<value>
+				<type>PINHOLESELECTOR</type>
 				<path>pinhole_selector\pinhole_selector.opi</path>
 				<description>The OPI for the pinhole selector.</description>
 				<macros>
@@ -189,6 +202,7 @@
 		<entry>
 			<key>Pixelman</key>
 			<value>
+				<type>UNCONFIRMED</type>
 				<path>pixelman.opi</path>
 				<description>Description required.</description>
 				<macros>
@@ -202,6 +216,7 @@
 		<entry>
 			<key>Polariser</key>
 			<value>
+				<type>POLARISER</type>
 				<path>polariser.opi</path>
 				<description>Description required.  No properties required.</description>
 				<macros>
@@ -211,6 +226,7 @@
 		<entry>
 			<key>Rotating Bench</key>
 			<value>
+				<type>ROTATINGBENCH</type>
 				<path>rotating_bench.opi</path>
 				<description>The OPI for the LARMOR rotating bench.</description>
 				<macros>
@@ -224,6 +240,7 @@
 		<entry>
 			<key>Sample changer</key>
 			<value>
+				<type>SAMPLECHANGER</type>
 				<path>stage/sample_changer.opi</path>
 				<description>Description required. No properties required.</description>
 				<macros>
@@ -233,6 +250,7 @@
 		<entry>
 			<key>Sample stage</key>
 			<value>
+				<type>SAMPLESTACK</type>
 				<path>stage/sample.opi</path>
 				<description>Description required. No properties required.</description>
 				<macros>
@@ -242,6 +260,7 @@
 		<entry>
 			<key>SD Test</key>
 			<value>
+				<type>UNCONFIRMED</type>
 				<path>SDTEST.opi</path>
 				<description>Description required.</description>
 				<macros>
@@ -251,6 +270,7 @@
 		<entry>
 			<key>Single Stage</key>
 			<value>
+				<type>SINGLESTAGE</type>
 				<path>single_stage.opi</path>
 				<description>Displays a single Motor along with a designated ID</description>
 				<macros>
@@ -268,6 +288,7 @@
 		<entry>
 			<key>Slit 1</key>
 			<value>
+				<type>JAWS</type>
 				<path>slit1.opi</path>
 				<description>Description required.</description>
 				<macros>
@@ -309,6 +330,7 @@
 		<entry>
 			<key>Slit motors</key>
 			<value>
+				<type>UNCONFIRMED</type>
 				<path>slit_motors.opi</path>
 				<description>Description required.</description>
 				<macros>
@@ -334,6 +356,7 @@
 		<entry>
 			<key>TPG300</key>
 			<value>
+				<type>UNCONFIRMED</type>
 				<path>TPG300.opi</path>
 				<description>Description required.</description>
 				<macros>

--- a/base/uk.ac.stfc.isis.ibex.opis/src/uk/ac/stfc/isis/ibex/opis/DescriptionsProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.opis/src/uk/ac/stfc/isis/ibex/opis/DescriptionsProvider.java
@@ -68,7 +68,7 @@ public class DescriptionsProvider extends Provider {
 	
 	public OpiDescription getDescription(String name) {
 		if (!descriptions.getOpis().containsKey(name)) {
-            return new OpiDescription("", "", new ArrayList<MacroInfo>());
+            return new OpiDescription("", "", "", new ArrayList<MacroInfo>());
 		}
 		
 		return descriptions.getOpis().get(name);

--- a/base/uk.ac.stfc.isis.ibex.opis/src/uk/ac/stfc/isis/ibex/opis/desc/OpiDescription.java
+++ b/base/uk.ac.stfc.isis.ibex.opis/src/uk/ac/stfc/isis/ibex/opis/desc/OpiDescription.java
@@ -35,6 +35,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "opi")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class OpiDescription {
+    private String type;
 	private String path;
 	private String description;
 	
@@ -42,6 +43,10 @@ public class OpiDescription {
 	@XmlElement(name = "macro", type = MacroInfo.class)
 	private List<MacroInfo> macros = new ArrayList<>();
 	
+    public String getType() {
+        return type;
+    }
+
 	public String getPath() {
 		return path;
 	}
@@ -76,7 +81,8 @@ public class OpiDescription {
 	 * @param description the description of the OPI
 	 * @param macros the macros for the OPI
 	 */
-	public OpiDescription(String path, String description, List<MacroInfo> macros) {
+    public OpiDescription(String type, String path, String description, List<MacroInfo> macros) {
+        this.type = type;
 		this.path = path;
 		this.description = description;
 		this.macros = macros;

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/target/DefaultTargetForComponent.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/target/DefaultTargetForComponent.java
@@ -21,10 +21,13 @@ package uk.ac.stfc.isis.ibex.ui.synoptic.editor.target;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.Maps;
+
 import uk.ac.stfc.isis.ibex.opis.Opi;
+import uk.ac.stfc.isis.ibex.opis.desc.OpiDescription;
 import uk.ac.stfc.isis.ibex.synoptic.model.ComponentType;
 import uk.ac.stfc.isis.ibex.synoptic.model.desc.TargetDescription;
 import uk.ac.stfc.isis.ibex.synoptic.model.desc.TargetType;
@@ -38,82 +41,13 @@ public final class DefaultTargetForComponent {
     private DefaultTargetForComponent() {
     }
 
-    public static Collection<TargetDescription> defaultTarget(ComponentType compType) {
-        Map<String, TargetType> targetNameList = new HashMap<>();
-
-        switch (compType) {
-            case UNKNOWN:
-            case MOVINGBEAMSTOP:
-                // no sensible default(s) for the above at present
-                break;
-            case DAE:
-                targetNameList.put("DAE", TargetType.COMPONENT);
-                break;
-            case GONIOMETER:
-                targetNameList.put("Goniometer", TargetType.COMPONENT);
-                break;
-            case JAWS:
-                targetNameList.put("Slit 1", TargetType.OPI);
-                break;
-            case CHOPPER:
-                targetNameList.put("Mk3 Chopper", TargetType.OPI);
-                break;
-            case MONITOR:
-                targetNameList.put("Double Monitor", TargetType.OPI);
-                targetNameList.put("Monitor", TargetType.OPI);
-                break;
-            case JULABO:
-                targetNameList.put("Julabo FL300", TargetType.OPI);
-                targetNameList.put("Julabo FP50", TargetType.OPI);
-                break;
-            case SAMPLESTACK:
-                targetNameList.put("Sample stage", TargetType.OPI);
-                break;
-            case CAEN:
-                targetNameList.put("Caen HV", TargetType.OPI);
-                break;
-            case KEPCO:
-                targetNameList.put("Kepco", TargetType.OPI);
-                break;
-            case BEAMSTOP:
-                targetNameList.put("Beam-stop", TargetType.OPI);
-                break;
-            case MOVINGMONITOR:
-                targetNameList.put("In Out Monitor", TargetType.OPI);
-                break;
-            case ROTATINGBENCH:
-                targetNameList.put("Rotating Bench", TargetType.OPI);
-                break;
-            case SAMPLECHANGER:
-                targetNameList.put("Sample changer", TargetType.OPI);
-                break;
-            case ANALYSER:
-                targetNameList.put("Analyser", TargetType.OPI);
-                break;
-            case POLARISER:
-                targetNameList.put("Polariser", TargetType.OPI);
-                break;
-            case EUROTHERM:
-                targetNameList.put("Eurotherm", TargetType.OPI);
-                break;
-            case PINHOLESELECTOR:
-                targetNameList.put("Pinhole Selector", TargetType.OPI);
-                break;
-            case SINGLESTAGE:
-                targetNameList.put("Single Stage", TargetType.OPI);
-                break;
-            default:
-                // no sensible default(s) at present
-                break;
-
-        }
-        
+    public static Collection<TargetDescription> defaultTarget(final ComponentType compType) {
         Collection<TargetDescription> targetDescriptions = new ArrayList<>();
 
-        for (String targetName : targetNameList.keySet()) {
-            if (targetNameInOpiList(targetName) && targetNameList.get(targetName) == TargetType.OPI) {
-                targetDescriptions.add(new TargetDescription(targetName, targetNameList.get(targetName)));
-            }
+        Map<String, OpiDescription> opis = Opi.getDefault().descriptionsProvider().getDescriptions().getOpis();
+        Collection<String> matchingTargetNames = Maps.filterValues(opis, typeMatches(compType)).keySet();
+        for (String targetName : matchingTargetNames) {
+            targetDescriptions.add(new TargetDescription(targetName, TargetType.OPI));
         }
         
         if (targetDescriptions.size() == 0) {
@@ -122,10 +56,13 @@ public final class DefaultTargetForComponent {
 
         return targetDescriptions;
     }
-
-    private static Boolean targetNameInOpiList(String targetName) {
-        Collection<String> availableOPIs = Opi.getDefault().descriptionsProvider().getOpiList();
-        return availableOPIs.contains(targetName);
+    
+    private static Predicate<OpiDescription> typeMatches(final ComponentType compType) {
+        return new Predicate<OpiDescription>() {
+            @Override
+            public boolean apply(OpiDescription opiDescription) {
+                return opiDescription.getType().equals(compType.toString());
+            }
+        };
     }
-
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/target/DefaultTargetForComponent.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/target/DefaultTargetForComponent.java
@@ -33,7 +33,7 @@ import uk.ac.stfc.isis.ibex.synoptic.model.desc.TargetDescription;
 import uk.ac.stfc.isis.ibex.synoptic.model.desc.TargetType;
 
 /**
- * @author kvlb23
+ * Identifies the default targets for the specified component type.
  *
  */
 public final class DefaultTargetForComponent {


### PR DESCRIPTION
…tly from the opi_info.xml file (Ticket 1088)

Code was refactored, so in the Synoptic Editor, the default Component Target Details for various Component Types should behave the same as before.

Component types are now in the <type> element in opi_info.xml and are read directly from this file, so that DefaultTargetForComponent doesn't need to handle them. Note that the new xml element is at the same level as <path> and <description>, so it is then read as a field in the OpiDescription class.

Note also that the class DefaultTargetForComponent does not take any special care of ComponentType.DAE or ComponentType.GONIOMETER (they had no effect in the old code's return value anyway).