### PR TITLE
Use primitive rather than reference type

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
@@ -86,7 +86,7 @@ public class DaeView extends ViewPart {
 		model.close();
 	}
 	
-	private void configureExperimentSetupForRunState(final Boolean isRunning) {
+	private void configureExperimentSetupForRunState(final boolean isRunning) {
 		DISPLAY.asyncExec(new Runnable() {	
 			@Override
 			public void run() {


### PR DESCRIPTION
If the reference "Boolean" type is used, the object it points to may be gone (i.e. null) by the time the async execute is performed (i.e. this ticket). Using the primitive type avoids this issue (though potentially forces the execution to be performed synchronously).

To test, run the workflow described in ticket 1112:

Open IBEX
Change instrument to "Demo"
Change to the DAE perspective
Click "Begin Run"
Close the application

https://github.com/ISISComputingGroup/IBEX/issues/1112