### PR TITLE
Ticket1092 configurable instrument names

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.instrument.tests/src/uk/ac/stfc/isis/ibex/instrument/list/tests/InstrumentListUtilsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument.tests/src/uk/ac/stfc/isis/ibex/instrument/list/tests/InstrumentListUtilsTest.java
@@ -1,0 +1,130 @@
+
+/*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+package uk.ac.stfc.isis.ibex.instrument.list.tests;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.epics.observing.Observable;
+import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
+import uk.ac.stfc.isis.ibex.instrument.list.InstrumentListUtils;
+
+@SuppressWarnings("checkstyle:methodname")
+public class InstrumentListUtilsTest {
+    
+    private Observable<Collection<InstrumentInfo>> mockObservable;
+    private InstrumentInfo instrument1;
+    private InstrumentInfo instrument2;
+    private InstrumentInfo nullNameInstrument;
+
+    @SuppressWarnings("unchecked")
+    @Before
+    public void setUp() {
+        mockObservable = mock(Observable.class);
+
+        instrument1 = mock(InstrumentInfo.class);
+        when(instrument1.name()).thenReturn("instrument1");
+
+        instrument2 = mock(InstrumentInfo.class);
+        when(instrument2.name()).thenReturn("instrument2");
+
+        nullNameInstrument = mock(InstrumentInfo.class);
+        when(nullNameInstrument.name()).thenReturn(null);
+    }
+    
+    @Test
+    public void filter_valid_instruments_returns_empty_list_if_pv_not_connected() {
+        // Arrange
+        when(mockObservable.isConnected()).thenReturn(false);
+
+        // Act
+        Collection<InstrumentInfo> instruments = InstrumentListUtils.filterValidInstruments(mockObservable);
+
+        // Assert
+        assertNotNull(instruments);
+        assertTrue(instruments.isEmpty());
+    }
+
+    @Test
+    public void filter_valid_instruments_returns_empty_list_if_pv_value_null() {
+        // Arrange
+        when(mockObservable.isConnected()).thenReturn(true);
+        when(mockObservable.getValue()).thenReturn(null);
+
+        // Act
+        Collection<InstrumentInfo> instruments = InstrumentListUtils.filterValidInstruments(mockObservable);
+
+        // Assert
+        assertNotNull(instruments);
+        assertTrue(instruments.isEmpty());
+    }
+
+    @Test
+    public void filter_valid_instruments_returns_pv_instruments_when_all_valid() {
+        // Arrange
+        Collection<InstrumentInfo> expected = new ArrayList<>();
+        expected.add(instrument1);
+        expected.add(instrument2);
+        int expectedSize = 2;
+
+        when(mockObservable.isConnected()).thenReturn(true);
+        when(mockObservable.getValue()).thenReturn(expected);
+
+        // Act
+        Collection<InstrumentInfo> instruments = InstrumentListUtils.filterValidInstruments(mockObservable);
+
+        // Assert
+        assertNotNull(instruments);
+        assertEquals(expectedSize, instruments.size());
+        assertEquals(expected, instruments);
+    }
+
+    @Test
+    public void filter_valid_instruments_does_not_return_invalid_items() {
+        // Arrange
+        Collection<InstrumentInfo> input = new ArrayList<>();
+        input.add(instrument1);
+        input.add(nullNameInstrument);
+        input.add(instrument2);
+
+        Collection<InstrumentInfo> expected = new ArrayList<>();
+        expected.add(instrument1);
+        expected.add(instrument2);
+        int expectedSize = 2;
+
+        when(mockObservable.isConnected()).thenReturn(true);
+        when(mockObservable.getValue()).thenReturn(input);
+
+        // Act
+        Collection<InstrumentInfo> instruments = InstrumentListUtils.filterValidInstruments(mockObservable);
+
+        // Assert
+        assertNotNull(instruments);
+        assertEquals(expectedSize, instruments.size());
+        assertEquals(expected, instruments);
+    }
+}
+

--- a/base/uk.ac.stfc.isis.ibex.instrument/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.instrument/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.osgi,
  com.google.common,
  uk.ac.stfc.isis.ibex.model;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.logger,
- org.csstudio.utility.pvmanager
+ org.csstudio.utility.pvmanager,
+ uk.ac.stfc.isis.ibex.json;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.instrument,
  uk.ac.stfc.isis.ibex.instrument.channels,

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
@@ -44,6 +44,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
 import uk.ac.stfc.isis.ibex.instrument.internal.LocalHostInstrumentInfo;
+import uk.ac.stfc.isis.ibex.instrument.list.InstrumentListObservable;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.model.SettableUpdatedValue;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
@@ -59,7 +60,6 @@ public class Instrument implements BundleActivator {
     	return instance; 
     }
 	
-	private List<InstrumentInfo> instruments = new ArrayList<>();
 	private SettableUpdatedValue<String> instrumentName = new SettableUpdatedValue<>();
 	private InstrumentInfo instrumentInfo;
 	private final InstrumentInfo localhost;
@@ -70,22 +70,10 @@ public class Instrument implements BundleActivator {
 	
 	public Instrument() {
 		instance = this;
+        localhost = new LocalHostInstrumentInfo();
 		
-		localhost = new LocalHostInstrumentInfo();
-		instruments.add(localhost);
-		
-        List<InstrumentInfo> instrumentsAlphabetical = new ArrayList<>();
-        instrumentsAlphabetical.add(new InstrumentInfo("LARMOR"));
-        instrumentsAlphabetical.add(new InstrumentInfo("ALF"));
-        instrumentsAlphabetical.add(new InstrumentInfo("DEMO"));
-        instrumentsAlphabetical.add(new InstrumentInfo("IMAT"));
-        instrumentsAlphabetical.add(new InstrumentInfo("MUONFE"));
-        Collections.sort(instrumentsAlphabetical, alphabeticalNameComparator());
-
-        instruments.addAll(instrumentsAlphabetical);
-
-		setInstrument(initialInstrument());	
-	}
+        setInstrument(initialInstrument());
+    }
     
 	public UpdatedValue<String> name() {
 		return instrumentName;
@@ -96,7 +84,17 @@ public class Instrument implements BundleActivator {
     }
 
 	public Collection<InstrumentInfo> instruments() {
-		return instruments;
+        List<InstrumentInfo> instruments = new ArrayList<>();
+        instruments.add(localhost);
+
+        InstrumentListObservable instrumentsObservable = new InstrumentListObservable();
+        Collection<InstrumentInfo> unorderedInstruments = instrumentsObservable.getInstruments();
+        List<InstrumentInfo> instrumentsAlphabetical = new ArrayList<>(unorderedInstruments);
+        Collections.sort(instrumentsAlphabetical, alphabeticalNameComparator());
+        instruments.addAll(instrumentsAlphabetical);
+
+        instrumentsObservable.close();
+        return instruments;
 	}
 	
 	static BundleContext getContext() {
@@ -170,7 +168,7 @@ public class Instrument implements BundleActivator {
 	private InstrumentInfo initialInstrument() {
 		final String initalName = initalPreference.get(initialInstrument, localhost.name());
 		
-		return Iterables.find(instruments, new Predicate<InstrumentInfo>() {
+        return Iterables.find(instruments(), new Predicate<InstrumentInfo>() {
 			@Override
 			public boolean apply(InstrumentInfo info) {
 				return initalName.endsWith(info.name());

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListObservable.java
@@ -1,0 +1,85 @@
+
+/*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.instrument.list;
+
+import java.util.Collection;
+
+import uk.ac.stfc.isis.ibex.epics.conversion.Convert;
+import uk.ac.stfc.isis.ibex.epics.conversion.Converter;
+import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
+import uk.ac.stfc.isis.ibex.epics.observing.ConvertingObservable;
+import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
+import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
+import uk.ac.stfc.isis.ibex.instrument.channels.CompressedCharWaveformChannel;
+import uk.ac.stfc.isis.ibex.json.JsonDeserialisingConverter;
+
+/**
+ * Holds the connection to the Instrument List PV.
+ * 
+ */
+public class InstrumentListObservable {
+    
+    private static final int MAX_RETRIES = 200;
+    private static final int WAIT_FOR_OBSERVABLE = 100; // milliseconds
+
+    private static final String ADDRESS = "NDW1298:IEW83206:CS:BLOCKSERVER:INSTRUMENT_NAMES";
+    private final ForwardingObservable<Collection<InstrumentInfo>> instrumentsRBV;
+
+    public InstrumentListObservable() {
+        instrumentsRBV = convert(readCompressed(ADDRESS));
+    }
+
+    public Collection<InstrumentInfo> getInstruments() {
+        return getValidInstruments();
+    }
+
+    public void close() {
+        instrumentsRBV.close();
+    }
+
+    private ForwardingObservable<String> readCompressed(String address) {
+        ClosableObservable<String> pvObservable = new CompressedCharWaveformChannel().reader(address);
+        return new ForwardingObservable<>(pvObservable);
+    }
+
+    private ForwardingObservable<Collection<InstrumentInfo>> convert(ForwardingObservable<String> source) {
+        Converter<String, Collection<InstrumentInfo>> converter = new JsonDeserialisingConverter<>(
+                InstrumentInfo[].class).apply(Convert.<InstrumentInfo> toCollection());
+        return new ForwardingObservable<>(new ConvertingObservable<>(source, converter));
+    }
+
+    private Collection<InstrumentInfo> getValidInstruments() {
+        // Wait for the PV to be connected
+        int i = 0;
+        while (!instrumentsRBV.isConnected() && i < MAX_RETRIES) {
+            try {
+                Thread.sleep(WAIT_FOR_OBSERVABLE);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            i++;
+        }
+        
+        return InstrumentListUtils.filterValidInstruments(instrumentsRBV);
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListObservable.java
@@ -68,7 +68,7 @@ public class InstrumentListObservable {
 
     private ForwardingObservable<Collection<InstrumentInfo>> convert(ForwardingObservable<String> source) {
         Converter<String, Collection<InstrumentInfo>> converter = new JsonDeserialisingConverter<>(
-                InstrumentInfo[].class).apply(Convert.<InstrumentInfo> toCollection());
+                InstrumentInfo[].class).apply(Convert.<InstrumentInfo>toCollection());
         return new ForwardingObservable<>(new ConvertingObservable<>(source, converter));
     }
 

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListObservable.java
@@ -42,7 +42,11 @@ public class InstrumentListObservable {
     private static final int MAX_RETRIES = 200;
     private static final int WAIT_FOR_OBSERVABLE = 100; // milliseconds
 
-    private static final String ADDRESS = "NDW1298:IEW83206:CS:BLOCKSERVER:INSTRUMENT_NAMES";
+    /**
+     * This is the PV that holds the list of instruments that can be selected.
+     */
+    private static final String ADDRESS = "CS:INSTLIST";
+
     private final ForwardingObservable<Collection<InstrumentInfo>> instrumentsRBV;
 
     public InstrumentListObservable() {

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListUtils.java
@@ -35,6 +35,10 @@ import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
  * 
  */
 public class InstrumentListUtils {
+
+    private InstrumentListUtils() {
+    }
+
     public static Collection<InstrumentInfo> filterValidInstruments(
             Observable<Collection<InstrumentInfo>> instrumentsRBV) {
         if (!instrumentsRBV.isConnected()) {

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListUtils.java
@@ -1,0 +1,56 @@
+
+/*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+package uk.ac.stfc.isis.ibex.instrument.list;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import uk.ac.stfc.isis.ibex.epics.observing.Observable;
+import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
+
+public class InstrumentListUtils {
+    public static Collection<InstrumentInfo> filterValidInstruments(
+            Observable<Collection<InstrumentInfo>> instrumentsRBV) {
+        if (!instrumentsRBV.isConnected()) {
+            return new ArrayList<>();
+        }
+
+        // In case of parsing errors the collection or individual fields may be
+        // null
+        Collection<InstrumentInfo> instruments = instrumentsRBV.getValue();
+        if (instruments == null) {
+            return new ArrayList<>();
+        }
+
+        Iterable<InstrumentInfo> validInstruments = Iterables.filter(instruments, new Predicate<InstrumentInfo>() {
+            @Override
+            public boolean apply(InstrumentInfo item) {
+                return item.name() != null;
+            }
+        });
+
+        return Lists.newArrayList(validInstruments);
+    }
+}
+

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListUtils.java
@@ -34,7 +34,7 @@ import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
  * instruments, e.g. due to parsing error.
  * 
  */
-public class InstrumentListUtils {
+public final class InstrumentListUtils {
 
     private InstrumentListUtils() {
     }

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListUtils.java
@@ -29,6 +29,11 @@ import com.google.common.collect.Lists;
 import uk.ac.stfc.isis.ibex.epics.observing.Observable;
 import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 
+/**
+ * Given an observable containing a list of instruments, filters out invalid
+ * instruments, e.g. due to parsing error.
+ * 
+ */
 public class InstrumentListUtils {
     public static Collection<InstrumentInfo> filterValidInstruments(
             Observable<Collection<InstrumentInfo>> instrumentsRBV) {


### PR DESCRIPTION
The Instrument list is now in a PV called CS:INSTLIST, a json string compressed and hexed.

To test this story, check that the list of instruments in the GUI (IBEX > Switch Instrument) matches those in the PV and is updated without closing the GUI when the PV changes, e.g. with a caput (you do have to close and re-open the Instrument selection dialog though).

In case of parsing error of the json string, the client shouldn't crash:
   a. if the error affects a single instrument (e.g. "name" spelled wrong), that instrument does not appear in the list
   b. if the error affects the entire string (e.g. missing brackets at the start), no instrument is displayed
We can discuss whether an error message should be displayed, but I suggest doing the work in another ticket, as the dialog has changed in the meantime (#1093).

Please take a look at the code too.



****************************************************************************************
To view the PV run this command from the EPICS terminal:
    caget -t -S CS:INSTLIST|uzhex

To write to the PV you can either do a caput from terminal (you need to know the compressed and hexed string):
    caput -S CS:INSTLIST 789c8bae56ca4bcc4d55b25250f2710cf2f50f52aad551408839fab8a10ab8b8fafa2bd5c60200ba260f87

or set it with the Python script below. This script should run from somewhere with access to the server_common.channel_access library, e.g. you can temporarily copy it in C:\Instrument\Apps\EPICS\ISIS\inst_servers\master


	from server_common.channel_access import caget, caput
	import time
	import zlib
	import os

	def compress_and_hex(value):
		compr = zlib.compress(value)
		return compr.encode('hex');

	def dehex_and_decompress(value):
		return zlib.decompress(value.decode("hex"))

	def set_env():
		epics_ca_addr_list = "EPICS_CA_ADDR_LIST"
		print epics_ca_addr_list + " = " + str(os.environ.get(epics_ca_addr_list))
		os.environ[epics_ca_addr_list] = "127.255.255.255"
		print epics_ca_addr_list + " = " + str(os.environ.get(epics_ca_addr_list))

	if __name__ == "__main__":
		set_env()

		pvAddress = "CS:INSTLIST"
		new_value = '[{"name": "LARMOR"}, {"name": "ALF"}, {"name": "DEMO"}, {"name": "IMAT"}, {"name": "MUONFE"}]'

		new_value_compressed = compress_and_hex(new_value)
		print "Desired value: " + new_value
		print "Compressed: " + new_value_compressed

		caput(pvAddress, str(new_value_compressed), True)

		result_compr = caget(pvAddress, True)
		result = dehex_and_decompress(result_compr)
		print "\nResult:" + str(result)
		print "Compressed: " + result_compr


