### PR TITLE
Ticket 1147: resource leak when creating many groups

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocSimulationCellDecorator.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocSimulationCellDecorator.java
@@ -29,6 +29,10 @@ import uk.ac.stfc.isis.ibex.configserver.configuration.SimLevel;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.CellDecorator;
 
+/**
+ * Decorator for the IOC name cells of items in the configuration IOC table.
+ * Controls the text formatting.
+ */
 public class IocSimulationCellDecorator extends CellDecorator<EditableIoc> {
 
 	private static final Display DISPLAY = Display.getCurrent();

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocSimulationCellDecorator.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocSimulationCellDecorator.java
@@ -22,29 +22,19 @@ package uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs;
 import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.services.IDisposable;
+import org.eclipse.wb.swt.SWTResourceManager;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.SimLevel;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.CellDecorator;
 
-public class IocSimulationCellDecorator extends CellDecorator<EditableIoc> implements IDisposable {
+public class IocSimulationCellDecorator extends CellDecorator<EditableIoc> {
 
 	private static final Display DISPLAY = Display.getCurrent();
 
-    private Font defaultFont;
-    private Font boldFont;
-
-    /**
-     * Dispose of fonts
-     */
-    @Override
-    public void dispose() {
-        disposeFont(defaultFont);
-        disposeFont(boldFont);
-    }
+    private static final Font NORMAL_FONT = SWTResourceManager.getFont("Arial", 10, SWT.NORMAL);
+    private static final Font BOLD_FONT = SWTResourceManager.getFont("Arial", 10, SWT.BOLD);
 
 	@Override
 	public void applyDecoration(ViewerCell cell) {
@@ -62,43 +52,15 @@ public class IocSimulationCellDecorator extends CellDecorator<EditableIoc> imple
 	}
 	
     private void bold(ViewerCell cell) {
-        applyBold(cell, true);
+        cell.setFont(BOLD_FONT);
 	}
 	
 	private void unbold(ViewerCell cell) {
-        applyBold(cell, false);
+        cell.setFont(NORMAL_FONT);
 	}
 	
 	private static void addSimulationLabel(ViewerCell cell) {
 		String text = cell.getText();
 		cell.setText(text + " (SIM)");
 	}
-	
-    private void applyBold(ViewerCell cell, boolean enable) {
-        int modifier = SWT.BOLD;
-        if (defaultFont == null) {
-            FontData fontData = cell.getFont().getFontData()[0];
-            createFonts(fontData, modifier);
-        }
-
-        if (enable) {
-            cell.setFont(boldFont);
-        } else {
-            cell.setFont(defaultFont);
-        }
-    }
-
-    private void createFonts(FontData fontData, int modifier) {
-        int defaultStyle = fontData.getStyle() & ~modifier;
-        defaultFont = new Font(DISPLAY, new FontData(fontData.getName(), fontData.getHeight(), defaultStyle));
-
-        int boldStyle = fontData.getStyle() | modifier;
-        boldFont = new Font(DISPLAY, new FontData(fontData.getName(), fontData.getHeight(), boldStyle));
-    }
-
-    private static void disposeFont(Font font) {
-        if (font != null && !font.isDisposed()) {
-            font.dispose();
-        }
-    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocSimulationCellDecorator.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocSimulationCellDecorator.java
@@ -24,14 +24,27 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.services.IDisposable;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.SimLevel;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.CellDecorator;
 
-public class IocSimulationCellDecorator extends CellDecorator<EditableIoc> {
+public class IocSimulationCellDecorator extends CellDecorator<EditableIoc> implements IDisposable {
 
 	private static final Display DISPLAY = Display.getCurrent();
+
+    private Font defaultFont;
+    private Font boldFont;
+
+    /**
+     * Dispose of fonts
+     */
+    @Override
+    public void dispose() {
+        disposeFont(defaultFont);
+        disposeFont(boldFont);
+    }
 
 	@Override
 	public void applyDecoration(ViewerCell cell) {
@@ -48,12 +61,12 @@ public class IocSimulationCellDecorator extends CellDecorator<EditableIoc> {
 		return getRow(cell).getSimLevel() != SimLevel.NONE;
 	}
 	
-	private static void bold(ViewerCell cell) {
-		modifyFont(cell, SWT.BOLD, true);
+    private void bold(ViewerCell cell) {
+        applyBold(cell, true);
 	}
 	
 	private void unbold(ViewerCell cell) {
-		modifyFont(cell, SWT.BOLD, false);
+        applyBold(cell, false);
 	}
 	
 	private static void addSimulationLabel(ViewerCell cell) {
@@ -61,10 +74,31 @@ public class IocSimulationCellDecorator extends CellDecorator<EditableIoc> {
 		cell.setText(text + " (SIM)");
 	}
 	
-	private static void modifyFont(ViewerCell cell, int modifier, boolean enable) {
-		FontData fontData = cell.getFont().getFontData()[0];
-		int newStyle = enable ? fontData.getStyle() | modifier : fontData.getStyle() & ~modifier;
-		Font font = new Font(DISPLAY, new FontData(fontData.getName(), fontData.getHeight(), newStyle));
-		cell.setFont(font);
-	}
+    private void applyBold(ViewerCell cell, boolean enable) {
+        int modifier = SWT.BOLD;
+        if (defaultFont == null) {
+            FontData fontData = cell.getFont().getFontData()[0];
+            createFonts(fontData, modifier);
+        }
+
+        if (enable) {
+            cell.setFont(boldFont);
+        } else {
+            cell.setFont(defaultFont);
+        }
+    }
+
+    private void createFonts(FontData fontData, int modifier) {
+        int defaultStyle = fontData.getStyle() & ~modifier;
+        defaultFont = new Font(DISPLAY, new FontData(fontData.getName(), fontData.getHeight(), defaultStyle));
+
+        int boldStyle = fontData.getStyle() | modifier;
+        boldFont = new Font(DISPLAY, new FontData(fontData.getName(), fontData.getHeight(), boldStyle));
+    }
+
+    private static void disposeFont(Font font) {
+        if (font != null && !font.isDisposed()) {
+            font.dispose();
+        }
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocsTable.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import org.eclipse.core.databinding.observable.map.IObservableMap;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.ui.services.IDisposable;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
@@ -52,12 +51,6 @@ public class IocsTable extends DataboundTable<EditableIoc> {
 		autostart();
 		restart();
 	}
-
-    @Override
-    public void dispose() {
-        super.dispose();
-        ((IDisposable) simulationDecorator).dispose();
-    }
 
 	private void name() {
 		TableViewerColumn name = createColumn("Name", 4);

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocsTable.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.eclipse.core.databinding.observable.map.IObservableMap;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.services.IDisposable;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
@@ -51,6 +52,12 @@ public class IocsTable extends DataboundTable<EditableIoc> {
 		autostart();
 		restart();
 	}
+
+    @Override
+    public void dispose() {
+        super.dispose();
+        ((IDisposable) simulationDecorator).dispose();
+    }
 
 	private void name() {
 		TableViewerColumn name = createColumn("Name", 4);


### PR DESCRIPTION
Resource leak was caused by many Fonts being created and not disposed within the IOCs table each time a property changed was fired by the editable configuration.

To test:
Try to create a new configuration, adding 30+ groups. The client shouldn't crash anymore.
(The issue was appearing when any property change was fired, so actions like adding/removing/renaming/swapping blocks and groups was contributing to the leak).

NOTE: there is now an RCPTT System Test to cover this, see pull request ISISComputingGroup/ibex_system_tests#1