### PR TITLE
Ticket1193 enable dae tabs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/Group.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/Group.java
@@ -53,6 +53,14 @@ public class Group extends Composite {
 	private static final int NUMBER_OF_FIELDS = 3;
     private Composite parent;
 
+    /**
+     * Provides the display of groups.
+     * 
+     * @param parent a widget which will be the parent of the new instance
+     * @param style the style of widget to construct
+     * @param group the group to be displayed
+     * @param showHiddenBlocks whether hidden blocks should be shown
+     */
 	public Group(Composite parent, int style, DisplayGroup group, boolean showHiddenBlocks) {
 		super(parent, style | SWT.BORDER);
 		

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
@@ -105,7 +105,7 @@ public class DaeView extends ViewPart {
 		DISPLAY.asyncExec(new Runnable() {	
 			@Override
 			public void run() {
-                experimentSetup.setEnabled(isRunning != null && isRunning);
+                experimentSetup.setEnabled(isRunning != null && !isRunning);
 			}
 		});
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
@@ -105,7 +105,7 @@ public class DaeView extends ViewPart {
 		DISPLAY.asyncExec(new Runnable() {	
 			@Override
 			public void run() {
-                experimentSetup.setEnabled(isRunning != null && !isRunning);
+                experimentSetup.setChildrenEnabled(isRunning != null && !isRunning);
 			}
 		});
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -113,6 +113,11 @@ public class ExperimentSetup extends Composite {
 		periods.setModel(viewModel.periodSettings());
 	}
 
+    /**
+     * Enable or disable the content / children panels of this composite.
+     * 
+     * @param isEnabled whether the contents should be enabled or not
+     */
     public void setChildrenEnabled(boolean isEnabled) {
         timeChannels.setEnabled(isEnabled);
         dataAcquisition.setEnabled(isEnabled);

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -113,4 +113,10 @@ public class ExperimentSetup extends Composite {
 		periods.setModel(viewModel.periodSettings());
 	}
 
+    public void setChildrenEnabled(boolean isEnabled) {
+        timeChannels.setEnabled(isEnabled);
+        dataAcquisition.setEnabled(isEnabled);
+        periods.setEnabled(isEnabled);
+    }
+
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 
 import uk.ac.stfc.isis.ibex.ui.dae.DaeUI;
@@ -116,12 +117,22 @@ public class ExperimentSetup extends Composite {
     /**
      * Enable or disable the content / children panels of this composite.
      * 
-     * @param isEnabled whether the contents should be enabled or not
+     * @param enabled whether the contents should be enabled or not
      */
-    public void setChildrenEnabled(boolean isEnabled) {
-        timeChannels.setEnabled(isEnabled);
-        dataAcquisition.setEnabled(isEnabled);
-        periods.setEnabled(isEnabled);
+    public void setChildrenEnabled(boolean enabled) {
+        recursiveSetEnabled(timeChannels, enabled);
+        recursiveSetEnabled(dataAcquisition, enabled);
+        recursiveSetEnabled(periods, enabled);
     }
 
+    private void recursiveSetEnabled(Control control, boolean enabled) {
+        if (control instanceof Composite) {
+            Composite composite = (Composite) control;
+            for (Control child : composite.getChildren()) {
+                recursiveSetEnabled(child, enabled);
+            }
+        }
+
+        control.setEnabled(enabled);
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -19,16 +19,16 @@
 
 package uk.ac.stfc.isis.ibex.ui.dae.experimentsetup;
 
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 
 import uk.ac.stfc.isis.ibex.ui.dae.DaeUI;
 import uk.ac.stfc.isis.ibex.ui.dae.experimentsetup.periods.PeriodsPanel;
@@ -74,7 +74,6 @@ public class ExperimentSetup extends Composite {
 		Composite dataAcquisitionComposite = new Composite(tabFolder, SWT.NONE);
 		tbtmDataAcquisition.setControl(dataAcquisitionComposite);
 		dataAcquisitionComposite.setLayout(new FillLayout(SWT.HORIZONTAL));
-		
 		dataAcquisition = new DataAcquisitionPanel(dataAcquisitionComposite, SWT.NONE);
 		
 		CTabItem tbtmPeriods = new CTabItem(tabFolder, SWT.NONE);

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/VerticalGradientComposite.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/VerticalGradientComposite.java
@@ -29,8 +29,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
-/*
- * A composite with a vertical gradient as a background
+/**
+ * A composite with a vertical gradient as a background.
  */
 @SuppressWarnings("checkstyle:magicnumber")
 public class VerticalGradientComposite extends Composite {


### PR DESCRIPTION
User can now switch between tabs in DAE Experiment Setup at any time (i.e. whether the instrument is running or not), but the panels inside the tabs are disabled when the instrument is running.
As part of this, I have fixed a bug introduced in the last sprint, that caused the tabs to be enabled when the instrument was running!

See also corresponding pull request for system tests ISISComputingGroup/ibex_system_tests#4

To be able to run an instrument, you need to have valid wiring/detector/spectra table files set in the DAE Experiment Setup -> Data Acquisition panel. Valid files (originally copied from NDXDEMO) can be found in this ticket's branch for the System Tests, under RCPTT_Tests\TestFiles\Tables