### PR TITLE
Ticket1228_Broken_target_platform

### DIFF
--- a/mvn_user_settings.xml
+++ b/mvn_user_settings.xml
@@ -1,14 +1,14 @@
 <settings>
   <proxies>
    <proxy>
-      <active>true</active>
+      <active>false</active>
       <protocol>http</protocol>
       <host>wwwcache.rl.ac.uk</host>
       <port>8080</port>
       <nonProxyHosts>*.rl.ac.uk|*.stfc.ac.uk|*.cclrc.ac.uk</nonProxyHosts>
     </proxy>
    <proxy>
-      <active>true</active>
+      <active>false</active>
       <protocol>https</protocol>
       <host>wwwcache.rl.ac.uk</host>
       <port>8080</port>


### PR DESCRIPTION
In the maven user settings, we were accessing external resources via proxies. My understanding is these were necessary in the past to get to external resources but they are in fact now blocking it. I've deactivated the filters and the Maven build works as expected. Isabella has confirmed.