### PR TITLE
Preference page for perspectives

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/META-INF/MANIFEST.MF
@@ -18,7 +18,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.databinding.beans;bundle-version="1.2.200",
  org.eclipse.core.databinding.property;bundle-version="1.4.100",
  uk.ac.stfc.isis.ibex.ui.statusbar,
- uk.ac.stfc.isis.ibex.alarm;bundle-version="1.0.0"
+ uk.ac.stfc.isis.ibex.alarm;bundle-version="1.0.0",
+ uk.ac.stfc.isis.ibex.preferences
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: uk.ac.stfc.isis.ibex.ui.perspectives,

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/plugin.xml
@@ -55,4 +55,13 @@
             restorable="true">
       </view>
    </extension>
+   
+	<extension
+	     point="org.eclipse.ui.preferencePages">
+	  <page
+	        class="uk.ac.stfc.isis.ibex.ui.perspectives.PreferencePage"
+	        id="uk.ac.stfc.isis.ibex.ui.perspectives.PreferencePage"
+	        name="ISIS Perspectives">
+	  </page>
+	</extension>
 </plugin>

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/BasePerspective.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/BasePerspective.java
@@ -32,7 +32,7 @@ import uk.ac.stfc.isis.ibex.ui.perspectives.switcher.PerspectiveSwitcherView;
 public abstract class BasePerspective implements IPerspectiveFactory, IsisPerspective {
 	
 	public static final String ID = "uk.ac.stfc.isis.ibex.ui.perspectives.base"; //$NON-NLS-1$	
-		
+	
 	public void createInitialLayout(IPageLayout layout) {					
 		layout.setEditorAreaVisible(false);
 		layout.setFixed(true);
@@ -54,5 +54,10 @@ public abstract class BasePerspective implements IPerspectiveFactory, IsisPerspe
 			view.setMoveable(false);
 			view.setCloseable(true);
 		}
+	}
+	
+	@Override
+	public boolean isVisibleDefault() {
+		return true;
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/IsisPerspective.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/IsisPerspective.java
@@ -22,11 +22,23 @@ package uk.ac.stfc.isis.ibex.ui.perspectives;
 import org.eclipse.swt.graphics.Image;
 
 public interface IsisPerspective extends Comparable<IsisPerspective> {
+	/**
+	 * @return The id of the perspective.
+	 */
 	String id();
 	
+	/**
+	 * @return The user-friendly name of the perspective. 
+	 */
 	String name();
 	
+	/**
+	 * @return The image to be used as an icon for the perspective.
+	 */
 	Image image();
 	
+	/**
+	 * @return Whether the perspective is visible as default.
+	 */
 	boolean isVisibleDefault();
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/IsisPerspective.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/IsisPerspective.java
@@ -27,4 +27,6 @@ public interface IsisPerspective extends Comparable<IsisPerspective> {
 	String name();
 	
 	Image image();
+	
+	boolean isVisibleDefault();
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/Perspectives.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/Perspectives.java
@@ -32,14 +32,19 @@ import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import uk.ac.stfc.isis.ibex.preferences.Preferences;
-import uk.ac.stfc.isis.ibex.ui.preference.PreferencePage;
 
+/**
+ * Class for holding all of the ISIS perspectives.
+ */
 public class Perspectives {
 
 	private final List<IsisPerspective> perspectives = new ArrayList<>();
 	private final Map<String, String> ids = new HashMap<>();
 	private IPreferenceStore store = Preferences.getDefault().getPreferenceStore();
 	
+	/**
+	 * Default constructor for the class, will gather all of the ISIS perspectives into a list.
+	 */
 	public Perspectives() {
 		IExtensionRegistry registry = Platform.getExtensionRegistry();
 		IConfigurationElement[] elements = registry.getConfigurationElementsFor("uk.ac.stfc.isis.ibex.ui.perspectives");
@@ -60,7 +65,7 @@ public class Perspectives {
 	}
 	
 	/**
-	 * Get all the ISIS perspectives
+	 * Get all the ISIS perspectives.
 	 * @return A list of all perspectives
 	 */
 	public List<IsisPerspective> get() {		
@@ -68,7 +73,7 @@ public class Perspectives {
 	}
 	
 	/**
-	 * Get the perspectives that are visible to the user
+	 * Get the perspectives that are visible to the user.
 	 * @return A list of visible perspectives
 	 */
 	public List<IsisPerspective> getVisible() {
@@ -83,6 +88,12 @@ public class Perspectives {
 		return newList;
 	}
 	
+	/**
+	 * Get the perspective id based on its name.
+	 * 
+	 * @param perspectiveName The name of an ISIS perspective
+	 * @return Its ID
+	 */
 	public String getID(String perspectiveName) {
 		return ids.get(perspectiveName);
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/Perspectives.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/Perspectives.java
@@ -29,11 +29,16 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import uk.ac.stfc.isis.ibex.preferences.Preferences;
+import uk.ac.stfc.isis.ibex.ui.preference.PreferencePage;
 
 public class Perspectives {
 
 	private final List<IsisPerspective> perspectives = new ArrayList<>();
 	private final Map<String, String> ids = new HashMap<>();
+	private IPreferenceStore store = Preferences.getDefault().getPreferenceStore();
 	
 	public Perspectives() {
 		IExtensionRegistry registry = Platform.getExtensionRegistry();
@@ -44,6 +49,8 @@ public class Perspectives {
 				IsisPerspective perspective = (IsisPerspective) obj;
 				perspectives.add(perspective);
 				ids.put(perspective.name(), perspective.id());
+
+				store.setDefault(perspective.id(), perspective.isVisibleDefault());
 				
 				Collections.sort(perspectives);
 			} catch (CoreException e) {
@@ -52,8 +59,28 @@ public class Perspectives {
 		}
 	}
 	
+	/**
+	 * Get all the ISIS perspectives
+	 * @return A list of all perspectives
+	 */
 	public List<IsisPerspective> get() {		
 		return perspectives;
+	}
+	
+	/**
+	 * Get the perspectives that are visible to the user
+	 * @return A list of visible perspectives
+	 */
+	public List<IsisPerspective> getVisible() {
+		List<IsisPerspective> newList = new ArrayList<>();
+		
+		for (IsisPerspective perspective : perspectives) {
+			if (store.getBoolean(perspective.id())) {
+				newList.add(perspective);
+			}
+		}
+		
+		return newList;
 	}
 	
 	public String getID(String perspectiveName) {

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/PreferencePage.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/PreferencePage.java
@@ -29,7 +29,7 @@ import org.eclipse.ui.IWorkbenchPreferencePage;
 import uk.ac.stfc.isis.ibex.preferences.Preferences;
 
 /**
- * A preference page for setting which of the ISIS perspectives 
+ * A preference page for setting which of the ISIS perspectives are visible
  */
 public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {		
 	public PreferencePage() {

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/PreferencePage.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/PreferencePage.java
@@ -1,0 +1,60 @@
+
+/*
+* This file is part of the ISIS IBEX application.
+* Copyright (C) 2012-2016 Science & Technology Facilities Council.
+* All rights reserved.
+*
+* This program is distributed in the hope that it will be useful.
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v1.0 which accompanies this distribution.
+* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+*
+* You should have received a copy of the Eclipse Public License v1.0
+* along with this program; if not, you can obtain a copy from
+* https://www.eclipse.org/org/documents/epl-v10.php or 
+* http://opensource.org/licenses/eclipse-1.0.php
+*/
+
+package uk.ac.stfc.isis.ibex.ui.perspectives;
+
+import org.eclipse.jface.dialogs.IMessageProvider;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+import uk.ac.stfc.isis.ibex.preferences.Preferences;
+
+/**
+ * A preference page for setting which of the ISIS perspectives 
+ */
+public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {		
+	public PreferencePage() {
+		super(GRID);
+	}
+
+    /** {@inheritDoc} */
+	@Override
+	public void init(IWorkbench workbench) {
+        setPreferenceStore(Preferences.getDefault().getPreferenceStore());
+        setDescription("");
+	}
+
+    /** {@inheritDoc} */
+	@Override
+	protected void createFieldEditors() {
+		for (IsisPerspective perspective : Activator.getDefault().perspectives().get()) {
+			addField(new BooleanFieldEditor(perspective.id(), perspective.name(), getFieldEditorParent()));
+		}
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public final void propertyChange(final PropertyChangeEvent event) {
+		setMessage("Please restart the application to apply the changed settings", IMessageProvider.INFORMATION);
+		super.propertyChange(event);
+	}
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/PreferencePage.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/PreferencePage.java
@@ -29,9 +29,12 @@ import org.eclipse.ui.IWorkbenchPreferencePage;
 import uk.ac.stfc.isis.ibex.preferences.Preferences;
 
 /**
- * A preference page for setting which of the ISIS perspectives are visible
+ * A preference page for setting which of the ISIS perspectives are visible.
  */
 public class PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {		
+	/**
+	 * The default constructor for the class.
+	 */
 	public PreferencePage() {
 		super(GRID);
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/switcher/PerspectiveSwitcherView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.perspectives/src/uk/ac/stfc/isis/ibex/ui/perspectives/switcher/PerspectiveSwitcherView.java
@@ -64,7 +64,7 @@ public class PerspectiveSwitcherView extends ViewPart implements ISizeProvider {
 		container.setBackground(BACKGROUND);
 		container.setLayout(new GridLayout(1, false));
 				
-		List<IsisPerspective> perspectives = Activator.getDefault().perspectives().get();
+		List<IsisPerspective> perspectives = Activator.getDefault().perspectives().getVisible();
 		
 		for (IsisPerspective perspective : perspectives) {	
 			PerspectiveButton button = buttonForPerspective(container, perspective);


### PR DESCRIPTION
### Description of work

Added a preference page for visible perspectives (currently all default to visible)

As per https://github.com/ISISComputingGroup/IBEX/issues/1372

### To test

* Go to preference menu (Ctrl+Alt+P)
* Go to the ISIS Perspectives tab
* Modify the checkboxes to only display some perspectives
* Restart IBEX and confirm only expected perspectives are shown

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
