### PR TITLE
Ticket1218 custom instrument names

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.instrument.tests/src/uk/ac/stfc/isis/ibex/instrument/custom/tests/CustomInstrumentInfoTest.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument.tests/src/uk/ac/stfc/isis/ibex/instrument/custom/tests/CustomInstrumentInfoTest.java
@@ -57,9 +57,9 @@ public class CustomInstrumentInfoTest {
     }
 
     @Test
-    public final void host_name_starting_with_NDW_is_valid() {
+    public final void host_name_starting_with_ND_is_valid() {
         // Arrange
-        String name = "NDW_a_valid_name_123";
+        String name = "ND_a_valid_name_123";
         String pvPrefix = "myPrefix";
         CustomInstrumentInfo instrument = new CustomInstrumentInfo(name, pvPrefix);
 
@@ -71,7 +71,7 @@ public class CustomInstrumentInfoTest {
     }
 
     @Test
-    public final void host_name_not_starting_with_NDW_is_invalid() {
+    public final void host_name_not_starting_with_ND_is_invalid() {
         // Arrange
         String name = "invalid_name";
         String pvPrefix = "prefix";

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/custom/CustomInstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/custom/CustomInstrumentInfo.java
@@ -51,7 +51,7 @@ public class CustomInstrumentInfo extends InstrumentInfo {
     }
 
     public static String validCustomInstrumentRegex() {
-        return PVPrefix.NDW + "[_a-zA-Z0-9]+";
+        return PVPrefix.ND + "[_a-zA-Z0-9]+";
     }
 
     @Override

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/internal/PVPrefix.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/internal/PVPrefix.java
@@ -24,7 +24,7 @@ public class PVPrefix {
 	private static final String INSTRUMENT_FORMAT = "IN:%s:";
 	private static final String USER_FORMAT = "%s:%s:";
 	public static final String NDX = "NDX";
-    public static final String NDW = "NDW";
+    public static final String ND = "ND";
 	
 	private final String prefix;
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.mainmenu/src/uk/ac/stfc/isis/ibex/ui/mainmenu/instrument/InstrumentSelectionPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.mainmenu/src/uk/ac/stfc/isis/ibex/ui/mainmenu/instrument/InstrumentSelectionPanel.java
@@ -45,7 +45,6 @@ import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 
 /**
  * A view allowing selection of an instrument from a list of instruments.
- * 
  */
 @SuppressWarnings("checkstyle:magicnumber")
 public class InstrumentSelectionPanel extends Composite {
@@ -53,6 +52,13 @@ public class InstrumentSelectionPanel extends Composite {
     private Text txtSelectedName;
     private InstrumentTable instrumentTable;
 
+    /**
+     * Creates an instance of the instrument selection panel.
+     * 
+     * @param parent the parent composite
+     * @param style the style of the panel
+     * @param viewModel the view model for the instrument selection
+     */
     public InstrumentSelectionPanel(Composite parent, int style, InstrumentSelectionViewModel viewModel) {
         super(parent, style);
 

--- a/base/uk.ac.stfc.isis.ibex.ui.mainmenu/src/uk/ac/stfc/isis/ibex/ui/mainmenu/instrument/InstrumentSelectionPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.mainmenu/src/uk/ac/stfc/isis/ibex/ui/mainmenu/instrument/InstrumentSelectionPanel.java
@@ -65,6 +65,7 @@ public class InstrumentSelectionPanel extends Composite {
         createInstrumentLabel(grpInstrument);
         createInstrumentTextBox(grpInstrument);
         createClearButton(grpInstrument);
+        createHelpLabel(grpInstrument);
         createTable(grpInstrument, viewModel.getInstruments());
 
         bindModel(viewModel);
@@ -78,8 +79,7 @@ public class InstrumentSelectionPanel extends Composite {
 
     private void createInstrumentTextBox(Composite parent) {
         txtSelectedName = new Text(parent, SWT.BORDER);
-        GridData gdInstrument = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdInstrument.widthHint = 130;
+        GridData gdInstrument = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
         txtSelectedName.setLayoutData(gdInstrument);
         txtSelectedName.addModifyListener(new ModifyListener() {
             @Override
@@ -102,6 +102,13 @@ public class InstrumentSelectionPanel extends Composite {
         };
 
         btnClear.addListener(SWT.Selection, clearListener);
+    }
+
+    private void createHelpLabel(Composite parent) {
+        String helpText = "(For custom names, type the machine name, e.g. \"NDXLARMOR\")";
+        Label lblHelp = new Label(parent, SWT.WRAP | SWT.LEFT);
+        lblHelp.setLayoutData(new GridData(SWT.HORIZONTAL, SWT.CENTER, true, false, 3, 1));
+        lblHelp.setText(helpText);
     }
 
     private void createTable(Composite parent, Collection<InstrumentInfo> instruments) {

--- a/base/uk.ac.stfc.isis.ibex.ui.mainmenu/src/uk/ac/stfc/isis/ibex/ui/mainmenu/instrument/custom/CustomInstrumentPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.mainmenu/src/uk/ac/stfc/isis/ibex/ui/mainmenu/instrument/custom/CustomInstrumentPanel.java
@@ -33,13 +33,20 @@ import org.eclipse.swt.widgets.Text;
 
 /**
  * A view for the definition of a new custom instrument info.
- * 
  */
 @SuppressWarnings("checkstyle:magicnumber")
 public class CustomInstrumentPanel extends Composite {
 
     private Text txtPVPrefix;
 
+    /**
+     * Creates an instance of the panel for configuring a new custom instrument
+     * info.
+     * 
+     * @param parent the parent composite
+     * @param style the style of the panel
+     * @param viewModel the view model for the custom instrument
+     */
     public CustomInstrumentPanel(Composite parent, int style, CustomIntrumentViewModel viewModel) {
         super(parent, style);
 
@@ -49,22 +56,33 @@ public class CustomInstrumentPanel extends Composite {
         grpPVPrefix.setText("Instrument PV Prefix");
         grpPVPrefix.setLayout(new GridLayout(2, false));
 
-        String warningMsg = "Please configure a PV prefix for the unknown instrument \"" + viewModel.getInstrumentName()
-                + "\"";
-        Label lblWarning = new Label(grpPVPrefix, SWT.NONE);
-        lblWarning.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
-        lblWarning.setText(warningMsg);
-
-        Label lblPVPrefix = new Label(grpPVPrefix, SWT.NONE);
-        lblPVPrefix.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-        lblPVPrefix.setText("PV Prefix:");
-
-        txtPVPrefix = new Text(grpPVPrefix, SWT.BORDER);
-        GridData gdTxtPVPrefix = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
-        gdTxtPVPrefix.widthHint = 250;
-        txtPVPrefix.setLayoutData(gdTxtPVPrefix);
+        createWarningLabel(grpPVPrefix, viewModel.getInstrumentName());
+        createPvPrefixLabel(grpPVPrefix);
+        createPvPrefixTextBox(grpPVPrefix);
 
         bindModel(viewModel);
+    }
+
+    private void createWarningLabel(Composite parent, String instrumentName) {
+        String warningMsg =
+                "Please configure a PV prefix for the unknown instrument \"" + instrumentName
+                        + "\"\n(e.g. \"IN:LARMOR:\". Do not forget the trailing colon!)";
+        Label lblWarning = new Label(parent, SWT.WRAP | SWT.LEFT);
+        lblWarning.setLayoutData(new GridData(SWT.HORIZONTAL, SWT.CENTER, true, false, 2, 1));
+        lblWarning.setText(warningMsg);
+    }
+
+    private void createPvPrefixLabel(Composite parent) {
+        Label lblPVPrefix = new Label(parent, SWT.NONE);
+        lblPVPrefix.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblPVPrefix.setText("PV Prefix:");
+    }
+
+    private void createPvPrefixTextBox(Composite parent) {
+        txtPVPrefix = new Text(parent, SWT.BORDER);
+        GridData gdTxtPVPrefix = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
+        gdTxtPVPrefix.widthHint = 250;
+        txtPVPrefix.setLayoutData(gdTxtPVPrefix);
     }
 
     private void bindModel(CustomIntrumentViewModel viewModel) {

--- a/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/InstrumentNameValidatorTest.java
+++ b/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/InstrumentNameValidatorTest.java
@@ -42,7 +42,7 @@ public class InstrumentNameValidatorTest {
     }
 
     @Test
-    public void alphanumeric_name_with_prefix_is_valid() {
+    public void WHEN_alphanumeric_name_with_prefix_is_validated_THEN_name_is_valid() {
         // Arrange
         String name = PREFIX + "valid123";
         InstrumentNameValidator valid = new InstrumentNameValidator(knownValidNames);
@@ -52,7 +52,7 @@ public class InstrumentNameValidatorTest {
     }
 
     @Test
-    public void known_valid_name_without_prefix_is_valid() {
+    public void WHEN_known_valid_name_without_prefix_is_validated_THEN_name_is_valid() {
         // Arrange
         String name = knownValidNames.get(0);
         InstrumentNameValidator valid = new InstrumentNameValidator(knownValidNames);
@@ -62,7 +62,7 @@ public class InstrumentNameValidatorTest {
     }
 
     @Test
-    public void alphanumeric_name_without_prefix_is_invalid() {
+    public void WHEN_alphanumeric_name_without_prefix_is_validated_THEN_name_is_invalid() {
         // Arrange
         String name = "invalid123";
         InstrumentNameValidator valid = new InstrumentNameValidator(knownValidNames);
@@ -72,7 +72,7 @@ public class InstrumentNameValidatorTest {
     }
 
     @Test
-    public void non_alphanumeric_name_is_invalid() {
+    public void WHEN_non_alphanumeric_name_is_validated_THEN_name_is_invalid() {
         // Arrange
         String name = PREFIX + "invalid@";
         InstrumentNameValidator valid = new InstrumentNameValidator(knownValidNames);
@@ -82,7 +82,7 @@ public class InstrumentNameValidatorTest {
     }
 
     @Test
-    public void message_for_valid_name_is_correct() {
+    public void WHEN_valid_name_is_validated_THEN_message_is_correct() {
         // Arrange
         String expected = "";
         String name = PREFIX + "valid123";
@@ -96,9 +96,9 @@ public class InstrumentNameValidatorTest {
     }
 
     @Test
-    public void message_for_invalid_name_is_correct() {
+    public void WHEN_non_alphanumeric_name_is_validated_THEN_message_is_correct() {
         // Arrange
-        String expected = InstrumentNameValidator.NAME_FORMAT;
+        String expected = InstrumentNameValidator.NAME_FORMAT_MSG;
         String name = PREFIX + "invalid@";
         InstrumentNameValidator valid = new InstrumentNameValidator(knownValidNames);
 
@@ -110,10 +110,24 @@ public class InstrumentNameValidatorTest {
     }
 
     @Test
-    public void message_for_empty_name_is_correct() {
+    public void WHEN_empty_name_is_validated_THEN_message_is_correct() {
         // Arrange
-        String expected = InstrumentNameValidator.NAME_EMPTY;
+        String expected = InstrumentNameValidator.NAME_EMPTY_MSG;
         String name = "";
+        InstrumentNameValidator valid = new InstrumentNameValidator(knownValidNames);
+
+        // Act
+        valid.validateInstrumentName(name);
+
+        // Assert
+        assertEquals(expected, valid.getErrorMessage());
+    }
+
+    @Test
+    public void WHEN_unknown_name_not_starting_with_prefix_is_validated_THEN_message_is_correct() {
+        // Arrange
+        String expected = InstrumentNameValidator.NAME_PREFIX_MSG;
+        String name = "AName";
         InstrumentNameValidator valid = new InstrumentNameValidator(knownValidNames);
 
         // Act

--- a/base/uk.ac.stfc.isis.ibex.validators/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.validators/META-INF/MANIFEST.MF
@@ -12,4 +12,5 @@ Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.validators;uses:="org.osgi.framework"
 Import-Package: org.apache.logging.log4j,
  org.eclipse.core.databinding.validation,
+ uk.ac.stfc.isis.ibex.instrument.internal,
  uk.ac.stfc.isis.ibex.logger

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/InstrumentNameValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/InstrumentNameValidator.java
@@ -21,6 +21,8 @@ package uk.ac.stfc.isis.ibex.validators;
 
 import java.util.Collection;
 
+import uk.ac.stfc.isis.ibex.instrument.internal.PVPrefix;
+
 /**
  * Provides validation for custom instrument names.
  * 
@@ -35,7 +37,8 @@ public class InstrumentNameValidator {
     /**
      * Error message for missing prefix in instrument name.
      */
-    public static final String NAME_PREFIX_MSG = "Instrument Name invalid, must be a known name or start with \"NDW\"";
+    public static final String NAME_PREFIX_MSG =
+            "Instrument Name invalid, must be a known name or start with \"" + PVPrefix.NDW + "\"";
 
     /**
      * Error message for empty instrument name.
@@ -43,7 +46,6 @@ public class InstrumentNameValidator {
     public static final String NAME_EMPTY_MSG = "Instrument Name invalid, must not be empty";
 
     private static final String NO_ERROR_MSG = "";
-    private static final String PREFIX = "NDW";
 
     private String errorMessage;
     private Collection<String> knownValidNames;
@@ -74,7 +76,7 @@ public class InstrumentNameValidator {
         } else if (nameIsKnown(instrumentName)) {
             isValid = true;
             setErrorMessage(NO_ERROR_MSG);
-        } else if (!(instrumentName.startsWith(PREFIX))) {
+        } else if (!(instrumentName.startsWith(PVPrefix.NDW))) {
             setErrorMessage(NAME_PREFIX_MSG);
         } else if (!(instrumentName.matches("[a-zA-Z0-9_]*$"))) {
             setErrorMessage(NAME_FORMAT_MSG);

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/InstrumentNameValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/InstrumentNameValidator.java
@@ -26,16 +26,36 @@ import java.util.Collection;
  * 
  */
 public class InstrumentNameValidator {
-    public static final String NAME_FORMAT = "Instrument Name invalid, must either be a known name or start with \"NDW\" and use only [a-z], [A-Z], [0-9], and _";
-    public static final String NAME_EMPTY = "Instrument Name invalid, must not be empty";
-    private static final String NO_ERROR = "";
+    /**
+     * Error message for wrong instrument name formatting.
+     */
+    public static final String NAME_FORMAT_MSG =
+            "Instrument Name invalid, must only use [a-z], [A-Z], [0-9], and _";
+
+    /**
+     * Error message for missing prefix in instrument name.
+     */
+    public static final String NAME_PREFIX_MSG = "Instrument Name invalid, must be a known name or start with \"NDW\"";
+
+    /**
+     * Error message for empty instrument name.
+     */
+    public static final String NAME_EMPTY_MSG = "Instrument Name invalid, must not be empty";
+
+    private static final String NO_ERROR_MSG = "";
     private static final String PREFIX = "NDW";
 
     private String errorMessage;
     private Collection<String> knownValidNames;
 
+    /**
+     * Creates an instance of the instrument name validator, given a list of
+     * known instrument names.
+     * 
+     * @param knownValidNames the list of known instrument names.
+     */
     public InstrumentNameValidator(Collection<String> knownValidNames) {
-        errorMessage = NO_ERROR;
+        errorMessage = NO_ERROR_MSG;
         this.knownValidNames = knownValidNames;
     }
     
@@ -50,20 +70,27 @@ public class InstrumentNameValidator {
         boolean isValid = false;
         
         if (instrumentName.isEmpty()) {
-            setErrorMessage(NAME_EMPTY);
+            setErrorMessage(NAME_EMPTY_MSG);
         } else if (nameIsKnown(instrumentName)) {
             isValid = true;
-            setErrorMessage(NO_ERROR);
-        } else if (!(instrumentName.matches(PREFIX + "[a-zA-Z0-9_]*$"))) {
-            setErrorMessage(NAME_FORMAT);
+            setErrorMessage(NO_ERROR_MSG);
+        } else if (!(instrumentName.startsWith(PREFIX))) {
+            setErrorMessage(NAME_PREFIX_MSG);
+        } else if (!(instrumentName.matches("[a-zA-Z0-9_]*$"))) {
+            setErrorMessage(NAME_FORMAT_MSG);
         } else {
             isValid = true;
-            setErrorMessage(NO_ERROR);
+            setErrorMessage(NO_ERROR_MSG);
         }
 
         return isValid;
     }
 
+    /**
+     * Gets the validation message.
+     * 
+     * @return the validation message.
+     */
     public String getErrorMessage() {
         return errorMessage;
     }

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/InstrumentNameValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/InstrumentNameValidator.java
@@ -38,7 +38,7 @@ public class InstrumentNameValidator {
      * Error message for missing prefix in instrument name.
      */
     public static final String NAME_PREFIX_MSG =
-            "Instrument Name invalid, must be a known name or start with \"" + PVPrefix.NDW + "\"";
+            "Instrument Name invalid, must be a known name or start with \"" + PVPrefix.ND + "\"";
 
     /**
      * Error message for empty instrument name.
@@ -76,7 +76,7 @@ public class InstrumentNameValidator {
         } else if (nameIsKnown(instrumentName)) {
             isValid = true;
             setErrorMessage(NO_ERROR_MSG);
-        } else if (!(instrumentName.startsWith(PVPrefix.NDW))) {
+        } else if (!(instrumentName.startsWith(PVPrefix.ND))) {
             setErrorMessage(NAME_PREFIX_MSG);
         } else if (!(instrumentName.matches("[a-zA-Z0-9_]*$"))) {
             setErrorMessage(NAME_FORMAT_MSG);


### PR DESCRIPTION
###Description of work

When switching instrument, the custom instrument name must now start with "ND" instead of "NDW".
Also added a help message under the instrument name text box and a help message for setting the PV prefix of the custom instrument info.

While doing this ticket I noticed that the validation message on the instrument name was too long and was getting cropped in the dialog, so I've split it into two shorter messages.

###To test

ISISComputingGroup/IBEX#1218

###Acceptance criteria

Open the Switch Instrument dialog. Verify that custom instrument names starting with "ND" are valid.
Check the usefulness of the help label for the instrument name in the Switch Instrument dialog and the help label for the PV prefix in the Instrument Setup dialog

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [x] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?