### PR TITLE
checkbox enabled state corresponds to pv connection state

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/observable/BooleanWritableObservableAdapter.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/observable/BooleanWritableObservableAdapter.java
@@ -46,6 +46,11 @@ public class BooleanWritableObservableAdapter implements Closable {
         }
 
         @Override
+        public void onCanWriteChanged(boolean canWrite) {
+            canSetValue.setValue(canWrite);
+        }
+
+        @Override
         protected Long transform(Boolean value) {
             if (value) {
                 return (long) 1;


### PR DESCRIPTION
###Description of work

The checkbox for setting the visibility of the experiment title should now correctly reflect whether the corresponding DISPLAY:TITLE PV is connected or disconnected at all times. (previously only checked connection to PV once on DAE initialisation)

###To test

https://github.com/ISISComputingGroup/IBEX/issues/1409

###Acceptance criteria

Switching the instrument on/off AFTER opening the DAE perspective in the GUI correctly changes enabled state of the display title checkbox.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?
