### PR TITLE
Ticket 1285: changed OPI so that name is read-only

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/mercuryiTC_single.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/mercuryiTC_single.opi
@@ -359,62 +359,6 @@ $(pv_value)</tooltip>
       <opifont.name fontName="Arial" height="14" style="1">ISIS_Label</opifont.name>
     </font>
   </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="1.0">
-    <precision>3</precision>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <horizontal_alignment>0</horizontal_alignment>
-    <rules />
-    <pv_value />
-    <auto_size>false</auto_size>
-    <text>0.0</text>
-    <rotation_angle>0.0</rotation_angle>
-    <show_units>false</show_units>
-    <height>30</height>
-    <multiline_input>false</multiline_input>
-    <border_width>1</border_width>
-    <visible>true</visible>
-    <pv_name>$(PV_ROOT):NAME:SP</pv_name>
-    <selector_type>0</selector_type>
-    <border_color>
-      <color name="ISIS_Check_Border" red="0" green="128" blue="255" />
-    </border_color>
-    <precision_from_pv>false</precision_from_pv>
-    <widget_type>Text Input</widget_type>
-    <confirm_message></confirm_message>
-    <name>txtSetpoint_1</name>
-    <actions hook="false" hook_all="false" />
-    <border_style>3</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <enabled>true</enabled>
-    <wuid>-1c6864:1559161122d:-74d5</wuid>
-    <transparent>false</transparent>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <vertical_alignment>1</vertical_alignment>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <format_type>4</format_type>
-    <limits_from_pv>false</limits_from_pv>
-    <background_color>
-      <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
-    </background_color>
-    <width>423</width>
-    <x>129</x>
-    <y>30</y>
-    <maximum>1.7976931348623157E308</maximum>
-    <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-    </foreground_color>
-    <minimum>-1.7976931348623157E308</minimum>
-    <font>
-      <opifont.name fontName="Arial" height="14" style="1">ISIS_Value</opifont.name>
-    </font>
-  </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.NativeText" version="1.0">
     <border_style>0</border_style>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
@@ -467,6 +411,57 @@ $(pv_value)</tooltip>
       <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <minimum>-1.7976931348623157E308</minimum>
+    <font>
+      <opifont.name fontName="Arial" height="14" style="1">ISIS_Label</opifont.name>
+    </font>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0">
+    <border_style>0</border_style>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <precision>3</precision>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <horizontal_alignment>0</horizontal_alignment>
+    <rules />
+    <enabled>true</enabled>
+    <wuid>552e46d6:155fe1fbd2c:-7f99</wuid>
+    <transparent>false</transparent>
+    <pv_value />
+    <auto_size>false</auto_size>
+    <text>######</text>
+    <rotation_angle>0.0</rotation_angle>
+    <scripts />
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <show_units>false</show_units>
+    <height>30</height>
+    <border_width>1</border_width>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <visible>true</visible>
+    <pv_name>$(PV_ROOT):NAME</pv_name>
+    <vertical_alignment>1</vertical_alignment>
+    <border_color>
+      <color name="ISIS_Check_Border" red="0" green="128" blue="255" />
+    </border_color>
+    <precision_from_pv>false</precision_from_pv>
+    <widget_type>Text Update</widget_type>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <wrap_words>false</wrap_words>
+    <format_type>4</format_type>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <width>423</width>
+    <x>129</x>
+    <name>Text Update_4</name>
+    <y>30</y>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <actions hook="false" hook_all="false" />
     <font>
       <opifont.name fontName="Arial" height="14" style="1">ISIS_Label</opifont.name>
     </font>


### PR DESCRIPTION
###Description of work

Changed the OPI so that the NAME field is read-only

###To test

ISISComputingGroup/IBEX#1285 (rework following review)

IMPORTANT: the Mercury IOC is one of those that hangs for a long time if it doesn't find an instrument, and so you can't simply start it in simulation mode. To make it work for the test, you'll need to modify the MercuryTemp.db to comment out all the DTYP fields and INP/OUT that use @asyn.
Then you can start the IOC and set the SIM record to 1.

To test, you'll need to start the Mercury IOC in simulation mode, add it to a synoptic and open the OPI from the synoptic. The NAME PV is a waveform; in simulation mode you'll need to do:
`caput -S %MYPVPREFIX%MERCURY_01:1:SIM:NAME "a test name"`


###Acceptance criteria

The name field is read-only in the OPI

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?
