### PR TITLE
change default experiment team role to 'User'

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/internal/ObservableModel.java
+++ b/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/internal/ObservableModel.java
@@ -119,7 +119,7 @@ public class ObservableModel extends Model {
 	public UserDetails addUser() {
 		Collection<UserDetails> originalUsers = getUserDetails();
 		
-		UserDetails user = new UserDetails(defaultUser, defaultOrg, Role.BLANK);
+		UserDetails user = new UserDetails(defaultUser, defaultOrg, Role.USER);
 		this.userDetails.add(user);
 		firePropertyChange("userDetails", originalUsers, getUserDetails());
 		return user;


### PR DESCRIPTION
ISISComputingGroup/IBEX/issues/1321

In the "Experiment Details" perspective, a default role for an added experiment team member is now 'User'. 
