### PR TITLE
Fixed typo in beam status legend

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamStatusView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamStatusView.java
@@ -294,7 +294,7 @@ public class BeamStatusView extends DataBrowserAwareView implements ModelListene
                     displayName = "TS2";
                     break;
                 case SYNCH_BEAM_CURRENT_PV:
-                    displayName = "Synchotron";
+                    displayName = "Synchrotron";
                     break;
                 default:
                     displayName = newItem.getDisplayName();


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/1429

To test ensure spelling is now correct