### PR TITLE
IOCs are now passed from configserver to editable configuration as co…

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -392,7 +392,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
 	private void mergeSelectedAndAvailableIocs(Collection<Ioc> selected, Collection<EditableIoc> available) {
 		Map<String, EditableIoc> iocs = new HashMap<>();
 		for (EditableIoc ioc : available) {
-			iocs.put(ioc.getName(), ioc);
+			iocs.put(ioc.getName(), new EditableIoc(ioc));
 		}
 		
 		// IOCs from the actual configuration contain the active macros and description


### PR DESCRIPTION
### Description of work

Fixed a bug where changes made to IOCs through the edit config dialog would persist in the GUI after cancelling. IOCs are now passed from the configserver to the editable configuration as copies rather than directly.

Found no evidence that the problem existed for any other configuration settings (i.e. all changes made in other tabs were appropriately reversed after cancelling)

No system tests as it's a very specific issue unlikely to reoccur.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1467

### Acceptance criteria
(For any combination of new/edit config dialogs)

1. Cancelling the edit config dialog discards any unsaved changes.
1. Saving configurations continues to work correctly.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

…pies