### PR TITLE
GUI: Date created/modified should not appear if blank

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -67,6 +67,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
 	private String synoptic;
 	private String dateCreated;
 	private String dateModified;
+    private Boolean datesVisible;
 	private final List<EditableIoc> editableIocs = new ArrayList<>();
 	private final List<EditableGroup> editableGroups = new ArrayList<>();
 	private final List<EditableBlock> editableBlocks = new ArrayList<>();
@@ -180,7 +181,19 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
 	public void setDateModified(String dateModified) {
 		firePropertyChange("dateModified", this.dateModified, this.dateModified = dateModified);
 	}
-	
+
+    /**
+     * @return Whether the date labels should be visible in the GUI. False if
+     *         configuration is new.
+     */
+    public boolean getDatesVisible() {
+        if (history.size() != 0) {
+            datesVisible = true;
+        } else {
+            datesVisible = false;
+        }
+        return datesVisible;
+    }
     Collection<Block> getBlocks() {
 		return Lists.newArrayList(Iterables.transform(editableBlocks, new Function<EditableBlock, Block>() {
 			@Override

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -183,8 +183,9 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
 	}
 
     /**
-     * @return Whether the date labels should be visible in the GUI. False if
-     *         configuration is new.
+     * Whether the date labels should be visible in the GUI.
+     * 
+     * @return False if configuration is new.
      */
     public boolean getDatesVisible() {
         if (history.size() != 0) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
@@ -52,7 +52,9 @@ public class SummaryPanel extends Composite {
 	private Text txtDescription;
 	private Text txtDateCreated;
 	private Text txtDateModified;
+    private Label lblDateCreated;
 	private Label lblDateCreatedField;
+    private Label lblDateModified;
 	private Label lblDateModifiedField;
 	private ComboViewer cmboSynoptic;
 	private EditableConfiguration config;
@@ -95,13 +97,13 @@ public class SummaryPanel extends Composite {
 		cmboSynoptic.setContentProvider(new ArrayContentProvider());
 		updateSynopticList();
 		
-		Label lblDateCreated = new Label(grpSummary, SWT.NONE);
+        lblDateCreated = new Label(grpSummary, SWT.NONE);
 		lblDateCreated.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
 		lblDateCreated.setText("Date Created:");
 		
 		lblDateCreatedField = new Label(grpSummary, SWT.NONE);
 				
-		Label lblDateModified = new Label(grpSummary, SWT.NONE);
+        lblDateModified = new Label(grpSummary, SWT.NONE);
 		lblDateModified.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
 		lblDateModified.setText("Date Modified:");
 		
@@ -122,7 +124,11 @@ public class SummaryPanel extends Composite {
 		
 		bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtName), BeanProperties.value("name").observe(config));
 		bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtDescription), BeanProperties.value("description").observe(config), strategy, null);
-		bindingContext.bindValue(WidgetProperties.selection().observe(cmboSynoptic.getCombo()), BeanProperties.value("synoptic").observe(config));		
+		bindingContext.bindValue(WidgetProperties.selection().observe(cmboSynoptic.getCombo()), BeanProperties.value("synoptic").observe(config));
+        bindingContext.bindValue(WidgetProperties.visible().observe(lblDateCreated),
+                BeanProperties.value("datesVisible").observe(config));
+        bindingContext.bindValue(WidgetProperties.visible().observe(lblDateModified),
+                BeanProperties.value("datesVisible").observe(config));
 		bindingContext.bindValue(WidgetProperties.text().observe(lblDateCreatedField), BeanProperties.value("dateCreated").observe(config));
 		bindingContext.bindValue(WidgetProperties.text().observe(lblDateModifiedField), BeanProperties.value("dateModified").observe(config));
 	}


### PR DESCRIPTION
### Description of work

Sets the visibility of the date created/modified labels in the summary tab depending on configuration history. If of length 0, it is a new configuration and the labels should not be visible.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1445

### Acceptance criteria

Labels are hidden in new configuration, visible otherwise.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

