### PR TITLE
Ticket1402 Spectra Plot Update

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
@@ -52,14 +52,18 @@ public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
 
 		@Override
 		public void onValue(float[] value) {
-            setXData(toDoubleArray(value, xLengthObserver.getValue()));
-		}
+            if (xLengthObserver.getValue() != null) {
+                setXData(toDoubleArray(value, xLengthObserver.getValue()));
+            }
+        }
 	};
 
 	private final DataObserver yDataObserver = new DataObserver() {
 		@Override
-		public void onValue(float[] value) {
-            setYData(toDoubleArray(value, yLengthObserver.getValue()));
+        public void onValue(float[] value) {
+            if (yLengthObserver.getValue() != null) {
+                setYData(toDoubleArray(value, yLengthObserver.getValue()));
+            }
 		}
 	};
 

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
@@ -1,7 +1,7 @@
 
 /*
 * This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* Copyright (C) 2012-2016 Science & Technology Facilities Council.
 * All rights reserved.
 *
 * This program is distributed in the hope that it will be useful.
@@ -21,59 +21,62 @@ package uk.ac.stfc.isis.ibex.dae.spectra;
 
 import uk.ac.stfc.isis.ibex.dae.DaeObservables;
 import uk.ac.stfc.isis.ibex.epics.observing.BaseObserver;
+import uk.ac.stfc.isis.ibex.epics.observing.BufferedObservablePair;
 import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
+import uk.ac.stfc.isis.ibex.epics.observing.Pair;
 import uk.ac.stfc.isis.ibex.epics.observing.Subscription;
 import uk.ac.stfc.isis.ibex.epics.pv.Closable;
 
 public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
 		
 	private final DaeObservables observables;
+    private BufferedObservablePair<Integer, float[]> xData;
+    private BufferedObservablePair<Integer, float[]> yData;
 	
-	private abstract class DataObserver extends BaseObserver<float[]> {
+    private abstract class DataObserver extends BaseObserver<Pair<Integer, float[]>> {
 		@Override
 		public void onError(Exception e) {			
 		}
 
 		@Override
 		public void onConnectionStatus(boolean isConnected) {			
-		}
-		
+        }
+
         protected double[] toDoubleArray(float[] value, int length) {
             double[] doubles = new double[length];
             for (int i = 0; i < length; i++) {
-				doubles[i] = value[i];
-			}
-			
-			return doubles;
-		}
+                doubles[i] = value[i];
+            }
+            return doubles;
+
+        }
 	}
 	
 	private final DataObserver xDataObserver = new DataObserver() {
 
 		@Override
-		public void onValue(float[] value) {
-            if (xLengthObserver.getValue() != null) {
-                setXData(toDoubleArray(value, xLengthObserver.getValue()));
-            }
+        public void onValue(Pair<Integer, float[]> value) {
+            setXData(toDoubleArray(value.second, value.first));
         }
 	};
 
 	private final DataObserver yDataObserver = new DataObserver() {
 		@Override
-        public void onValue(float[] value) {
-            if (yLengthObserver.getValue() != null) {
-                setYData(toDoubleArray(value, yLengthObserver.getValue()));
-            }
-		}
+        public void onValue(Pair<Integer, float[]> value) {
+            setYData(toDoubleArray(value.second, value.first));
+        }
 	};
 
 	private Subscription xSubscription;
 	private Subscription ySubscription;
 
-    private ForwardingObservable<Integer> xLengthObserver;
-    private ForwardingObservable<Integer> yLengthObserver;
+    private ForwardingObservable<Integer> xLengthObservable;
+    private ForwardingObservable<Integer> yLengthObservable;
 
-	public ObservedSpectrum(DaeObservables observables) {
+    private ForwardingObservable<float[]> xValObservable;
+    private ForwardingObservable<float[]> yValObservable;
+
+    public ObservedSpectrum(DaeObservables observables) {
 		this.observables = observables;
 	}
 	
@@ -94,13 +97,20 @@ public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
 	}
 	
 	private void updateSubscriptions() {
-		cancelSubscriptions();
-        xLengthObserver = observables.spectrumXDataLength(getNumber(), getPeriod());
-        yLengthObserver = observables.spectrumYDataLength(getNumber(), getPeriod());
+        cancelSubscriptions();
 
-		xSubscription = observables.spectrumXData(getNumber(), getPeriod()).addObserver(xDataObserver);
-		ySubscription = observables.spectrumYData(getNumber(), getPeriod()).addObserver(yDataObserver);
-	}
+        xLengthObservable = observables.spectrumXDataLength(getNumber(), getPeriod());
+        yLengthObservable = observables.spectrumYDataLength(getNumber(), getPeriod());
+        
+        xValObservable = observables.spectrumXData(getNumber(), getPeriod());
+        yValObservable = observables.spectrumYData(getNumber(), getPeriod());
+        
+        xData = new BufferedObservablePair<>(xLengthObservable, xValObservable);
+        yData = new BufferedObservablePair<>(yLengthObservable, yValObservable);
+
+        xSubscription = xData.addObserver(xDataObserver);
+        ySubscription = yData.addObserver(yDataObserver);
+    }
 
 	@Override
 	public void close() {

--- a/base/uk.ac.stfc.isis.ibex.epics.tests/src/uk/ac/stfc/isis/ibex/epics/tests/observing/BufferedObservablePairTest.java
+++ b/base/uk.ac.stfc.isis.ibex.epics.tests/src/uk/ac/stfc/isis/ibex/epics/tests/observing/BufferedObservablePairTest.java
@@ -1,0 +1,127 @@
+
+/*
+* This file is part of the ISIS IBEX application.
+* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* All rights reserved.
+*
+* This program is distributed in the hope that it will be useful.
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v1.0 which accompanies this distribution.
+* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+*
+* You should have received a copy of the Eclipse Public License v1.0
+* along with this program; if not, you can obtain a copy from
+* https://www.eclipse.org/org/documents/epl-v10.php or 
+* http://opensource.org/licenses/eclipse-1.0.php
+*/
+
+package uk.ac.stfc.isis.ibex.epics.tests.observing;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+
+import uk.ac.stfc.isis.ibex.epics.observing.BufferedObservablePair;
+import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
+import uk.ac.stfc.isis.ibex.epics.observing.Observer;
+import uk.ac.stfc.isis.ibex.epics.observing.Pair;
+
+// A lot of unchecked type conversions for mocking purposes
+@SuppressWarnings({ "unchecked", "checkstyle:methodname" })
+/**
+ * Test for BufferedObservablePair
+ */
+public class BufferedObservablePairTest {
+	
+    private Observer<Pair<String, Integer>> mockObserver;
+	
+	private TestableObservable<String> testableStringObservable;
+	private TestableObservable<Integer> testableIntegerObservable;
+	
+	private ForwardingObservable<String> initStringObservable;
+	private ForwardingObservable<Integer> initIntegerObservable;
+	
+    private BufferedObservablePair<String, Integer> bufferedObservablePair;
+	
+	@Captor
+	private ArgumentCaptor<Pair<String, Integer>> pairCaptor;
+	
+	@Before
+	public void setUp() {
+		// This is to initialise the captor
+		MockitoAnnotations.initMocks(this);
+		
+        mockObserver = mock(Observer.class);
+		
+		testableStringObservable = new TestableObservable<>();
+		testableStringObservable.setValue(TestHelpers.STRING_VALUE);
+		initStringObservable = new ForwardingObservable<>(testableStringObservable);
+		
+		testableIntegerObservable = new TestableObservable<Integer>();
+		testableIntegerObservable.setValue(TestHelpers.INT_VALUE);
+		initIntegerObservable = new ForwardingObservable<>(testableIntegerObservable);
+		
+        bufferedObservablePair =
+                new BufferedObservablePair<String, Integer>(initStringObservable, initIntegerObservable);
+        bufferedObservablePair.addObserver(mockObserver);
+	}
+	
+	@Test
+    public void WHEN_only_first_value_set_THEN_observers_not_notified() {
+		// Act
+		testableStringObservable.setValue(TestHelpers.NEW_STRING_VALUE);
+		
+        // Assert - The observer has not had its onValue called and the public
+        // value remains null.
+        verify(mockObserver, times(0)).onValue(pairCaptor.capture());
+        assertEquals(null, bufferedObservablePair.getValue());
+	}
+
+    @Test
+    public void WHEN_only_second_value_set_THEN_observers_not_notified() {
+        // Act
+        testableIntegerObservable.setValue(TestHelpers.NEW_INT_VALUE);
+
+        // Assert - The observer has not had its onValue called and the public
+        // value remains null.
+        verify(mockObserver, times(0)).onValue(pairCaptor.capture());
+        assertEquals(null, bufferedObservablePair.getValue());
+    }
+
+    @Test
+    public void WHEN_both_values_set_THEN_observers_notified_and_stored_value_correct() {
+        // Act
+        testableStringObservable.setValue(TestHelpers.NEW_STRING_VALUE);
+        testableIntegerObservable.setValue(TestHelpers.NEW_INT_VALUE);
+
+        // Assert - The observer has its onValue called once and has the new
+        // value
+        verify(mockObserver, times(1)).onValue(pairCaptor.capture());
+        assertEquals(TestHelpers.NEW_STRING_VALUE, pairCaptor.getValue().first);
+        assertEquals(TestHelpers.NEW_INT_VALUE, pairCaptor.getValue().second);
+    }
+
+    @Test
+    public void
+            GIVEN_value_pair_in_buffer_WHEN_new_second_value_observed_THEN_values_collated_into_most_recent_value_pair_and_set() {
+        // Arrange
+        testableStringObservable.setValue("initial_val");
+        testableIntegerObservable.setValue(TestHelpers.NEW_INT_VALUE);
+
+        // Act
+        testableStringObservable.setValue("new_val");
+
+        // Assert - The observer has its on value method called twice, and has
+        // the most recent values for both values in the pair.
+        verify(mockObserver, times(2)).onValue(pairCaptor.capture());
+        assertEquals("new_val", pairCaptor.getValue().first);
+        assertEquals(TestHelpers.NEW_INT_VALUE, pairCaptor.getValue().second);
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.epics.tests/src/uk/ac/stfc/isis/ibex/epics/tests/observing/BufferedObservablePairTest.java
+++ b/base/uk.ac.stfc.isis.ibex.epics.tests/src/uk/ac/stfc/isis/ibex/epics/tests/observing/BufferedObservablePairTest.java
@@ -110,7 +110,7 @@ public class BufferedObservablePairTest {
 
     @Test
     public void
-            GIVEN_value_pair_in_buffer_WHEN_new_second_value_observed_THEN_values_collated_into_most_recent_value_pair_and_set() {
+            GIVEN_value_pair_in_buffer_WHEN_new_first_value_observed_THEN_values_collated_into_most_recent_value_pair_and_set() {
         // Arrange
         testableStringObservable.setValue("initial_val");
         testableIntegerObservable.setValue(TestHelpers.NEW_INT_VALUE);

--- a/base/uk.ac.stfc.isis.ibex.epics/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.epics/META-INF/MANIFEST.MF
@@ -23,4 +23,5 @@ Export-Package: uk.ac.stfc.isis.ibex.epics.adapters,
  uk.ac.stfc.isis.ibex.epics.observing,
  uk.ac.stfc.isis.ibex.epics.pv,
  uk.ac.stfc.isis.ibex.epics.writing
-Import-Package: uk.ac.stfc.isis.ibex.alarm
+Import-Package: uk.ac.stfc.isis.ibex.alarm,
+ uk.ac.stfc.isis.ibex.epics.observing

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/BufferedObservablePair.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/BufferedObservablePair.java
@@ -1,0 +1,118 @@
+
+/*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.epics.observing;
+
+/**
+ * Links together two related, interdependent observables into a single
+ * observable and buffers values so that observers are not notified until both
+ * observables have a non-null value.
+ *
+ * @param <T1> The type of the first value being observed.
+ * @param <T2> The type of the second value being observed.
+ */
+public class BufferedObservablePair<T1, T2> extends ObservablePair<T1, T2> {
+
+    private Pair<T1, T2> buffer;
+    
+    /**
+     * Calls superclass constructor.
+     * 
+     * @param firstSource the first observable
+     * @param secondSource the second observable
+     */
+    public BufferedObservablePair(ForwardingObservable<T1> firstSource, ForwardingObservable<T2> secondSource) {
+        super(firstSource, secondSource);
+    }
+
+    /**
+     * Updates buffer with the newly received value pair. Properly sets the
+     * value and notifies observers once both values in the buffer pair are
+     * non-null.
+     * 
+     * @param value the new value pair
+     */
+    @Override
+    protected void setValue(Pair<T1, T2> value) {
+        if (buffer == null) {
+            buffer = new Pair<T1, T2>(null, null);
+        }
+        this.buffer = collateWithBuffer(value);
+
+        if (checkNotNull()) {
+            super.setValue(buffer);
+        }
+    }
+
+    /**
+     * Collates the newly received value pair with values already present in the
+     * buffer.
+     * 
+     * @param pair the new value pair
+     * @return the new value pair with missing values filled in from the buffer.
+     */
+    private Pair<T1, T2> collateWithBuffer(Pair<T1, T2> pair) {
+        T1 first = collateFirst(pair.first);
+        T2 second = collateSecond(pair.second);
+        return new Pair<T1, T2>(first, second);
+    }
+
+    /**
+     * Sets the most recent available value as the first value in the pair in
+     * the order: new value received from observable, value from buffer, null.
+     * 
+     * @param value the new value
+     * @return the most recent available value
+     */
+    private T1 collateFirst(T1 value) {
+        T1 first = buffer.first;
+        if (value != null) {
+            first = value;
+        }
+        return first;
+    }
+
+    /**
+     * Sets the most recent available value as the second value in the pair in
+     * the order: new value received from observable, value from buffer, null.
+     * 
+     * @param value the new value
+     * @return the most recent available value
+     */
+    private T2 collateSecond(T2 value) {
+        T2 second = buffer.second;
+        if (value != null) {
+            second = value;
+        }
+        return second;
+    }
+
+    /**
+     * Checks whether both values in the pair are set.
+     * 
+     * @return true if both values in the pair are set, false if at least one is
+     *         still null.
+     */
+    private Boolean checkNotNull() {
+        return (buffer.first != null && buffer.second != null);
+    }
+}


### PR DESCRIPTION
### Description of work

Fixed a bug where the spectra plots occasionally wouldn't update after switching to a different spectra plot number. The bug stemmed from a method being called with a PV value as argument before that value had been received, resulting in the thread to die. Fixed by adding a check for null before the method call.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1402

### Acceptance criteria

Graph always updates appropriately after switching to a different spectra plot. I verified by printing a line in case of the value being null and comparing the subsequent behaviour with and without the check.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

