### PR TITLE
Use specific pump speed percentage PV

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/linkam95.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/linkam95.opi
@@ -531,7 +531,7 @@ $(pv_value)</tooltip>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
       <visible>true</visible>
-      <pv_name>$(PV_ROOT):PUMP:SPEED</pv_name>
+      <pv_name>$(PV_ROOT):PUMP:SPEED:PC</pv_name>
       <vertical_alignment>1</vertical_alignment>
       <border_color>
         <color name="ISIS_Border" red="0" green="0" blue="0" />


### PR DESCRIPTION
### Description of work

Update OPI to use PUMP:SPEED:PC instead of raw PUMP:SPEED value

### To test

1477

### Acceptance criteria

Behaviour should be unchanged. The PUMP:SPEED:PC should report the same value as PUMP:SPEED did before PR https://github.com/ISISComputingGroup/EPICS-ioc/pull/69

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

