### PR TITLE
Targets and targets.ui were missing from the base feature

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.devicescreens/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.devicescreens/META-INF/MANIFEST.MF
@@ -12,8 +12,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Import-Package: uk.ac.stfc.isis.ibex.epics.conversion,
  uk.ac.stfc.isis.ibex.epics.observing,
- uk.ac.stfc.isis.ibex.epics.switching,
- uk.ac.stfc.isis.ibex.targets
+ uk.ac.stfc.isis.ibex.epics.switching
 Export-Package: uk.ac.stfc.isis.ibex.devicescreens,
  uk.ac.stfc.isis.ibex.devicescreens.components,
  uk.ac.stfc.isis.ibex.devicescreens.desc

--- a/base/uk.ac.stfc.isis.ibex.feature.base/feature.xml
+++ b/base/uk.ac.stfc.isis.ibex.feature.base/feature.xml
@@ -464,4 +464,18 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="uk.ac.stfc.isis.ibex.targets"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="uk.ac.stfc.isis.ibex.ui.targets"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/1513

### Description of work

Running the GUI from within Eclipse fails because of dependency issues. I suspect everyone is getting around this by using "Run Configurations".
I have added the required dependencies to the base feature.

### To test

(on master) If you start ibex.product from within Eclipse **it should fail to start.** Though it might not if you have been using a run configuration to get round the problem - you could try deleting your copy of Eclipse and installing a fresh copy from Kits$

(on this branch) If you start ibex.product from within Eclipse **it should start**.

### Acceptance criteria

The GUI can be started from ibex,product without fiddling with run configurations

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

