### PR TITLE
better handling of alarm error

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/displaying/DisplayBlock.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/displaying/DisplayBlock.java
@@ -146,7 +146,9 @@ public class DisplayBlock extends ModelObject {
 
         @Override
         public void onError(Exception e) {
-            setValue("error");
+            BlockState alarm = BlockState.MINOR_ALARM;
+            lastAlarmState = alarm;
+            setBlockState(alarm);
         }
 
         @Override


### PR DESCRIPTION
### Description of work

Previously, the alarm observer would (wrongly) set the display value to "error" in case of an error (e.g. observed alarm value has wrong type on CA). Now it sets the block's alarm state to minor. This is a preliminary solution aiming to make as little changes as possible.
I have created https://github.com/ISISComputingGroup/IBEX/issues/1573 to discuss how we want to handle these errors properly.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1571

### Acceptance criteria

1. Block value does not get obscured by "error" message
1. Block alarm is set to "minor" in case of error in the alarm field (e.g. PV observed by block does not possess an alarm field)

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [x] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

