### PR TITLE
Allow field to be added to PV addresses

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/PvValidatorTest.java
+++ b/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/PvValidatorTest.java
@@ -22,9 +22,7 @@
  */
 package uk.ac.stfc.isis.ibex.validators.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -37,13 +35,63 @@ public class PvValidatorTest {
      * Test method for {@link uk.ac.stfc.isis.ibex.validators.PvValidator#validatePvAddress(java.lang.String)}.
      */
     @Test
-    public void valid_pv_address() {
+    public void GIVEN_plain_pv_address_WHEN_validate_THEN_valid() {
         // Arrange
         String testAddress = "valid";
         // Act
         PvValidator addressValid = new PvValidator();
         // Assert
         assertTrue(addressValid.validatePvAddress(testAddress));
+    }
+
+    @Test
+    public void GIVEN_pv_address_with_field_WHEN_validate_THEN_valid() {
+        // Arrange
+        String testAddress = "valid.field";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertTrue(addressValid.validatePvAddress(testAddress));
+    }
+
+    @Test
+    public void GIVEN_pv_address_with_non_alpha_character_WHEN_validate_THEN_valid() {
+        // Arrange
+        String testAddress = "va_:lid.fi_:eld";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertTrue(addressValid.validatePvAddress(testAddress));
+    }
+
+    @Test
+    public void GIVEN_pv_address_two_field_WHEN_validate_THEN_error() {
+        // Arrange
+        String testAddress = "invalid.field.field";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertFalse(addressValid.validatePvAddress(testAddress));
+    }
+
+    @Test
+    public void GIVEN_pv_address_blank_field_WHEN_validate_THEN_error() {
+        // Arrange
+        String testAddress = "invalid.";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertFalse(addressValid.validatePvAddress(testAddress));
+    }
+
+    @Test
+    public void GIVEN_pv_address_just_field_WHEN_validate_THEN_error() {
+        // Arrange
+        String testAddress = ".invalid";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertFalse(addressValid.validatePvAddress(testAddress));
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/PvValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/PvValidator.java
@@ -23,12 +23,13 @@
 package uk.ac.stfc.isis.ibex.validators;
 
 /**
- * Provides validation for PV items
+ * Provides validation for PV items.
  *
  */
 public class PvValidator {
 
-    public static final String ADDRESS_FORMAT = "PV Address invalid, use only [a-z], [A-Z], [0-9], : and _";
+    public static final String ADDRESS_FORMAT =
+            "PV Address invalid, use only [a-z], [A-Z], [0-9], : and _ (a field may be added using a .)";
     public static final String ADDRESS_EMPTY = "PV Address invalid, must not be empty";    
     private static final String NO_ERROR = "";
 
@@ -45,18 +46,18 @@ public class PvValidator {
     /**
      * Checks that a String conforms to the requirements of a PV address Can
      * only contain alphanumeric, underscore and colon Case is not specified as
-     * PVs are not necessarily uppercase - e.g. non instrument prefixes
+     * PVs are not necessarily upper case - e.g. non instrument prefixes
      * 
-     * @param pvAddress
+     * @param pvAddress the address to validate
      * @return Boolean addressValid
      */
     public Boolean validatePvAddress(String pvAddress) {
         boolean isValid = false;
 
-        if (!(pvAddress.matches("^[a-zA-Z0-9_:]*$"))) {
+        if (pvAddress.isEmpty()) {
+            setErrorMessage(ADDRESS_EMPTY);
+        } else if (!(pvAddress.matches("^[a-zA-Z0-9_:]+(\\.[a-zA-Z0-9_:]+)?$"))) {
             setErrorMessage(ADDRESS_FORMAT);
-        } else if (pvAddress.isEmpty()) {
-        	setErrorMessage(ADDRESS_EMPTY);
         } else {
             isValid = true;
             setErrorMessage(NO_ERROR);
@@ -69,6 +70,9 @@ public class PvValidator {
         this.errorMessage = errorMessage;
     }
 
+    /**
+     * @return the last error message
+     */
     public String getErrorMessage() {
         return errorMessage;
     }


### PR DESCRIPTION
### Description of work

Allow field on PVs in edit config.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1576

### Acceptance criteria

1. Go to edit config
1. Add a block with a field
1. Check error message for invalid PV
---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [x] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
Check they are in release 2.1.0
After merge please add commit to release branch as well
