### PR TITLE
Ticket1632 dashboard numbers display

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
@@ -243,6 +243,7 @@
 		<module>../uk.ac.stfc.isis.ibex.ui.configserver.tests</module>
 		<module>../uk.ac.stfc.isis.ibex.ui.scriptgenerator</module>
 		<module>../uk.ac.stfc.isis.ibex.scriptgenerator</module>
+		<module>../uk.ac.stfc.isis.ibex.ui.dashboard.tests</module>
 	</modules>
 </project>
 

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/.classpath
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/.classpath
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/.project
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>uk.ac.stfc.isis.ibex.ui.dashboard.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tests
+Bundle-SymbolicName: uk.ac.stfc.isis.ibex.ui.dashboard.tests
+Bundle-Version: 1.0.0.qualifier
+Fragment-Host: uk.ac.stfc.isis.ibex.ui.dashboard;bundle-version="1.0.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Require-Bundle: org.junit;bundle-version="4.11.0",
+ org.mockito;bundle-version="1.9.5"

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/build.properties
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>uk.ac.stfc.isis.ibex.ui.dashboard.tests</artifactId>
+  <packaging>eclipse-test-plugin</packaging>
+  <parent>
+  	<groupId>CSS_ISIS</groupId>
+  	<artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
+  	<version>1.0.0-SNAPSHOT</version>
+  	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
+  </parent>
+</project>

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/src/uk/ac/stfc/isis/ibex/ui/dashboard/tests/models/ObservableDecimalRatioTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard.tests/src/uk/ac/stfc/isis/ibex/ui/dashboard/tests/models/ObservableDecimalRatioTest.java
@@ -1,0 +1,164 @@
+
+/*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.ui.dashboard.tests.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
+import uk.ac.stfc.isis.ibex.epics.observing.Pair;
+import uk.ac.stfc.isis.ibex.ui.dashboard.models.ObservableDecimalRatio;
+
+@SuppressWarnings({ "unchecked", "checkstyle:methodname" })
+public class ObservableDecimalRatioTest {
+
+    private ClosableObservable<Pair<Number, Number>> mockSource;
+
+    @Before
+    public void setUp() {
+        // Arrange
+        mockSource = mock(ClosableObservable.class);
+        when(mockSource.currentError()).thenReturn(null);
+        when(mockSource.isConnected()).thenReturn(true);
+    }
+
+    private void setSourceNumbers(double first, double second) {
+        Pair<Number, Number> pair = new Pair<Number, Number>(first, second);
+        when(mockSource.getValue()).thenReturn(pair);
+    }
+
+    @Test
+    public void
+            GIVEN_integer_source_numbers_WHEN_they_are_converted_with_default_settings_THEN_formatting_is_correct() {
+        // Arrange
+        setSourceNumbers(3, 4);
+
+        // Act
+        ObservableDecimalRatio ratio = new ObservableDecimalRatio(mockSource);
+
+        // Assert
+        assertEquals("3 / 4", ratio.getValue());
+    }
+
+    @Test
+    public void
+            GIVEN_fractional_source_numbers_WHEN_they_are_converted_with_default_settings_THEN_formatting_is_correct() {
+        // Arrange
+        setSourceNumbers(123.456, 456.789);
+
+        // Act
+        ObservableDecimalRatio ratio = new ObservableDecimalRatio(mockSource);
+
+        // Assert
+        assertEquals("123.456 / 456.789", ratio.getValue());
+    }
+
+    @Test
+    public void
+            GIVEN_fractional_source_numbers_exceeding_max_fractional_digits_WHEN_they_are_converted_with_default_settings_THEN_formatting_is_correct() {
+        // Arrange
+        setSourceNumbers(123.4567, 456.7899);
+
+        // Act
+        ObservableDecimalRatio ratio = new ObservableDecimalRatio(mockSource);
+
+        // Assert
+        assertEquals("123.457 / 456.79", ratio.getValue());
+    }
+
+    @Test
+    public void
+            GIVEN_fractional_source_numbers_exceeding_max_integer_digits_WHEN_they_are_converted_with_default_settings_THEN_formatting_is_correct() {
+        // Arrange
+        setSourceNumbers(1234.567, 4567.899);
+
+        // Act
+        ObservableDecimalRatio ratio = new ObservableDecimalRatio(mockSource);
+
+        // Assert
+        assertEquals("234.567 / 567.899", ratio.getValue());
+    }
+
+    @Test
+    public void
+            GIVEN_integer_source_numbers_WHEN_they_are_converted_with_custom_settings_THEN_formatting_is_correct() {
+        // Arrange
+        setSourceNumbers(3, 4);
+        int maxIntDigits = 5;
+        int maxFracDigits = 4;
+
+        // Act
+        ObservableDecimalRatio ratio = new ObservableDecimalRatio(mockSource, maxIntDigits, maxFracDigits);
+
+        // Assert
+        assertEquals("3 / 4", ratio.getValue());
+    }
+
+    @Test
+    public void
+            GIVEN_fractional_source_numbers_WHEN_they_are_converted_with_custom_settings_THEN_formatting_is_correct() {
+        // Arrange
+        setSourceNumbers(12345.4567, 45656.7899);
+        int maxIntDigits = 5;
+        int maxFracDigits = 4;
+
+        // Act
+        ObservableDecimalRatio ratio = new ObservableDecimalRatio(mockSource, maxIntDigits, maxFracDigits);
+
+        // Assert
+        assertEquals("12,345.4567 / 45,656.7899", ratio.getValue());
+    }
+
+    @Test
+    public void
+            GIVEN_fractional_source_numbers_exceeding_max_fractional_digits_WHEN_they_are_converted_with_custom_settings_THEN_formatting_is_correct() {
+        // Arrange
+        setSourceNumbers(123.45678, 456.78992);
+        int maxIntDigits = 5;
+        int maxFracDigits = 4;
+
+        // Act
+        ObservableDecimalRatio ratio = new ObservableDecimalRatio(mockSource, maxIntDigits, maxFracDigits);
+
+        // Assert
+        assertEquals("123.4568 / 456.7899", ratio.getValue());
+    }
+
+    @Test
+    public void
+            GIVEN_fractional_source_numbers_exceeding_max_integer_digits_WHEN_they_are_converted_with_custom_settings_THEN_formatting_is_correct() {
+        // Arrange
+        setSourceNumbers(123456.567, 456712.899);
+        int maxIntDigits = 5;
+        int maxFracDigits = 4;
+
+        // Act
+        ObservableDecimalRatio ratio = new ObservableDecimalRatio(mockSource, maxIntDigits, maxFracDigits);
+
+        // Assert
+        assertEquals("23,456.567 / 56,712.899", ratio.getValue());
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/MonitorPanelModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/MonitorPanelModel.java
@@ -36,6 +36,8 @@ public class MonitorPanelModel extends Closer {
     private final UpdatedValue<String> goodOverRawFrames;
     private final UpdatedValue<String> currentOverTotal;
     private final UpdatedValue<String> monitorCounts;
+    private static final int MAX_CURR_INT_DIGITS = 4;
+    private static final int MAX_CURR_FRAC_DIGITS = 2;
 
     public MonitorPanelModel(DashboardObservables observables) {
         goodOverRawFrames = createGoodOverRawFrames(observables);
@@ -68,7 +70,7 @@ public class MonitorPanelModel extends Closer {
         ClosableObservable<Pair<Number, Number>> pair = registerForClose(
                 new ObservablePair<>(observables.dae.beamCurrent, observables.dae.goodCurrent));
         ForwardingObservable<String> ratio = new ForwardingObservable<String>(
-                new ObservableDecimalRatio(pair));
+                new ObservableDecimalRatio(pair, MAX_CURR_INT_DIGITS, MAX_CURR_FRAC_DIGITS));
 
         return registerForClose(new TextUpdatedObservableAdapter(ratio));
     }

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/ObservableDecimalRatio.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/ObservableDecimalRatio.java
@@ -33,7 +33,7 @@ import uk.ac.stfc.isis.ibex.epics.observing.TransformingObservable;
  */
 public class ObservableDecimalRatio extends TransformingObservable<Pair<Number, Number>, String> {
 
-	private static final NumberFormat FORMAT = DecimalFormat.getInstance(Locale.ENGLISH);
+    private final NumberFormat format = DecimalFormat.getInstance(Locale.ENGLISH);
     private static final int DEFAULT_MAX_INTEGER_DIGITS = 3;
     private static final int DEFAULT_MAX_FRACTION_DIGITS = 3;
 	
@@ -57,8 +57,8 @@ public class ObservableDecimalRatio extends TransformingObservable<Pair<Number, 
      */
     public ObservableDecimalRatio(ClosableObservable<Pair<Number, Number>> source, int maxIntegerDigits,
             int maxFractionDigits) {
-        FORMAT.setMaximumIntegerDigits(maxIntegerDigits);
-        FORMAT.setMaximumFractionDigits(maxFractionDigits);
+        format.setMaximumIntegerDigits(maxIntegerDigits);
+        format.setMaximumFractionDigits(maxFractionDigits);
         setSource(source);
 
     }
@@ -73,6 +73,6 @@ public class ObservableDecimalRatio extends TransformingObservable<Pair<Number, 
 	}
 
 	private String format(Number value) {
-		return FORMAT.format(value);
+        return format.format(value);
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/ObservableDecimalRatio.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/ObservableDecimalRatio.java
@@ -27,19 +27,42 @@ import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.Pair;
 import uk.ac.stfc.isis.ibex.epics.observing.TransformingObservable;
 
-@SuppressWarnings("checkstyle:magicnumber")
+/**
+ * A class to translate an observable pair of numbers into a string
+ * representation of their ratio, also an observable.
+ */
 public class ObservableDecimalRatio extends TransformingObservable<Pair<Number, Number>, String> {
 
 	private static final NumberFormat FORMAT = DecimalFormat.getInstance(Locale.ENGLISH);
-	static {
-		FORMAT.setMaximumIntegerDigits(3);
-		FORMAT.setMaximumFractionDigits(3);
-	}
+    private static final int DEFAULT_MAX_INTEGER_DIGITS = 3;
+    private static final int DEFAULT_MAX_FRACTION_DIGITS = 3;
 	
+    /**
+     * Creates a new instance of the class. Maps an input observable pair of
+     * numbers into an observable string representation of their ratio.
+     * 
+     * @param source the pair of numbers to observe
+     */
 	public ObservableDecimalRatio(ClosableObservable<Pair<Number, Number>> source) {
-		setSource(source);
+        this(source, DEFAULT_MAX_INTEGER_DIGITS, DEFAULT_MAX_FRACTION_DIGITS);
 	}
 	
+    /**
+     * Creates a new instance of the class. Maps an input observable pair of
+     * numbers into an observable string representation of their ratio.
+     * 
+     * @param source the pair of numbers to observe
+     * @param maxIntegerDigits how many digits to be used for the integer part
+     * @param maxFractionDigits how many digits to be used for the fraction part
+     */
+    public ObservableDecimalRatio(ClosableObservable<Pair<Number, Number>> source, int maxIntegerDigits,
+            int maxFractionDigits) {
+        FORMAT.setMaximumIntegerDigits(maxIntegerDigits);
+        FORMAT.setMaximumFractionDigits(maxFractionDigits);
+        setSource(source);
+
+    }
+
 	@Override
 	protected String transform(Pair<Number, Number> value) {		
 		if (value.first == null || value.second == null) {

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
@@ -84,7 +84,9 @@ public class DashboardView extends ViewPart implements ISizeProvider {
         separator2.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 		
 		MonitorPanel monitors = new MonitorPanel(parent, SWT.NONE, monitorsModel, textFont);
-		monitors.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
+        GridData monitorsLayoutGridData = new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1);
+        monitorsLayoutGridData.widthHint = 315;
+        monitors.setLayoutData(monitorsLayoutGridData);
 		
 		Label separator3 = new Label(parent, SWT.SEPARATOR | SWT.VERTICAL);
 		separator3.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 1, 1));

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
@@ -65,23 +65,23 @@ public class DashboardView extends ViewPart implements ISizeProvider {
 	
 	@Override
     public void createPartControl(Composite parent) {
-		GridLayout glParent = new GridLayout(3, false);
+        GridLayout glParent = new GridLayout(3, false);
 		glParent.marginHeight = 0;
 		glParent.marginWidth = 0;
 		glParent.horizontalSpacing = 1;
 		glParent.verticalSpacing = 0;
 		parent.setLayout(glParent);
 		Banner banner = new Banner(parent, SWT.NONE, bannerModel, bannerTitleFont, bannerFont);
-		banner.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1));
+        banner.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1));
 		
 		Label separator1 = new Label(parent, SWT.SEPARATOR | SWT.HORIZONTAL);
-		separator1.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
+        separator1.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 		
 		TitlePanel title = new TitlePanel(parent, SWT.NONE, titleModel, textFont);
-		title.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
+        title.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 		
 		Label separator2 = new Label(parent, SWT.SEPARATOR | SWT.HORIZONTAL);
-		separator2.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
+        separator2.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1));
 		
 		MonitorPanel monitors = new MonitorPanel(parent, SWT.NONE, monitorsModel, textFont);
 		monitors.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/widgets/MonitorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/widgets/MonitorPanel.java
@@ -22,13 +22,13 @@ package uk.ac.stfc.isis.ibex.ui.dashboard.widgets;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
-import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.graphics.Font;
-import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.wb.swt.SWTResourceManager;
 
 import uk.ac.stfc.isis.ibex.ui.dashboard.models.MonitorPanelModel;
@@ -46,14 +46,14 @@ public class MonitorPanel extends Composite {
 		
 		Label lblGoodRaw = new Label(this, SWT.NONE);
 		lblGoodRaw.setFont(font);
-		lblGoodRaw.setText("Good / Raw Frames:");
+        lblGoodRaw.setText("Good / Raw Frames:");
 		
 		goodRawFrames = new StyledText(this, SWT.READ_ONLY | SWT.SINGLE);
 		goodRawFrames.setEnabled(false);
 		goodRawFrames.setBackground(SWTResourceManager.getColor(SWT.COLOR_WIDGET_BACKGROUND));
 		goodRawFrames.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 		goodRawFrames.setFont(font);
-		goodRawFrames.setText("xxx / xxx");
+        goodRawFrames.setText("xxxxxxxx / xxxxxxxx");
 		
 		Label lblCurrentTotal = new Label(this, SWT.NONE);
 		lblCurrentTotal.setFont(font);

--- a/base/uk.ac.stfc.isis.ibex.ui/src/org/eclipse/wb/swt/SWTResourceManager.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/org/eclipse/wb/swt/SWTResourceManager.java
@@ -1,5 +1,3 @@
-//CHECKSTYLE:OFF
-
 /*******************************************************************************
  * Copyright (c) 2011 Google, Inc.
  * All rights reserved. This program and the accompanying materials
@@ -447,5 +445,3 @@ public class SWTResourceManager {
 		disposeCursors();
 	}
 }
-
-//CHECKSTYLE:ON


### PR DESCRIPTION
### Description of work

Fixed formatting of current/total so it now displays up to 9999.99.
Added extra space to the monitor panel in the dashboard, so the good/raw frames can display up to 8 digits each.

### To test
ISISComputingGroup/IBEX#1632 and ISISComputingGroup/IBEX#1648

### Acceptance criteria

The dashboard should now be able to display the correct number of digits.
I suggest you create in the SIMPLE IOC some TEST versions of the following PVs and point the GUI DAE observables to the test versions, so you can try out numbers with various digits:
%MYPVPREFIX%DAE:BEAMCURRENT (this is an ai)
%MYPVPREFIX%DAE:GOODUAH (ai)
%MYPVPREFIX%DAE:GOODFRAMES (longin)
%MYPVPREFIX%DAE:RAWFRAMES (longin)

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
