### PR TITLE
Ticket1110 remember custom inst

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
@@ -43,6 +43,7 @@ import org.osgi.service.prefs.Preferences;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
+import uk.ac.stfc.isis.ibex.instrument.custom.CustomInstrumentInfo;
 import uk.ac.stfc.isis.ibex.instrument.internal.LocalHostInstrumentInfo;
 import uk.ac.stfc.isis.ibex.instrument.list.InstrumentListObservable;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -145,7 +146,7 @@ public class Instrument implements BundleActivator {
                 count++;
             }
         }
-        LOG.debug("Changing to instrument " + instrumentInfo.hostName()
+        LOG.debug("Changing to instrument " + instrumentInfo.name()
         		+ ", Number of connected channels = " + Integer.toString(count));
     }
 
@@ -168,11 +169,14 @@ public class Instrument implements BundleActivator {
 	}
 	
 	private InstrumentInfo initialInstrument() {
-		final String initalName = initalPreference.get(INIT_INST_NAME_KEY, localhost.name());
-		final String initalPV = initalPreference.get(INIT_INST_PV_KEY, localhost.pvPrefix());
-		final String initalHost = initalPreference.get(INIT_INST_HOST_KEY, localhost.hostName());
+		final String initialName = initalPreference.get(INIT_INST_NAME_KEY, localhost.name());
+		if (initialName.equals(localhost.name())) {
+			return new LocalHostInstrumentInfo();
+		}
+		final String initialPV = initalPreference.get(INIT_INST_PV_KEY, localhost.pvPrefix());
+		final String initialHost = initalPreference.get(INIT_INST_HOST_KEY, localhost.hostName());
 		
-		return new InstrumentInfo(initalName, initalPV, initalHost);
+		return new CustomInstrumentInfo(initialName, initialPV, initialHost);
 	}
 	
 	public void setInitial() {		

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
@@ -66,7 +66,9 @@ public class Instrument implements BundleActivator {
 	
 	private final Preferences initalPreference = ConfigurationScope.INSTANCE.getNode("uk.ac.stfc.isis.ibex.instrument").node("preferences");
 	
-	private static String initialInstrument = "initial";
+	private static String INIT_INST_NAME_KEY = "initialName";
+	private static String INIT_INST_HOST_KEY = "initialHost";
+	private static String INIT_INST_PV_KEY = "initialPV";	
 	
 	public Instrument() {
 		instance = this;
@@ -123,8 +125,7 @@ public class Instrument implements BundleActivator {
 		this.instrumentInfo = selectedInstrument;
 
         if (!instrumentInfo.hasValidHostName()) {
-            LOG.error("Invalid host name:" + instrumentInfo.hostName());
-            return;
+            LOG.warn("Invalid host name:" + instrumentInfo.hostName());
 		}
 
         instrumentName.setValue(selectedInstrument.name());
@@ -167,18 +168,17 @@ public class Instrument implements BundleActivator {
 	}
 	
 	private InstrumentInfo initialInstrument() {
-		final String initalName = initalPreference.get(initialInstrument, localhost.name());
+		final String initalName = initalPreference.get(INIT_INST_NAME_KEY, localhost.name());
+		final String initalPV = initalPreference.get(INIT_INST_PV_KEY, localhost.pvPrefix());
+		final String initalHost = initalPreference.get(INIT_INST_HOST_KEY, localhost.hostName());
 		
-        return Iterables.find(instruments(), new Predicate<InstrumentInfo>() {
-			@Override
-			public boolean apply(InstrumentInfo info) {
-				return initalName.endsWith(info.name());
-			}
-		}, localhost);
+		return new InstrumentInfo(initalName, initalPV, initalHost);
 	}
 	
-	public void setInitial() {
-		initalPreference.put(initialInstrument, currentInstrument().name());
+	public void setInitial() {		
+		initalPreference.put(INIT_INST_NAME_KEY, currentInstrument().name());
+		initalPreference.put(INIT_INST_PV_KEY, currentInstrument().pvPrefix());
+		initalPreference.put(INIT_INST_HOST_KEY, currentInstrument().hostName());
 		
         try {
             // forces the application to save the preferences

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
@@ -40,9 +40,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-
 import uk.ac.stfc.isis.ibex.instrument.custom.CustomInstrumentInfo;
 import uk.ac.stfc.isis.ibex.instrument.internal.LocalHostInstrumentInfo;
 import uk.ac.stfc.isis.ibex.instrument.list.InstrumentListObservable;
@@ -122,6 +119,12 @@ public class Instrument implements BundleActivator {
 		Instrument.context = null;
 	}
 
+	/**
+	 * Set the instrument that IBEX is pointing to. 
+	 * This will update all plugins that are hooked into the instrument extension point. 
+	 * 
+	 * @param selectedInstrument Information on the new instrument.
+	 */
 	public void setInstrument(InstrumentInfo selectedInstrument) {
 		this.instrumentInfo = selectedInstrument;
 

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
@@ -64,9 +64,9 @@ public class Instrument implements BundleActivator {
 	
 	private final Preferences initalPreference = ConfigurationScope.INSTANCE.getNode("uk.ac.stfc.isis.ibex.instrument").node("preferences");
 	
-	private static String INIT_INST_NAME_KEY = "initialName";
-	private static String INIT_INST_HOST_KEY = "initialHost";
-	private static String INIT_INST_PV_KEY = "initialPV";	
+	private static String initNameKey = "initialName";
+	private static String initHostKey = "initialHost";
+	private static String initPVKey = "initialPV";	
 	
 	public Instrument() {
 		instance = this;
@@ -172,20 +172,20 @@ public class Instrument implements BundleActivator {
 	}
 	
 	private InstrumentInfo initialInstrument() {
-		final String initialName = initalPreference.get(INIT_INST_NAME_KEY, localhost.name());
+		final String initialName = initalPreference.get(initNameKey, localhost.name());
 		if (initialName.equals(localhost.name())) {
 			return new LocalHostInstrumentInfo();
 		}
-		final String initialPV = initalPreference.get(INIT_INST_PV_KEY, localhost.pvPrefix());
-		final String initialHost = initalPreference.get(INIT_INST_HOST_KEY, localhost.hostName());
+		final String initialPV = initalPreference.get(initPVKey, localhost.pvPrefix());
+		final String initialHost = initalPreference.get(initHostKey, localhost.hostName());
 		
 		return new CustomInstrumentInfo(initialName, initialPV, initialHost);
 	}
 	
 	public void setInitial() {		
-		initalPreference.put(INIT_INST_NAME_KEY, currentInstrument().name());
-		initalPreference.put(INIT_INST_PV_KEY, currentInstrument().pvPrefix());
-		initalPreference.put(INIT_INST_HOST_KEY, currentInstrument().hostName());
+		initalPreference.put(initNameKey, currentInstrument().name());
+		initalPreference.put(initPVKey, currentInstrument().pvPrefix());
+		initalPreference.put(initHostKey, currentInstrument().hostName());
 		
         try {
             // forces the application to save the preferences

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
@@ -29,20 +29,10 @@ import uk.ac.stfc.isis.ibex.instrument.internal.PVPrefix;
 public class InstrumentInfo {
 
 	private final String name;
-	private final String pv;
-	private final String hostName;
-	
-	public InstrumentInfo(String name, String pv, String hostName) {
-		this.name = name;
-		this.pv = pv;
-		this.hostName = hostName;
-	}
 	
 	public InstrumentInfo(String name) {
 		this.name = name;
         assert (hasValidHostName());
-        this.pv = PVAddress.startWith("IN").append(name).toString() + PVAddress.COLON;
-        this.hostName = PVPrefix.NDX + name;
 	}
 
 	public String name() {
@@ -50,11 +40,11 @@ public class InstrumentInfo {
 	}
 	
 	public String pvPrefix() {
-		return pv;
+		return PVAddress.startWith("IN").append(name).toString() + PVAddress.COLON;
 	}
 	
     public String hostName() {
-        return hostName;
+        return PVPrefix.NDX + name;
 	}
 
     public static String validInstrumentRegex() {

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
@@ -33,8 +33,13 @@ public class InstrumentInfo {
     private final String hostName;
     
     /**
-     * CONSTRUCTOR NOT CALLED FOR INSTRUMENTS IN INSTLIST AS JSON DESERIALISED
+     * CONSTRUCTORS NOT CALLED FOR INSTRUMENTS IN INSTLIST AS JSON DESERIALISED
      */
+    
+	public InstrumentInfo(String name) {
+		this(name, null, null);
+	}
+    
 	public InstrumentInfo(String name, String pvPrefix, String hostName) {
 		this.name = name;
 		this.hostName = hostName;

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
@@ -29,9 +29,16 @@ import uk.ac.stfc.isis.ibex.instrument.internal.PVPrefix;
 public class InstrumentInfo {
 
 	private final String name;
-	
-	public InstrumentInfo(String name) {
+    private final String pvPrefix;
+    private final String hostName;
+    
+    /**
+     * CONSTRUCTOR NOT CALLED FOR INSTRUMENTS IN INSTLIST AS JSON DESERIALISED
+     */
+	public InstrumentInfo(String name, String pvPrefix, String hostName) {
 		this.name = name;
+		this.hostName = hostName;
+		this.pvPrefix = pvPrefix;
         assert (hasValidHostName());
 	}
 
@@ -40,11 +47,11 @@ public class InstrumentInfo {
 	}
 	
 	public String pvPrefix() {
-		return PVAddress.startWith("IN").append(name).toString() + PVAddress.COLON;
+		return pvPrefix == null ? PVAddress.startWith("IN").append(name).toString() + PVAddress.COLON : pvPrefix;
 	}
 	
     public String hostName() {
-        return PVPrefix.NDX + name;
+    	return hostName == null ? PVPrefix.NDX + name : hostName;
 	}
 
     public static String validInstrumentRegex() {

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
@@ -29,10 +29,20 @@ import uk.ac.stfc.isis.ibex.instrument.internal.PVPrefix;
 public class InstrumentInfo {
 
 	private final String name;
+	private final String pv;
+	private final String hostName;
+	
+	public InstrumentInfo(String name, String pv, String hostName) {
+		this.name = name;
+		this.pv = pv;
+		this.hostName = hostName;
+	}
 	
 	public InstrumentInfo(String name) {
 		this.name = name;
         assert (hasValidHostName());
+        this.pv = PVAddress.startWith("IN").append(name).toString() + PVAddress.COLON;
+        this.hostName = PVPrefix.NDX + name;
 	}
 
 	public String name() {
@@ -40,11 +50,11 @@ public class InstrumentInfo {
 	}
 	
 	public String pvPrefix() {
-		return PVAddress.startWith("IN").append(name).toString() + PVAddress.COLON;
+		return pv;
 	}
 	
     public String hostName() {
-        return PVPrefix.NDX + name;
+        return hostName;
 	}
 
     public static String validInstrumentRegex() {

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
@@ -33,13 +33,22 @@ public class InstrumentInfo {
     private final String hostName;
     
     /**
+     * Default constructor for creating a simple instrument based on only a name.
      * CONSTRUCTORS NOT CALLED FOR INSTRUMENTS IN INSTLIST AS JSON DESERIALISED
+     * 
+     * @param name The name of the instrument
      */
-    
 	public InstrumentInfo(String name) {
 		this(name, null, null);
 	}
     
+	/**
+	 * Constructor for creating any general instrument.
+	 * CONSTRUCTORS NOT CALLED FOR INSTRUMENTS IN INSTLIST AS JSON DESERIALISED
+	 * @param name The user friendly name of the instrument
+	 * @param pvPrefix The PV prefix used to connect to the instrument
+	 * @param hostName The host name of the machine that the instrument is running on
+	 */
 	public InstrumentInfo(String name, String pvPrefix, String hostName) {
 		this.name = name;
 		this.hostName = hostName;
@@ -47,22 +56,38 @@ public class InstrumentInfo {
         assert (hasValidHostName());
 	}
 
+	/**
+	 * @return The user friendly name of the instrument.
+	 */
 	public String name() {
 		return name;
 	}
 	
+	/**
+	 * @return The PV prefix of the instrument. Returns IN:name: if no pvPrefix has been set.
+	 */
 	public String pvPrefix() {
 		return pvPrefix == null ? PVAddress.startWith("IN").append(name).toString() + PVAddress.COLON : pvPrefix;
 	}
 	
+	/**
+	 * @return The hostname of the machine that the instrument is running on. Returns NDX + name if no host name has been set.
+	 */
     public String hostName() {
     	return hostName == null ? PVPrefix.NDX + name : hostName;
 	}
 
+    /**
+     * @return Regex describing a valid default instrument hostname.
+     */
     public static String validInstrumentRegex() {
         return PVPrefix.NDX + "[_a-zA-Z0-9]+";
     }
 
+    /**
+     * A helper method to check the instrument host name against its valid regex.
+     * @return True if the host name is valid.
+     */
     public boolean hasValidHostName() {
         return hostName().matches(validInstrumentRegex());
     }

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/custom/CustomInstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/custom/CustomInstrumentInfo.java
@@ -26,14 +26,17 @@ import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 import uk.ac.stfc.isis.ibex.instrument.internal.PVPrefix;
 
 /**
- * Some basic info that defines a custom instrument. Instrument hostname is the
- * same as the instrument name. User must specify a pvPrefix.
+ * Some basic info that defines a custom instrument. User must specify a pvPrefix and hostname.
  */
 public class CustomInstrumentInfo extends InstrumentInfo {
 
     private String pvPrefix;
 
     public CustomInstrumentInfo(String name, String pvPrefix) {
+    	this(name, pvPrefix, name);
+    }
+    
+    public CustomInstrumentInfo(String name, String pvPrefix, String hostName) {
         super(name);
 
         checkPreconditions(pvPrefix);

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/custom/CustomInstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/custom/CustomInstrumentInfo.java
@@ -26,14 +26,26 @@ import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 import uk.ac.stfc.isis.ibex.instrument.internal.PVPrefix;
 
 /**
- * Some basic info that defines a custom instrument. User must specify a pvPrefix and hostname.
+ * Some basic info that defines a custom instrument. User can specify a pvPrefix and hostname. <br>
+ * If no hostname is specified it is assumed to be the same as the instrument name.
  */
 public class CustomInstrumentInfo extends InstrumentInfo {
 
+	/**
+	 * Constructor that sets the hostname as the same as the instrument name.
+	 * @param name The instrument name
+	 * @param pvPrefix The PV prefix for the instrument
+	 */
     public CustomInstrumentInfo(String name, String pvPrefix) {
     	this(name, pvPrefix, name);
     }
     
+	/**
+	 * Constructor that sets a different name, pv prefix and hostname for an instrument.
+	 * @param name The instrument name
+	 * @param pvPrefix The PV prefix for the instrument
+	 * @param hostName The hostname of the instrument PC
+	 */
     public CustomInstrumentInfo(String name, String pvPrefix, String hostName) {
         super(name, pvPrefix, hostName);
         

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/custom/CustomInstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/custom/CustomInstrumentInfo.java
@@ -30,27 +30,14 @@ import uk.ac.stfc.isis.ibex.instrument.internal.PVPrefix;
  */
 public class CustomInstrumentInfo extends InstrumentInfo {
 
-    private String pvPrefix;
-
     public CustomInstrumentInfo(String name, String pvPrefix) {
     	this(name, pvPrefix, name);
     }
     
     public CustomInstrumentInfo(String name, String pvPrefix, String hostName) {
-        super(name);
-
+        super(name, pvPrefix, hostName);
+        
         checkPreconditions(pvPrefix);
-        this.pvPrefix = pvPrefix;
-    }
-
-    @Override
-    public String pvPrefix() {
-        return pvPrefix;
-    }
-
-    @Override
-    public String hostName() {
-        return name();
     }
 
     public static String validCustomInstrumentRegex() {

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/internal/LocalHostInstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/internal/LocalHostInstrumentInfo.java
@@ -24,18 +24,12 @@ import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 public class LocalHostInstrumentInfo extends InstrumentInfo {
 
 	public LocalHostInstrumentInfo() {
-		super(MachineName.get());
+		super(MachineName.get(), constructPvPrefix(), "localhost");
 	}
 
-	@Override
-	public String pvPrefix() {
+	private static String constructPvPrefix() {
 	    PVPrefix pvPrefix = new PVPrefix(MachineName.get(), UserName.get());
         return pvPrefix.get();
-	}
-	
-	@Override
-	public String hostName() {
-		return "localhost";
 	}
 
     public static String validLocalInstrumentRegex() {

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterSettings.java
@@ -70,7 +70,7 @@ public class LogPlotterSettings implements InstrumentInfoReceiver {
         } else if (containsRegex(preference, CustomInstrumentInfo.validCustomInstrumentRegex())) {
             preference = preference.replaceAll(CustomInstrumentInfo.validCustomInstrumentRegex(), hostName);
         } else {
-            throw new RuntimeException("Invalid preference string, does not contain a matching host pattern:" + preference);
+            //throw new RuntimeException("Invalid preference string, does not contain a matching host pattern:" + preference);
         }
 
         return preference;

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterSettings.java
@@ -70,7 +70,7 @@ public class LogPlotterSettings implements InstrumentInfoReceiver {
         } else if (containsRegex(preference, CustomInstrumentInfo.validCustomInstrumentRegex())) {
             preference = preference.replaceAll(CustomInstrumentInfo.validCustomInstrumentRegex(), hostName);
         } else {
-            //throw new RuntimeException("Invalid preference string, does not contain a matching host pattern:" + preference);
+            throw new RuntimeException("Invalid preference string, does not contain a matching host pattern:" + preference);
         }
 
         return preference;


### PR DESCRIPTION
### Description of work

More information is now saved and loaded when the GUI is closed. Rather than just instrument name, the host name and pv prefix are also now saved/restored. Fixes https://github.com/ISISComputingGroup/IBEX/issues/1110. 

### To test

* Test that the GUI is able to display the remembered instrument when the instrument list is down (just change the hardcoded INSTLIST PV)
* Test that custom instruments are remembered on GUI restart

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
