### PR TITLE
Point run information at correct PVs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeObservables.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeObservables.java
@@ -97,7 +97,7 @@ public class DaeObservables {
         title = obsFactory.getSwitchableObservable(new CharWaveformChannel(), addPrefix(DAE.endWith("TITLE")));
         displayTitle =
                 obsFactory.getSwitchableObservable(new BooleanChannel(), addPrefix(DAE.endWith("TITLE:DISPLAY")));
-        users = obsFactory.getSwitchableObservable(new CharWaveformChannel(), addPrefix(DAE.endWith("USERNAME")));
+        users = obsFactory.getSwitchableObservable(new CharWaveformChannel(), addPrefix(DAE.endWith("_USERNAME")));
         goodFrames = obsFactory.getSwitchableObservable(new IntegerChannel(), addPrefix(DAE.endWith("GOODFRAMES")));
         rawFrames = obsFactory.getSwitchableObservable(new IntegerChannel(), addPrefix(DAE.endWith("RAWFRAMES")));
         monitorCounts = obsFactory.getSwitchableObservable(new IntegerChannel(),
@@ -134,7 +134,7 @@ public class DaeObservables {
                 addPrefix(DAE.endWith("DAEMEMORYUSED")));
         timingSource = obsFactory.getSwitchableObservable(new StringChannel(),
                 addPrefix(DAE.endWith("DAETIMINGSOURCE")));
-        rbNumber = obsFactory.getSwitchableObservable(new StringChannel(), addPrefix(DAE.endWith("RBNUMBER")));
+        rbNumber = obsFactory.getSwitchableObservable(new StringChannel(), addPrefix(DAE.endWith("_RBNUMBER")));
         countRate = obsFactory.getSwitchableObservable(new DoubleChannel(), addPrefix(DAE.endWith("COUNTRATE")));
         eventMode = obsFactory.getSwitchableObservable(new DoubleChannel(),
                 addPrefix(DAE.endWith("EVENTMODEFRACTION")));


### PR DESCRIPTION
### Description of work

RBNUMBER and USERNAME in run information previously pointed at the incorrect PVs
### To test

https://github.com/ISISComputingGroup/IBEX/issues/1653
### Acceptance criteria

RB number and user name appear in DAE run information as expected and are updated when:
- DAE info is updated
- Instrument is switched
---
#### Code Review
- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
### Functional Tests
- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
