### PR TITLE
Ticket1603: Don't switch to IOC log on update

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/WaitFor.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/WaitFor.java
@@ -102,9 +102,7 @@ public class WaitFor {
 	private Runnable handleWait(final Waiting waiter) {
 		return new Runnable() {
 			@Override
-			public void run() {
-				UI.getDefault().switchPerspective(PerspectiveSwitcher.LOG_PERSPECTIVE_ID);
-			
+            public void run() {
 				boolean isWaiting = waiter.isWaiting();
 				if (isWaiting) {
 					doWait();


### PR DESCRIPTION
### Description of work

Don't switch to the IOC log view on updates. It disrupts the user workflow

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1603

### Acceptance criteria

Perspective does not switch to IOC log when configuration changed

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [x] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Did any existing system test break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

… the user workflow