### PR TITLE
Reset task lock denied flag on requeue of task.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.tests/src/uk/ac/stfc/isis/ibex/ui/tests/ASyncEventLimiterTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.tests/src/uk/ac/stfc/isis/ibex/ui/tests/ASyncEventLimiterTest.java
@@ -111,4 +111,17 @@ public class ASyncEventLimiterTest {
 
     }
 
+    @Test
+    public void GIVEN_asycn_event_has_not_been_processed_and_reQueued_WHEN_new_task_THEN_task_is_not_rerun() {
+
+        underTest.requestTaskLock(); // first task starts
+        underTest.requestTaskLock(); // second task fails to start
+        underTest.releaseTaskLock(); // task finish and task should be requeued
+        underTest.requestTaskLock(); // last task
+        underTest.releaseTaskLock(); // task is requeued without interuption and
+                                     // so task is not requeued
+
+        verify(rerunTask, times(1)).reQueueTask();
+    }
+
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.tests/src/uk/ac/stfc/isis/ibex/ui/tests/ASyncEventLimiterTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.tests/src/uk/ac/stfc/isis/ibex/ui/tests/ASyncEventLimiterTest.java
@@ -47,7 +47,7 @@ public class ASyncEventLimiterTest {
     }
 
     @Test
-    public void GIVEN_no_asycn_event_WHEN_run_new_event_THEN_event_allowed() {
+    public void GIVEN_no_async_event_WHEN_run_new_event_THEN_event_allowed() {
 
         boolean result = underTest.requestTaskLock();
 
@@ -56,7 +56,7 @@ public class ASyncEventLimiterTest {
     }
 
     @Test
-    public void GIVEN_asycn_event_already_running_WHEN_run_new_event_THEN_event_disallowed() {
+    public void GIVEN_async_event_already_running_WHEN_run_new_event_THEN_event_disallowed() {
 
         underTest.requestTaskLock();
 
@@ -67,7 +67,7 @@ public class ASyncEventLimiterTest {
     }
 
     @Test
-    public void GIVEN_asycn_event_processed_WHEN_run_new_event_THEN_event_allowed() {
+    public void GIVEN_async_event_processed_WHEN_run_new_event_THEN_event_allowed() {
 
         underTest.requestTaskLock();
         underTest.releaseTaskLock();
@@ -78,7 +78,7 @@ public class ASyncEventLimiterTest {
     }
 
     @Test
-    public void GIVEN_asycn_event_has_not_been_processed_WHEN_initial_task_finish_THEN_task_refired() {
+    public void GIVEN_async_event_has_not_been_processed_WHEN_initial_task_finish_THEN_task_refired() {
 
         underTest.requestTaskLock(); // first task starts
         underTest.requestTaskLock(); // second task fails to start
@@ -89,7 +89,7 @@ public class ASyncEventLimiterTest {
     }
 
     @Test
-    public void GIVEN_asycn_event_has_been_processed_WHEN_initial_task_finish_THEN_task_not_refired() {
+    public void GIVEN_async_event_has_been_processed_WHEN_initial_task_finish_THEN_task_not_refired() {
 
         underTest.requestTaskLock(); // first task starts
         underTest.releaseTaskLock(); // first task finish
@@ -112,7 +112,7 @@ public class ASyncEventLimiterTest {
     }
 
     @Test
-    public void GIVEN_asycn_event_has_not_been_processed_and_reQueued_WHEN_new_task_THEN_task_is_not_rerun() {
+    public void GIVEN_async_event_has_not_been_processed_and_reQueued_WHEN_new_task_THEN_task_is_not_rerun() {
 
         underTest.requestTaskLock(); // first task starts
         underTest.requestTaskLock(); // second task fails to start

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/AsyncMessageModerator.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/AsyncMessageModerator.java
@@ -73,12 +73,12 @@ public class AsyncMessageModerator {
 
     /**
      * Once a task has finished this should be called to release the task lock.
-     * 
+     * It will also reset the task lock was denied because the job will run.
      * 
      */
     public void releaseTaskLock() {
         processing.set(false);
-        if (this.taskRerunner != null && taskLockDenied.get()) {
+        if (this.taskRerunner != null && taskLockDenied.getAndSet(false)) {
             this.taskRerunner.reQueueTask();
         }
     }


### PR DESCRIPTION
### Description of work

https://github.com/ISISComputingGroup/IBEX/issues/1850

### Acceptance criteria

Hit it with lot of messages ensure that when messages stop CPU load returns to normal. (connect to MUONFE is good test for this and compare to original client)

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

