### PR TITLE
Add option to clear target details when we change type

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/BaseComponentTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/BaseComponentTest.java
@@ -116,7 +116,7 @@ public class BaseComponentTest {
 		// Arrange
 		ComponentDescription compDesc = new ComponentDescription();
 		ComponentType compType = ComponentType.ANALYSER;
-		compDesc.setType(compType);
+        compDesc.setType(compType, false);
 		BaseComponent baseComp = new BaseComponent(compDesc) {
 			@Override
 			public Target target() {

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/model/desc/ComponentDescriptionTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/model/desc/ComponentDescriptionTest.java
@@ -19,11 +19,7 @@
 
 package uk.ac.stfc.isis.ibex.synoptic.tests.model.desc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -61,7 +57,7 @@ public class ComponentDescriptionTest {
         source = new ComponentDescription();
         source.setParent(new ComponentDescription());
         source.setName(COMPONENT_NAME);
-        source.setType(ComponentType.UNKNOWN);
+        source.setType(ComponentType.UNKNOWN, false);
         TargetDescription targetDescription = new TargetDescription();
         targetDescription.setName(NEW_NAME);
         source.setTarget(targetDescription);
@@ -124,7 +120,7 @@ public class ComponentDescriptionTest {
     public void copied_object_has_type_that_is_not_liked_to_source_object() {
         // Act
         ComponentDescription copied = new ComponentDescription(source);
-        copied.setType(ComponentType.GONIOMETER);
+        copied.setType(ComponentType.GONIOMETER, false);
 
         // Assert
         assertNotSame(source.type(), copied.type());

--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/ComponentDescription.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/ComponentDescription.java
@@ -145,9 +145,13 @@ public class ComponentDescription implements SynopticParentDescription {
      * Set the component type.
      * 
      * @param type the new type
+     * @param whether to clear the target whilst changing type
      */
-    public void setType(ComponentType type) {
+    public void setType(ComponentType type, boolean clearTarget) {
         this.type = type;
+        if (clearTarget) {
+            target = null;
+        }
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/component/ComponentDetailView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/component/ComponentDetailView.java
@@ -281,7 +281,7 @@ public class ComponentDetailView extends Composite {
 			int typeIndex = cmboType.getCombo().getSelectionIndex();
             String selection = typeList.get(typeIndex);
             ComponentType type = ComponentType.valueOf(selection);
-			component.setType(type);
+            component.setType(type, true);
 
             if (isFinalUpdate) {
                 synopticViewModel.broadcastInstrumentUpdate(UpdateTypes.EDIT_COMPONENT_FINAL);

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/model/SynopticViewModel.java
@@ -127,7 +127,7 @@ public class SynopticViewModel {
 
         DefaultName namer = new DefaultName("New Component", " ", true);
         component.setName(namer.getUnique(synoptic.getComponentNameListWithChildren()));
-		component.setType(ComponentType.UNKNOWN);
+        component.setType(ComponentType.UNKNOWN, false);
 
 		int position = 0;
 		if (selectedComponents == null) {


### PR DESCRIPTION
### Description of work

I've set the target details of the current component to clear when creating/editing a new synoptic and the type of the component is changed. This means that the target details will always switch to the default when the component type is changed. Under the previous behaviour, it only occurred on the first change.

I've added a manual system test for the synoptics

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1602

### Acceptance criteria

When the component type of a synoptic is changed, the target details switch to default

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

