### PR TITLE
instantiate PVPrefixFactory when needed to avoid NPE

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
@@ -30,15 +30,17 @@ public class InstrumentInfo {
 	private final String name;
     private String pvPrefix;
     private final String hostName;
-    private PVPrefixFactory pvPrefixFactory = new PVPrefixFactory();
 
 	/**
-	 * Constructor for creating any general instrument.
-	 * CONSTRUCTORS NOT CALLED FOR INSTRUMENTS IN INSTLIST AS JSON DESERIALISED
-	 * @param name The user friendly name of the instrument
-	 * @param pvPrefix The PV prefix used to connect to the instrument
-	 * @param hostName The host name of the machine that the instrument is running on
-	 */
+     * Constructor for creating any general instrument. CONSTRUCTORS NOT CALLED
+     * FOR INSTRUMENTS IN INSTLIST AS JSON DESERIALISED. THIS INCLUDES INLINE
+     * CONSTRUCTOR.
+     * 
+     * @param name The user friendly name of the instrument
+     * @param pvPrefix The PV prefix used to connect to the instrument
+     * @param hostName The host name of the machine that the instrument is
+     *            running on
+     */
 	public InstrumentInfo(String name, String pvPrefix, String hostName) {
 		this.name = name;
 		this.hostName = hostName;
@@ -58,6 +60,7 @@ public class InstrumentInfo {
 	 */
 	public String pvPrefix() {
         if (pvPrefix == null) {
+            PVPrefixFactory pvPrefixFactory = new PVPrefixFactory();
             pvPrefix = pvPrefixFactory.fromInstrumentName(name);
         }
 

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentInfo.java
@@ -60,8 +60,7 @@ public class InstrumentInfo {
 	 */
 	public String pvPrefix() {
         if (pvPrefix == null) {
-            PVPrefixFactory pvPrefixFactory = new PVPrefixFactory();
-            pvPrefix = pvPrefixFactory.fromInstrumentName(name);
+            pvPrefix = new PVPrefixFactory().fromInstrumentName(name);
         }
 
         return pvPrefix;


### PR DESCRIPTION
### Description of work

https://github.com/ISISComputingGroup/IBEX/issues/1855

### To test

Set PV INST LIST to SIMPLE IOC set the instrument list to only have names (no pvprefix).

### Acceptance criteria

Can switch instruments.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
No it is failing because the constructor is not being fired through deserialisation magic which I don't know how to replicate.
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
Not needed
- [x] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

