### PR TITLE
added check that devices do not have blank targets + test

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/DeviceScreensDescriptionViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/DeviceScreensDescriptionViewModelTest.java
@@ -57,6 +57,7 @@ public class DeviceScreensDescriptionViewModelTest {
     private String propertyValue2 = "Value2";
     private String propertyDescription2 = "This is value 2";
     private List<MacroInfo> macros;
+    MessageDisplayer displayer;
 
     @Before
     public void setUp() {
@@ -81,7 +82,7 @@ public class DeviceScreensDescriptionViewModelTest {
         propertyNames.add(propertyName2);
 
         // Set up the mocks
-        MessageDisplayer displayer = mock(MessageDisplayer.class);
+        displayer = mock(MessageDisplayer.class);
         
         OpiDescription opiDesc1 = mock(OpiDescription.class);
         when(opiDesc1.getMacros()).thenReturn(macros);
@@ -241,5 +242,19 @@ public class DeviceScreensDescriptionViewModelTest {
         assertEquals("", viewModel.getScreens().get(2).getDescription());
     }
 
+    @Test
+    public void WHEN_setting_blank_target_THEN_error_triggered() {
+        // Arrange
+        String expectedSource = "ViewModel";
+        String expectedMsg = "Device 'Device1' is not pointing at a valid target. Please select a target OPI.";
+
+        // Act
+        viewModel.setSelectedScreen(0);
+        viewModel.setCurrentKey("");
+
+        // Assert
+        verify(displayer, times(0)).setErrorMessage(expectedSource, "");
+        verify(displayer).setErrorMessage(expectedSource, expectedMsg);
+    }
 }
 //CHECKSTYLE:ON

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/models/DeviceScreensDescriptionViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/models/DeviceScreensDescriptionViewModel.java
@@ -199,6 +199,12 @@ public class DeviceScreensDescriptionViewModel extends ModelObject {
                 messageDisplayer.setErrorMessage("ViewModel", errorMessageNames);
                 return;
             }
+            if (d.getKey().length() == 0) {
+                String errorMessageTarget =
+                        "Device '" + d.getName() + "' is not pointing at a valid target. Please select a target OPI.";
+                messageDisplayer.setErrorMessage("ViewModel", errorMessageTarget);
+                return;
+            }
         }
 
         // No errors
@@ -270,6 +276,7 @@ public class DeviceScreensDescriptionViewModel extends ModelObject {
         firePropertyChange("currentKey", previousKey, previousKey = newKey);
         // Must update to the corresponding description
         updateCurrentDescription();
+        checkScreensValid();
     }
 
     /**


### PR DESCRIPTION
### Description of work

Added a check in the Edit Device Screens Dialogue to see if any of the device screens are pointed at a blank target, in which case a helpful error message is displayed and the "OK" button disabled. 
This prevents the user from creating device screens with non-existent OPI that throws an error when attempted to view.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1810

### Acceptance criteria

* User can not save device screens with a blank target
* Functionality to create/edit/delete valid device screens is preserved

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

