### PR TITLE
Getting time & date from java.util.date rather than LocalDate/LocalTime

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/PythonBuilderTest.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/PythonBuilderTest.java
@@ -21,8 +21,6 @@ package uk.ac.stfc.isis.ibex.scriptgenerator.tests;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -47,8 +45,8 @@ import uk.ac.stfc.isis.ibex.scriptgenerator.settings.SansSettings;
  */
 public class PythonBuilderTest {
     private PythonBuilder builder;
-    private LocalDate date;
-    private LocalTime time;
+    private String date;
+    private String time;
     private SansSettings settings;
     private Collection<Row> rows;
     private final String INDENT = "    ";
@@ -119,8 +117,8 @@ public class PythonBuilderTest {
         builder = new PythonBuilder(new Script(), dateTime);
         builder.setSettings(settings);
 
-        date = LocalDate.now();
-        time = LocalTime.now();
+        date = "2016-01-01";
+        time = "12:13:14";
         when(dateTime.getDate()).thenReturn(date);
         when(dateTime.getTime()).thenReturn(time);
     }

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/DateTimeProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/DateTimeProvider.java
@@ -33,7 +33,7 @@ public class DateTimeProvider {
     DateFormat timeFormat = new SimpleDateFormat("HH:mm:ss");
 
     /**
-     * Returns the current local date.
+     * Returns the current date.
      * 
      * @return The date.
      */
@@ -43,7 +43,7 @@ public class DateTimeProvider {
     }
 
     /**
-     * Returns the current local time.
+     * Returns the current time.
      * 
      * @return The time.
      */

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/DateTimeProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/DateTimeProvider.java
@@ -21,21 +21,25 @@
  */
 package uk.ac.stfc.isis.ibex.scriptgenerator;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * Provides methods to get the current date and time.
  */
 public class DateTimeProvider {
+    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    DateFormat timeFormat = new SimpleDateFormat("HH:mm:ss");
 
     /**
      * Returns the current local date.
      * 
      * @return The date.
      */
-    public LocalDate getDate() {
-        return LocalDate.now();
+    public String getDate() {
+
+        return dateFormat.format(new Date());
     }
 
     /**
@@ -43,7 +47,7 @@ public class DateTimeProvider {
      * 
      * @return The time.
      */
-    public LocalTime getTime() {
-        return LocalTime.now();
+    public String getTime() {
+        return timeFormat.format(new Date());
     }
 }


### PR DESCRIPTION
### Description of work

Replaced LocalDate & LocalTime in the script generator package with java.util.date to make it Java 1.7 compatible until we have decided it is time to move onto 1.8.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1920

### Acceptance criteria

* Package is Java 1.7 compatible
* Script generator not broken

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
