### PR TITLE
Ticket1925: Unable to save synoptic

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/SynopticHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/SynopticHandler.java
@@ -73,8 +73,10 @@ public abstract class SynopticHandler<T> extends AbstractHandler {
 		if (editDialog.open() == Window.OK) {
 			SYNOPTIC.edit().saveSynoptic().write(editDialog.getSynoptic());
 			
-			// Refresh the synoptic
-			if (editDialog.getSynoptic().name().equals(SYNOPTIC.getSynopticInfo().name())) {
+            // Refresh the synoptic. Synoptic info may be null if the synoptic
+            // perspective has never been opened.
+            if (SYNOPTIC.getSynopticInfo() != null
+                    && editDialog.getSynoptic().name().equals(SYNOPTIC.getSynopticInfo().name())) {
 				SYNOPTIC.setViewerSynoptic(editDialog.getSynoptic().name());
 			}
 		}

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/SynopticHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/SynopticHandler.java
@@ -66,6 +66,18 @@ public abstract class SynopticHandler<T> extends AbstractHandler {
 		destination.subscribe(synopticService);
 	}		
 	
+    /**
+     * Handle the sequence of opening a synoptic editor dialog and the
+     * subsequent cancel/save.
+     * 
+     * @param synoptic
+     *            The synoptic to edit
+     * @param title
+     *            The title of the synoptic editor dialog
+     * @param isBlank
+     *            Whether the requested synoptic has existing components or it
+     *            is blank
+     */
 	protected void openDialog(SynopticDescription synoptic, String title, boolean isBlank) {
         Collection<String> opis = Opi.getDefault().descriptionsProvider().getOpiList();
         EditSynopticDialog editDialog = new EditSynopticDialog(shell(), title, synoptic, isBlank, opis,
@@ -75,6 +87,9 @@ public abstract class SynopticHandler<T> extends AbstractHandler {
 		}
 	}
 	
+    /**
+     * @return The shell for the current workbench
+     */
 	protected Shell shell() {
 		return PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
 	}	

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/SynopticHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/SynopticHandler.java
@@ -72,13 +72,6 @@ public abstract class SynopticHandler<T> extends AbstractHandler {
                 new SynopticViewModel());
 		if (editDialog.open() == Window.OK) {
 			SYNOPTIC.edit().saveSynoptic().write(editDialog.getSynoptic());
-			
-            // Refresh the synoptic. Synoptic info may be null if the synoptic
-            // perspective has never been opened.
-            if (SYNOPTIC.getSynopticInfo() != null
-                    && editDialog.getSynoptic().name().equals(SYNOPTIC.getSynopticInfo().name())) {
-				SYNOPTIC.setViewerSynoptic(editDialog.getSynoptic().name());
-			}
 		}
 	}
 	


### PR DESCRIPTION
…d before the synoptic perspective is opened

### Description of work

To reproduce the problem:

- Open Ibex client
- Edit a synoptic
- Click save

You should see the null pointer exception (on master). This is because `SynopticHandler.java` tries to get the name of the current displayed synoptic. If the synoptic perspective has never been opened, the current synoptic will be `null`. I've added an extra check for that condition.

The only other instance of this method is `refreshSynoptic` in `SynopticSelectionViewModel`. In that case we don't need to check for null because the synoptic perspective will have definitely been opened.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1925

### Acceptance criteria

- No null pointer exception when a synoptic is edited and saved before the synoptic perspective is opened.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
