### PR TITLE
Ticket1878: Error on no target

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/DevicesOpiTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/DevicesOpiTargetView.java
@@ -22,6 +22,9 @@
  */
 package uk.ac.stfc.isis.ibex.ui.devicescreens;
 
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.ui.PlatformUI;
+
 import uk.ac.stfc.isis.ibex.opis.OPIViewCreationException;
 import uk.ac.stfc.isis.ibex.targets.OpiTarget;
 import uk.ac.stfc.isis.ibex.ui.targets.OpiTargetView;
@@ -43,7 +46,13 @@ public class DevicesOpiTargetView extends OpiTargetView {
      * @throws OPIViewCreationException when opi can not be created
      */
     public static void displayOpi(OpiTarget opiTarget) throws OPIViewCreationException {
-        OpiTargetView.displayOpi(opiTarget, ID);
+        if (opiTarget.opiName().length() > 0) {
+            OpiTargetView.displayOpi(opiTarget, ID);
+        } else {
+            MessageDialog.openError(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Error",
+                    "Unable to open OPI " + opiTarget.name()
+                            + ", target is blank. Edit the device screens and select a target, then try again.");
+        }
     }
 
 }


### PR DESCRIPTION
### Description of work

The device screens UI will now popup an error dialog if the user tries to open a device screen with no target assigned. Note that this is a protective measure as ticket #1810 will prevent users from saving a device screen without a target.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1878

### Acceptance criteria

- [x] Appropriate error is displayed if no target assigned
- [x] No popup if target assigned

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [x] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Did any existing system test break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
