### PR TITLE
Make device screens avialable by default

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/Perspective.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/Perspective.java
@@ -64,6 +64,6 @@ public class Perspective extends BasePerspective {
 
     @Override
     public boolean isVisibleDefault() {
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
### Description of work

Make the device screens available by default

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1930

### Acceptance criteria

The device screen should be available by default.

If you have previously manually added the device screens, you will need to go into the settings menu (CTRL + ALT + P), then go into "ISIS perspectives" and restore defaults. When you restart the GUI, check that device screens are enabled.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
