### PR TITLE
Ticket 1932: Disable synoptic menu

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/plugin.xml
@@ -16,7 +16,7 @@
       <command
             defaultHandler="uk.ac.stfc.isis.ibex.ui.synoptic.editor.commands.DeleteSynopticHandler"
             id="uk.ac.stfc.isis.ibex.ui.synoptic.editor.commands.DeleteSynoptic"
-            name="Edit Synoptic">
+            name="Delete Synoptic">
       </command>
    </extension>
    <extension
@@ -53,10 +53,11 @@
                  tooltip="Delete a synoptic">
            </command>
          </menu>
+         <!-- Required to force the menu items to check for enabled on startup -->
+        <dynamic
+              class="uk.ac.stfc.isis.ibex.ui.synoptic.editor.commands.NOP"
+              id="uk.ac.stfc.isis.ibex.ui.synoptic.editor.dynamic">
+        </dynamic>
       </menuContribution>
-   </extension>
-	<extension
-         point="org.eclipse.ui.startup">
-      <startup>uk.ac.stfc.isis.ibex.synoptic.Activator</startup>
    </extension>
 </plugin>

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/NOP.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/NOP.java
@@ -38,14 +38,11 @@ import org.eclipse.jface.action.ContributionItem;
  */
 public class NOP extends ContributionItem {
 
+
     /**
      * The default constructor for the menu item.
-     * 
-     * @param id
-     *            The id of the menu item.
      */
-    public NOP(String id) {
-		super(id);
+    public NOP() {
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/NOP.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/NOP.java
@@ -1,0 +1,59 @@
+
+/*
+* This file is part of the ISIS IBEX application.
+* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* All rights reserved.
+*
+* This program is distributed in the hope that it will be useful.
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v1.0 which accompanies this distribution.
+* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+*
+* You should have received a copy of the Eclipse Public License v1.0
+* along with this program; if not, you can obtain a copy from
+* https://www.eclipse.org/org/documents/epl-v10.php or 
+* http://opensource.org/licenses/eclipse-1.0.php
+*/
+
+/*
+ * Copyright (C) 2013-2014 Research Councils UK (STFC)
+ *
+ * This file is part of the Instrument Control Project at ISIS.
+ *
+ * This code and information are provided "as is" without warranty of any 
+ * kind, either expressed or implied, including but not limited to the
+ * implied warranties of merchantability and/or fitness for a particular 
+ * purpose.
+ */
+package uk.ac.stfc.isis.ibex.ui.synoptic.editor.commands;
+
+import org.eclipse.jface.action.ContributionItem;
+
+/**
+ * A dynamic menu item that does nothing, this forces the synoptic menu items to
+ * be instantiated when first selected. This means that the check for the
+ * command to be enabled can be done.
+ */
+public class NOP extends ContributionItem {
+
+    /**
+     * The default constructor for the menu item.
+     * 
+     * @param id
+     *            The id of the menu item.
+     */
+    public NOP(String id) {
+		super(id);
+	}
+	
+	/**
+     * Say the list is dynamic so as to force menu items to be refreshed each
+     * time.
+     */
+	@Override
+	public boolean isDynamic() {
+		return true;
+	}
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/NOP.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/NOP.java
@@ -48,6 +48,8 @@ public class NOP extends ContributionItem {
 	/**
      * Say the list is dynamic so as to force menu items to be refreshed each
      * time.
+     * 
+     * @return Whether the menu item is dynamic.
      */
 	@Override
 	public boolean isDynamic() {


### PR DESCRIPTION
### Description of work

A bit of a fudge to force the menu to check for enabled at startup of GUI.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1932

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [x] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [x] Did any existing system test break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [x] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
