### PR TITLE
Ticket 1229: Target platform updated to point at 3.3.11

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
+++ b/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="uk.ac.stfc.isis.ibex.targetplatform" sequenceNumber="135">
+<?pde version="3.8"?><target name="uk.ac.stfc.isis.ibex.targetplatform" sequenceNumber="147">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.python.pydev.feature.feature.group" version="4.5.1.201601132212"/>
@@ -24,12 +24,13 @@
 <repository location="http://shadow.nd.rl.ac.uk/ICP_P2/Mockito_P2/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.csstudio.alarm.beast.ui.feature.feature.group" version="3.2.1.20170210-1551"/>
-<unit id="org.csstudio.pvmanager.ca.feature.feature.group" version="3.2.2.20170210-1551"/>
-<unit id="org.csstudio.opibuilder.feature.feature.group" version="3.2.7.20170210-1551"/>
-<unit id="org.csstudio.pvmanager.feature.feature.group" version="3.3.0.20170210-1618"/>
-<unit id="org.csstudio.boy.feature.feature.group" version="3.2.1.20170210-1551"/>
-<unit id="org.csstudio.trends.databrowser2.feature.feature.group" version="3.2.2.20170210-1551"/>
+<unit id="org.csstudio.alarm.beast.ui.feature.feature.group" version="3.2.1.20170213-1049"/>
+<unit id="org.csstudio.boy.feature.feature.group" version="3.2.1.20170213-1049"/>
+<unit id="org.csstudio.trends.databrowser2.feature.feature.group" version="3.2.2.20170213-1049"/>
+<unit id="org.csstudio.opibuilder.feature.feature.group" version="3.2.7.20170213-1049"/>
+<unit id="org.csstudio.pvmanager.ca.feature.feature.group" version="3.2.2.20170213-1049"/>
+<unit id="org.csstudio.core.util.feature.feature.group" version="3.1.0.20170213-1049"/>
+<unit id="org.csstudio.pvmanager.feature.feature.group" version="3.3.0.20170213-1039"/>
 <repository location="http://shadow.nd.rl.ac.uk/ICP_P2/CSStudio_P2_3_3_10"/>
 </location>
 </locations>

--- a/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
+++ b/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
@@ -1,23 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="uk.ac.stfc.isis.ibex.targetplatform" sequenceNumber="122">
+<?pde version="3.8"?><target name="uk.ac.stfc.isis.ibex.targetplatform" sequenceNumber="135">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.mockito.feature.feature.group" version="1.0.0.20150724-1352"/>
-<repository location="http://shadow.nd.rl.ac.uk/ICP_P2/Mockito_P2/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.csstudio.pvmanager.feature.feature.group" version="3.3.0.20140923-1503"/>
-<unit id="org.csstudio.pvmanager.ca.feature.feature.group" version="3.2.2.20140923-1511"/>
-<unit id="org.csstudio.core.util.feature.feature.group" version="3.1.0.20140923-1511"/>
-<unit id="org.csstudio.opibuilder.feature.feature.group" version="3.2.7.20140923-1511"/>
-<unit id="org.csstudio.trends.databrowser2.feature.feature.group" version="3.2.2.20140923-1511"/>
-<unit id="org.csstudio.boy.feature.feature.group" version="3.2.1.20140923-1511"/>
-<unit id="org.csstudio.alarm.beast.ui.feature.feature.group" version="3.2.1.20140923-1511"/>
-<repository location="http://shadow.nd.rl.ac.uk/ICP_P2/CSStudio_P2/"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.rcp.sdk.id" version="3.8.2.M20130131-0800"/>
-<repository location="http://download.eclipse.org/eclipse/updates/3.8"/>
+<unit id="org.python.pydev.feature.feature.group" version="4.5.1.201601132212"/>
+<repository location="https://dl.bintray.com/fabioz/pydev/4.5.1"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.apache.lucene" version="3.5.0.v20120725-1805"/>
@@ -26,12 +12,25 @@
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140114142710/repository/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.python.pydev.feature.feature.group" version="4.5.1.201601132212"/>
-<repository location="https://dl.bintray.com/fabioz/pydev/4.5.1"/>
+<unit id="org.eclipse.rcp.sdk.id" version="3.8.2.M20130131-0800"/>
+<repository location="http://download.eclipse.org/eclipse/updates/3.8"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.nebula.visualization.feature.feature.group" version="1.0.0.201605312033"/>
 <repository location="http://download.eclipse.org/nebula/releases/1.0.0"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.mockito.feature.feature.group" version="1.0.0.20150724-1352"/>
+<repository location="http://shadow.nd.rl.ac.uk/ICP_P2/Mockito_P2/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.csstudio.alarm.beast.ui.feature.feature.group" version="3.2.1.20170210-1551"/>
+<unit id="org.csstudio.pvmanager.ca.feature.feature.group" version="3.2.2.20170210-1551"/>
+<unit id="org.csstudio.opibuilder.feature.feature.group" version="3.2.7.20170210-1551"/>
+<unit id="org.csstudio.pvmanager.feature.feature.group" version="3.3.0.20170210-1618"/>
+<unit id="org.csstudio.boy.feature.feature.group" version="3.2.1.20170210-1551"/>
+<unit id="org.csstudio.trends.databrowser2.feature.feature.group" version="3.2.2.20170210-1551"/>
+<repository location="http://shadow.nd.rl.ac.uk/ICP_P2/CSStudio_P2_3_3_10"/>
 </location>
 </locations>
 <environment>


### PR DESCRIPTION
### Description of work

https://github.com/ISISComputingGroup/IBEX/issues/1229

The target platform has been updated to point at 3.3.11.

### To test

This fixes #1229 upgrade CS-Studio and #1206 remove exception on startup.

You will need to "set the target platform" to the new one in this PR.

![image](https://cloud.githubusercontent.com/assets/3032495/22890031/f7fdbd9c-f202-11e6-8e70-b2cb171de614.png)

#1206 is simple to test: start the GUI from Eclipse and confirm you don't get the Security Exception mentioned in the ticket.

If none of this works it might be because Eclipse has cached the previous version. Try restarting Eclipse, if that fails delete the ibex_gui repo and clone it again.

### Acceptance criteria

Check everything works as it should in the GUI. Please check that you can connect to your local instrument and a remote one.

Please also close #1206.

---

#### Code Review

- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
