### PR TITLE
Ignore case on sorting device screens

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/src/uk/ac/stfc/isis/ibex/opis/DescriptionsProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.opis/src/uk/ac/stfc/isis/ibex/opis/DescriptionsProvider.java
@@ -101,7 +101,7 @@ public class DescriptionsProvider extends Provider {
 	@Override
 	public Collection<String> getOpiList() {
         List<String> availableOPIs = new ArrayList<String>(descriptions.getOpis().keySet());
-        Collections.sort(availableOPIs);
+        Collections.sort(availableOPIs, String.CASE_INSENSITIVE_ORDER);
         return availableOPIs;
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/list/DeviceScreensComparitor.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/list/DeviceScreensComparitor.java
@@ -79,15 +79,15 @@ public class DeviceScreensComparitor extends ViewerComparator {
         int rc = 0;
         switch (this.sortedOn) {
             case NAME:
-                rc = p1.getName().compareTo(p2.getName());
+                rc = p1.getName().compareToIgnoreCase(p2.getName());
                 if (rc == 0) {
-                    rc = p1.getKey().compareTo(p2.getKey());
+                    rc = p1.getKey().compareToIgnoreCase(p2.getKey());
                 }
                 break;
             case TYPE:
-                rc = p1.getKey().compareTo(p2.getKey());
+                rc = p1.getKey().compareToIgnoreCase(p2.getKey());
                 if (rc == 0) {
-                    rc = p1.getName().compareTo(p2.getName());
+                    rc = p1.getName().compareToIgnoreCase(p2.getName());
                 }
                 break;
             default:


### PR DESCRIPTION
### Description of work

Sort device screens in a case insensitive way so `a` comes before `B`.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/1973

### Acceptance criteria

Device screens are sorted alphabetically invariant of capitalisation

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
