### PR TITLE
Ticket2016: Wrap java path

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/AboutDialogBox.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/AboutDialogBox.java
@@ -38,7 +38,7 @@ public class AboutDialogBox extends TitleAreaDialog {
     /** Dialog width. */
     public static final int WIDTH = 300;
     /** Dialog height. */
-    private static final int HEIGHT = 260;
+    private static final int HEIGHT = 240;
 
     /**
      * Construct a new about Ibex dialog box.

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/AboutDialogBox.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/AboutDialogBox.java
@@ -38,7 +38,7 @@ public class AboutDialogBox extends TitleAreaDialog {
     /** Dialog width. */
     public static final int WIDTH = 300;
     /** Dialog height. */
-    private static final int HEIGHT = 250;
+    private static final int HEIGHT = 260;
 
     /**
      * Construct a new about Ibex dialog box.
@@ -70,7 +70,7 @@ public class AboutDialogBox extends TitleAreaDialog {
 		container.setLayout(new GridLayout(1, false));
 			
 		new VersionPanel(container, SWT.NONE);
-		
+
 		return container;
 	}	
 

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
@@ -24,6 +24,8 @@ import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -45,7 +47,7 @@ public class VersionPanel extends Composite {
     /** The version of Java that the client is using */
     private Label javaVersion;
     /** The path to the Java that the client is using */
-    private Label javaPath;
+    private Label javaPathLabel;
 
     /**
      * Construct a new version panel.
@@ -92,13 +94,24 @@ public class VersionPanel extends Composite {
         lblJavaPath.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
         lblJavaPath.setText("Java Path:");
 
-        javaPath = new Label(this, SWT.WRAP);
+        javaPathLabel = new Label(this, SWT.WRAP);
         GridData javaPathGd = new GridData(SWT.LEFT, SWT.CENTER, true, true, 1, 1);
         javaPathGd.widthHint = 200;
-        // Not bound as fixed
-        javaPath.setText(System.getProperties().getProperty("java.home"));
-        javaPath.setLayoutData(javaPathGd);
+        javaPathLabel.setLayoutData(javaPathGd);
 
+        // Not bound as fixed
+
+        String javaPath = System.getProperties().getProperty("java.home");
+        Point pathSize = new GC(javaPathLabel).stringExtent(javaPath);
+        if (pathSize.x > (javaPathGd.widthHint * 2.0)) {
+            javaPathLabel.setToolTipText(javaPath);
+            // Assuming chars are the same width calculate how many can we fit
+            // on one line
+            int charsToPrint = javaPathGd.widthHint * javaPath.length() / pathSize.x;
+            javaPathLabel.setText(javaPath.substring(0, charsToPrint - 3) + "...");
+        } else {
+            javaPathLabel.setText(javaPath);
+        }
         bind(Help.getInstance());
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
@@ -53,6 +53,7 @@ public class VersionPanel extends Composite {
      * @param parent The parent component
      * @param style The style to apply to the panel
      */
+    @SuppressWarnings("checkstyle:magicnumber")
 	public VersionPanel(Composite parent, int style) {
 		super(parent, style);
 		setLayout(new GridLayout(2, false));
@@ -91,11 +92,11 @@ public class VersionPanel extends Composite {
         lblJavaPath.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
         lblJavaPath.setText("Java Path:");
 
-        javaPath = new Label(this, SWT.NONE);
-        GridData javaPathGd = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
+        javaPath = new Label(this, SWT.WRAP);
+        GridData javaPathGd = new GridData(SWT.LEFT, SWT.CENTER, true, true, 1, 1);
+        javaPathGd.widthHint = 200;
         // Not bound as fixed
         javaPath.setText(System.getProperties().getProperty("java.home"));
-        javaPathGd.widthHint = AboutDialogBox.WIDTH;
         javaPath.setLayoutData(javaPathGd);
 
         bind(Help.getInstance());

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
@@ -94,7 +94,7 @@ public class VersionPanel extends Composite {
         lblJavaPath.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
         lblJavaPath.setText("Java Path:");
 
-        javaPathLabel = new Label(this, SWT.WRAP);
+        javaPathLabel = new Label(this, SWT.NONE);
         GridData javaPathGd = new GridData(SWT.LEFT, SWT.CENTER, true, true, 1, 1);
         javaPathGd.widthHint = 200;
         javaPathLabel.setLayoutData(javaPathGd);
@@ -103,7 +103,7 @@ public class VersionPanel extends Composite {
 
         String javaPath = System.getProperties().getProperty("java.home");
         Point pathSize = new GC(javaPathLabel).stringExtent(javaPath);
-        if (pathSize.x > (javaPathGd.widthHint * 2.0)) {
+        if (pathSize.x > javaPathGd.widthHint) {
             javaPathLabel.setToolTipText(javaPath);
             // Assuming chars are the same width calculate how many can we fit
             // on one line


### PR DESCRIPTION
### Description of work

The java path in the about dialog is now wrapped to be on 2 lines. This will still cut off text >2 lines but as path lengths can vary a lot it is hard to find a solution that looks sensible for all cases.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2016

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
