### PR TITLE
Ticket2165 temporary fix for pvs disappearing

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServerVariables.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServerVariables.java
@@ -219,7 +219,7 @@ public class ConfigServerVariables extends Closer {
      * @return the corresponding observable
      */
 	public ForwardingObservable<String> blockValue(String blockName) {
-        return closingObsFactory.getForwardingObservable(new DefaultChannel(),
+        return closingObsFactory.getSwitchableObservable(new DefaultChannel(),
                 InstrumentUtils.addPrefix(blockServerAlias(blockName)));
 	}
 	
@@ -230,7 +230,7 @@ public class ConfigServerVariables extends Closer {
      * @return the corresponding observable
      */
 	public ForwardingObservable<String> blockDescription(String blockName) {
-        return closingObsFactory.getForwardingObservable(new StringChannel(),
+        return closingObsFactory.getSwitchableObservable(new StringChannel(),
                 InstrumentUtils.addPrefix(blockServerAddresses.blockDescription(blockServerAlias(blockName))));
 	}
 
@@ -241,7 +241,7 @@ public class ConfigServerVariables extends Closer {
      * @return the observable object
      */
     public ForwardingObservable<AlarmState> alarm(String blockName) {
-        return closingObsFactory.getForwardingObservable(new EnumChannel<>(AlarmState.class),
+        return closingObsFactory.getSwitchableObservable(new EnumChannel<>(AlarmState.class),
                 InstrumentUtils.addPrefix(blockServerAddresses.blockAlarm(blockServerAlias(blockName))));
     }
 
@@ -272,7 +272,7 @@ public class ConfigServerVariables extends Closer {
      * @return the new observable
      */
 	private ForwardingObservable<String> readCompressed(String address) {
-        return switchingObsFactory.getForwardingObservable(new CompressedCharWaveformChannel(),
+        return switchingObsFactory.getSwitchableObservable(new CompressedCharWaveformChannel(),
                 InstrumentUtils.addPrefix(address));
 	}
 	
@@ -284,7 +284,7 @@ public class ConfigServerVariables extends Closer {
      * @return the new observable
      */
 	private ForwardingObservable<String> readCompressedClosing(String address) {
-        return closingObsFactory.getForwardingObservable(new CompressedCharWaveformChannel(),
+        return closingObsFactory.getSwitchableObservable(new CompressedCharWaveformChannel(),
                 InstrumentUtils.addPrefix(address));
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ClosableObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ClosableObservable.java
@@ -111,16 +111,4 @@ public abstract class ClosableObservable<T> implements Observable<T>, Closable {
         }
     }
 
-    /**
-     * Forces this observable to close before it is garbage collected.
-     * 
-     * <p>
-     * This is necessary to prevent memory leaks!
-     * </p>
-     */
-    @Override
-    public void finalize() {
-        close();
-    }
-
 }


### PR DESCRIPTION
### Description of work

This will cause regression of issue #2017 but will act as a temporary fix for blocks appearing disconnected due to being garbage collected.

This PR is intended as a **temporary** fix while a proper fix is worked on.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2165

### Acceptance criteria

- [x] Blocks don't disappear when they get garbage collected (use the java visual VM to force a garbage collection)

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Did any existing system test break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
