### PR TITLE
Ticket2023 dae crashing if disconnected

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/WritingXmlFromPeriodSettingsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/WritingXmlFromPeriodSettingsTest.java
@@ -20,7 +20,7 @@
 package uk.ac.stfc.isis.ibex.dae.tests.periods;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -138,6 +138,16 @@ public class WritingXmlFromPeriodSettingsTest extends FileReadingTest {
 		
 		assertThat(periodSettings.getPeriodType(), is(newValue));		
 	}
+	
+	@Test
+    public void period_control_type_is_not_updated_if_null() {
+
+        assertNotEquals(periodSettings.getPeriodType(), null);
+        periodSettings.setPeriodType(null);
+        reloadSettingsFromCurrentValues();
+        
+        assertNotEquals(periodSettings.getPeriodType(), null);       
+    }
 	
 	@Test
 	public void software_periods_is_updated() {	

--- a/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/WritingXmlFromPeriodSettingsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/WritingXmlFromPeriodSettingsTest.java
@@ -142,10 +142,14 @@ public class WritingXmlFromPeriodSettingsTest extends FileReadingTest {
 	@Test
     public void period_control_type_is_not_updated_if_null() {
 
+	    // Arrange: Check that null is not the current period type.
         assertNotEquals(periodSettings.getPeriodType(), null);
+        
+        // Act: Try to set a period type as null.
         periodSettings.setPeriodType(null);
         reloadSettingsFromCurrentValues();
         
+        // Assert: Check that null has been ignored.
         assertNotEquals(periodSettings.getPeriodType(), null);       
     }
 	

--- a/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/WritingXmlFromPeriodSettingsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/WritingXmlFromPeriodSettingsTest.java
@@ -116,6 +116,20 @@ public class WritingXmlFromPeriodSettingsTest extends FileReadingTest {
 		assertThat(periodSettings.getSetupSource(), is(newValue));
 	}
 	
+	@Test
+    public void setup_source_is_not_updated_if_null() {
+
+        // Arrange: Check that null is not the current setup source.
+        assertNotEquals(periodSettings.getSetupSource(), null);
+        
+        // Act: Try to set a setup source as null.
+        periodSettings.setSetupSource(null);
+        reloadSettingsFromCurrentValues();
+        
+        // Assert: Check that null has been ignored.
+        assertNotEquals(periodSettings.getSetupSource(), null);       
+    }
+	
 
 	@Test
 	public void period_file_is_updated() {

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/periods/XMLBackedPeriodSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/periods/XMLBackedPeriodSettings.java
@@ -33,6 +33,9 @@ import uk.ac.stfc.isis.ibex.dae.xml.XmlFile;
 import uk.ac.stfc.isis.ibex.dae.xml.XmlNode;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 
+/**
+ * Gets the DAE period settings from XML.
+ */
 public class XMLBackedPeriodSettings extends PeriodSettings {
 
     private static final Logger LOG = IsisLog.getLogger(XMLBackedPeriodSettings.class);
@@ -51,6 +54,9 @@ public class XMLBackedPeriodSettings extends PeriodSettings {
 	
 	private final ArrayList<XmlBackedPeriod> periods = new ArrayList<>();
 	
+	/**
+	 * Constructor.
+	 */
 	public XMLBackedPeriodSettings() {
 		nodes.add(setupSource);
 		nodes.add(periodFile);
@@ -68,51 +74,75 @@ public class XMLBackedPeriodSettings extends PeriodSettings {
 		xmlFile = new XmlFile(nodes);
 	}
 	
+	/**
+	 * Sets the xml.
+	 * @param xml the xml to set
+	 */
 	public void setXml(String xml) {
 		xmlFile.setXml(xml);
 		initialiseFromXml();
 	}
 
+	/**
+	 * Gets the xml from file.
+	 * @return the xml
+	 */
 	public String xml() {
 		return xmlFile.toString();
 	}	
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void setSetupSource(PeriodSetupSource value) {
 		super.setSetupSource(value);
 		setupSource.setValue(value);
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void setNewPeriodFile(String value) {
 		super.setNewPeriodFile(value);
 		periodFile.setValue(value);
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void setPeriodType(PeriodControlType value) {
 	    if (value == null) {
-	        /**
-	         * If the XML gives us an unrecognisable period type that comes to us as null, ignore it.
-	         */
+	        LOG.info("Error, attempted to set a null PeriodControlType.");
 	        return;
 	    }
 		super.setPeriodType(value);
 		periodType.setValue(value);
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void setSoftwarePeriods(int value) {
 		super.setSoftwarePeriods(value);
 		softwarePeriods.setValue(value);
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void setHardwarePeriods(double value) {
 		super.setHardwarePeriods(value);
 		hardwarePeriods.setValue(value);
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void setOutputDelay(double value) {
 		super.setOutputDelay(value);

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/periods/XMLBackedPeriodSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/periods/XMLBackedPeriodSettings.java
@@ -96,6 +96,10 @@ public class XMLBackedPeriodSettings extends PeriodSettings {
 	 */
 	@Override
 	public void setSetupSource(PeriodSetupSource value) {
+	    if (value == null) {
+            LOG.info("Error, attempted to set a null PeriodSetupSource.");
+            return;
+        }
 		super.setSetupSource(value);
 		setupSource.setValue(value);
 	}

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/periods/XMLBackedPeriodSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/periods/XMLBackedPeriodSettings.java
@@ -91,6 +91,12 @@ public class XMLBackedPeriodSettings extends PeriodSettings {
 	
 	@Override
 	public void setPeriodType(PeriodControlType value) {
+	    if (value == null) {
+	        /**
+	         * If the XML gives us an unrecognisable period type that comes to us as null, ignore it.
+	         */
+	        return;
+	    }
 		super.setPeriodType(value);
 		periodType.setValue(value);
 	}


### PR DESCRIPTION
### Description of work

Adds a null check against period control type

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2023

### Acceptance criteria

Unfortunately we haven't found a way to reproduce the crash as reported on the initial ticket. If DAE is not running the instrument just stays in a "processing" state and on a real instrument you'll get a popup saying "DAE not running". After a chat with @FreddieAkeroyd we think it's getting some bad XML from somehow, which causes a value to go to null and then the DAE perspective to crash with a `NullPointerException`

From the stack trace/code, I've added a null check and a unit test against the appropriate behaviour. 

Reviewer, merge this/mark complete if it looks like a sensible solution to the exception in the original ticket. You're welcome to look for ways to reproduce it, but obviously it has already been looked at without success.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there automated [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
    - Manual system tests for the functionality should be added if there are no automated tests
    - Manual system tests can be removed from the template if they are covered by suitable automated tests
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section
