### PR TITLE
Ticket2273 groups should be orderable

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/internal/ComponentFilteredConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/internal/ComponentFilteredConfigurationTest.java
@@ -1,0 +1,139 @@
+
+/*
+* This file is part of the ISIS IBEX application.
+* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* All rights reserved.
+*
+* This program is distributed in the hope that it will be useful.
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v1.0 which accompanies this distribution.
+* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+*
+* You should have received a copy of the Eclipse Public License v1.0
+* along with this program; if not, you can obtain a copy from
+* https://www.eclipse.org/org/documents/epl-v10.php or 
+* http://opensource.org/licenses/eclipse-1.0.php
+*/
+
+package uk.ac.stfc.isis.ibex.configserver.tests.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.configserver.configuration.Group;
+import uk.ac.stfc.isis.ibex.configserver.internal.ComponentFilteredConfiguration;
+
+@SuppressWarnings("checkstyle:methodname")
+public class ComponentFilteredConfigurationTest {
+	
+	@Before
+    public void setup() {
+	}
+	
+    public static void assertGroupsAreEqual(Group expected, Group actual) {
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getComponent(), actual.getComponent());
+        assertEquals(expected.getBlocks(), expected.getBlocks());
+	}
+
+    public static void assertGroupListsAreEqual(List<Group> emptyList, List<Group> actual) {
+        assertEquals(emptyList.size(), actual.size());
+        if (emptyList.size() > 0) {
+            for (int i = 0; i < emptyList.size(); i++) {
+                assertGroupsAreEqual(emptyList.get(i), actual.get(i));
+            }
+        }
+    }
+
+    @Test
+    public void WHEN_groups_empty_THEN_filtered_groups_is_empty() {
+        List<Group> empty = new ArrayList<>();
+        assertGroupListsAreEqual(empty, ComponentFilteredConfiguration.filterGroups(empty));
+    }
+
+    @Test
+    public void WHEN_groups_contains_one_non_component_item_THEN_filtered_groups_is_same_as_original() {
+        // Arrange
+        List<Group> groups = new ArrayList<>();
+        List<String> blocks = new ArrayList<>();
+        blocks.add("block1");
+        blocks.add("block2");
+        groups.add(new Group("name", blocks, null));
+
+        // Assert
+        assertGroupListsAreEqual(groups, ComponentFilteredConfiguration.filterGroups(groups));
+    }
+
+    @Test
+    public void WHEN_groups_contains_two_non_component_items_THEN_filtered_groups_is_same_as_original() {
+        // Arrange
+        List<String> blocks = new ArrayList<>();
+        blocks.add("block1");
+        blocks.add("block2");
+
+        List<Group> groups = new ArrayList<>();
+        groups.add(new Group("name1", blocks, null));
+        groups.add(new Group("name2", blocks, null));
+
+        // Assert
+        assertGroupListsAreEqual(groups, ComponentFilteredConfiguration.filterGroups(groups));
+    }
+
+    @Test
+    public void WHEN_groups_contains_several_component_items_THEN_filtered_groups_are_the_same_but_without_blocks() {
+        // Arrange
+        List<String> blocks = new ArrayList<>();
+        blocks.add("block1");
+        blocks.add("block2");
+
+        List<String> groupNames = new ArrayList<>();
+        groupNames.add("name1");
+        groupNames.add("name2");
+        
+        String component = "my_component";
+
+        List<Group> groups = new ArrayList<Group>();
+        for (String name : groupNames) {
+            groups.add(new Group(name, blocks, component));
+        }
+
+        List<Group> expected = new ArrayList<Group>();
+        for (String name : groupNames) {
+            expected.add(new Group(name, new ArrayList<>(), component));
+        }
+
+        // Assert
+        assertGroupListsAreEqual(expected, ComponentFilteredConfiguration.filterGroups(groups));
+    }
+
+    @Test
+    public void
+            WHEN_groups_contains_a_component_and_non_component_group_THEN_component_group_has_blocks_removed() {
+        // Arrange
+        List<String> blocks = new ArrayList<String>();
+        blocks.add("block1");
+        blocks.add("block2");
+
+        Group component_group = new Group("name1", blocks, "my_component");
+        Group component_group_no_blocks = new Group("name1", new ArrayList<>(), "my_component");
+        Group non_component_group = new Group("name1", blocks, null);
+
+        List<Group> groups = new ArrayList<Group>();
+        groups.add(component_group);
+        groups.add(non_component_group);
+
+        List<Group> expected = new ArrayList<Group>();
+        expected.add(component_group_no_blocks);
+        expected.add(non_component_group);
+
+        // Assert
+        assertGroupListsAreEqual(expected, ComponentFilteredConfiguration.filterGroups(groups));
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/internal/ComponentFilteredConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/internal/ComponentFilteredConfigurationTest.java
@@ -54,15 +54,15 @@ public class ComponentFilteredConfigurationTest {
 
     @Test
     public void GIVEN_no_groups_WHEN_groups_filtered_THEN_filtered_groups_is_empty() {
-        List<Group> empty = new ArrayList<>();
+        List<Group> empty = new ArrayList<Group>();
         assertGroupListsAreEqual(empty, ComponentFilteredConfiguration.filterGroups(empty));
     }
 
     @Test
     public void GIVEN_one_non_component_group_WHEN_groups_filtered_THEN_filtered_groups_is_same_as_original() {
         // Arrange
-        List<Group> groups = new ArrayList<>();
-        List<String> blocks = new ArrayList<>();
+        List<Group> groups = new ArrayList<Group>();
+        List<String> blocks = new ArrayList<String>();
         blocks.add("block1");
         blocks.add("block2");
         groups.add(new Group("name", blocks, null));
@@ -74,11 +74,11 @@ public class ComponentFilteredConfigurationTest {
     @Test
     public void GIVEN_two_non_component_groups_WHEN_groups_filtered_THEN_filtered_groups_is_same_as_original() {
         // Arrange
-        List<String> blocks = new ArrayList<>();
+        List<String> blocks = new ArrayList<String>();
         blocks.add("block1");
         blocks.add("block2");
 
-        List<Group> groups = new ArrayList<>();
+        List<Group> groups = new ArrayList<Group>();
         groups.add(new Group("name1", blocks, null));
         groups.add(new Group("name2", blocks, null));
 
@@ -90,11 +90,11 @@ public class ComponentFilteredConfigurationTest {
     public void
             GIVEN_several_component_groups_WHYEN_groups_filtered_THEN_filtered_groups_are_the_same_but_without_blocks() {
         // Arrange
-        List<String> blocks = new ArrayList<>();
+        List<String> blocks = new ArrayList<String>();
         blocks.add("block1");
         blocks.add("block2");
 
-        List<String> groupNames = new ArrayList<>();
+        List<String> groupNames = new ArrayList<String>();
         groupNames.add("name1");
         groupNames.add("name2");
         
@@ -107,7 +107,7 @@ public class ComponentFilteredConfigurationTest {
 
         List<Group> expected = new ArrayList<Group>();
         for (String name : groupNames) {
-            expected.add(new Group(name, new ArrayList<>(), component));
+            expected.add(new Group(name, new ArrayList<String>(), component));
         }
 
         // Assert
@@ -123,7 +123,7 @@ public class ComponentFilteredConfigurationTest {
         blocks.add("block2");
 
         Group component_group = new Group("name1", blocks, "my_component");
-        Group component_group_no_blocks = new Group("name1", new ArrayList<>(), "my_component");
+        Group component_group_no_blocks = new Group("name1", new ArrayList<String>(), "my_component");
         Group non_component_group = new Group("name1", blocks, null);
 
         List<Group> groups = new ArrayList<Group>();

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/internal/ComponentFilteredConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/internal/ComponentFilteredConfigurationTest.java
@@ -53,13 +53,13 @@ public class ComponentFilteredConfigurationTest {
     }
 
     @Test
-    public void WHEN_groups_empty_THEN_filtered_groups_is_empty() {
+    public void GIVEN_no_groups_WHEN_groups_filtered_THEN_filtered_groups_is_empty() {
         List<Group> empty = new ArrayList<>();
         assertGroupListsAreEqual(empty, ComponentFilteredConfiguration.filterGroups(empty));
     }
 
     @Test
-    public void WHEN_groups_contains_one_non_component_item_THEN_filtered_groups_is_same_as_original() {
+    public void GIVEN_one_non_component_group_WHEN_groups_filtered_THEN_filtered_groups_is_same_as_original() {
         // Arrange
         List<Group> groups = new ArrayList<>();
         List<String> blocks = new ArrayList<>();
@@ -72,7 +72,7 @@ public class ComponentFilteredConfigurationTest {
     }
 
     @Test
-    public void WHEN_groups_contains_two_non_component_items_THEN_filtered_groups_is_same_as_original() {
+    public void GIVEN_two_non_component_groups_WHEN_groups_filtered_THEN_filtered_groups_is_same_as_original() {
         // Arrange
         List<String> blocks = new ArrayList<>();
         blocks.add("block1");
@@ -87,7 +87,8 @@ public class ComponentFilteredConfigurationTest {
     }
 
     @Test
-    public void WHEN_groups_contains_several_component_items_THEN_filtered_groups_are_the_same_but_without_blocks() {
+    public void
+            GIVEN_several_component_groups_WHYEN_groups_filtered_THEN_filtered_groups_are_the_same_but_without_blocks() {
         // Arrange
         List<String> blocks = new ArrayList<>();
         blocks.add("block1");
@@ -115,7 +116,7 @@ public class ComponentFilteredConfigurationTest {
 
     @Test
     public void
-            WHEN_groups_contains_a_component_and_non_component_group_THEN_component_group_has_blocks_removed() {
+            GIVEN_a_component_and_non_component_group_WHEN_groups_filtered_THEN_component_group_has_blocks_removed() {
         // Arrange
         List<String> blocks = new ArrayList<String>();
         blocks.add("block1");

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -157,7 +157,9 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
         for (Block block : config.getBlocks()) {
             EditableBlock eb = new EditableBlock(block);
             editableBlocks.add(eb);
-            makeBlockAvailable(eb);
+            if (!block.hasComponent()) {
+                makeBlockAvailable(eb);
+            }
             addRenameListener(eb);
         }
 

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.configserver.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -91,12 +92,12 @@ public class ComponentFilteredConfiguration extends Configuration {
      *            The groups
      * @return The filtered collection of groups
      */
-    public static Collection<Group> filterGroups(Collection<Group> groups) {
+    public static List<Group> filterGroups(Collection<Group> groups) {
         return Lists.newArrayList(Iterables.transform(groups, new Function<Group, Group>() {
             @Override
             public Group apply(Group group) {
                 return group.getComponent() == null ? group
-                        : new Group(group.getName(), new ArrayList<String>(), null);
+                        : new Group(group.getName(), new ArrayList<String>(), group.getComponent());
             }
         }));
 	}

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
@@ -19,8 +19,10 @@
 
 package uk.ac.stfc.isis.ibex.configserver.internal;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
+import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -90,6 +92,11 @@ public class ComponentFilteredConfiguration extends Configuration {
      * @return The filtered collection of groups
      */
     public static Collection<Group> filterGroups(Collection<Group> groups) {
-        return groups;
+        return Lists.newArrayList(Iterables.transform(groups, new Function<Group, Group>() {
+            @Override
+            public Group apply(Group group) {
+                return new Group(group.getName(), new ArrayList<String>(), group.getComponent());
+            }
+        }));
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
@@ -85,8 +85,10 @@ public class ComponentFilteredConfiguration extends Configuration {
 	}
 
     /**
-     * Takes a collection of groups and filters out the ones that are part of a
-     * component.
+     * Takes a collection of groups and returns a filtered list. Configuration
+     * groups are unaltered. Component groups are cleared of blocks and labelled
+     * as component groups. This assumes groups cannot be jointly members of
+     * configurations and components.
      * 
      * @param groups
      *            The groups

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
@@ -95,7 +95,8 @@ public class ComponentFilteredConfiguration extends Configuration {
         return Lists.newArrayList(Iterables.transform(groups, new Function<Group, Group>() {
             @Override
             public Group apply(Group group) {
-                return new Group(group.getName(), new ArrayList<String>(), group.getComponent());
+                return group.getComponent() == null ? group
+                        : new Group(group.getName(), new ArrayList<String>(), null);
             }
         }));
 	}

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ComponentFilteredConfiguration.java
@@ -90,11 +90,6 @@ public class ComponentFilteredConfiguration extends Configuration {
      * @return The filtered collection of groups
      */
     public static Collection<Group> filterGroups(Collection<Group> groups) {
-        return Lists.newArrayList(Iterables.filter(groups, new Predicate<Group>() {
-			@Override
-			public boolean apply(Group group) {
-				return !group.hasComponent();
-			}
-		}));
+        return groups;
 	}
 }


### PR DESCRIPTION
### Description of work

Preserve the order of groups as set in the configuration editor, including component groups

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2273

### Acceptance criteria

Before starting, create a component with at least 2 groups

-  [x] Create a config, add the component. Verify that the component groups appear in the config when it is saved
- [x] Edit the component, delete one of the groups. Verify it is removed from the config
- [x] Edit the config, verify none of the unused group blocks can be added to the config group
- [x] Edit the config, move the component group around in the group ordering. Save the group, verify that the group order is reflected in the block display
- [x] Restart the GUI, check that the group ordering is preserved
- [x] Remove the component from the config, verify that the component group is removed from the config

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [x] Are there automated [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
    - Manual system tests for the functionality should be added if there are no automated tests
    - Manual system tests can be removed from the template if they are covered by suitable automated tests
- [ ] Did any existing system test break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [x] Has developer documentation been updated if required?
- [x] Have any new plugins been added to the appropriate feature.xml? You can check if this is needed by validating plugins as per method at  https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Common-Eclipse-Issues

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

