### PR TITLE
Ticket2420: Device screens not written to server

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.devicescreens/src/uk/ac/stfc/isis/ibex/devicescreens/DeviceScreensModel.java
+++ b/base/uk.ac.stfc.isis.ibex.devicescreens/src/uk/ac/stfc/isis/ibex/devicescreens/DeviceScreensModel.java
@@ -23,8 +23,8 @@ package uk.ac.stfc.isis.ibex.devicescreens;
 
 import uk.ac.stfc.isis.ibex.devicescreens.desc.DeviceDescription;
 import uk.ac.stfc.isis.ibex.devicescreens.desc.DeviceScreensDescription;
+import uk.ac.stfc.isis.ibex.epics.observing.BaseObserver;
 import uk.ac.stfc.isis.ibex.epics.observing.Observable;
-import uk.ac.stfc.isis.ibex.epics.observing.Observer;
 import uk.ac.stfc.isis.ibex.epics.writing.SameTypeWriter;
 import uk.ac.stfc.isis.ibex.epics.writing.Writable;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
@@ -79,7 +79,7 @@ public class DeviceScreensModel extends ModelObject {
         this.writableDeviceScreenDescriptions.writeTo(writableDeviceScreenDescriptions);
         writableDeviceScreenDescriptions.subscribe(this.writableDeviceScreenDescriptions);
 
-        observableDeviceScreensDescription.addObserver(new Observer<DeviceScreensDescription>() {
+        observableDeviceScreensDescription.addObserver(new BaseObserver<DeviceScreensDescription>() {
 
             @Override
             public void update(DeviceScreensDescription value, Exception error, boolean isConnected) {
@@ -105,16 +105,6 @@ public class DeviceScreensModel extends ModelObject {
 
                 setDeviceScreensDescription(copy);
             }
-
-            @Override
-            public void onError(Exception e) {
-                // Do nothing
-            }
-
-            @Override
-            public void onConnectionStatus(boolean isConnected) {
-                // Do nothing
-            }
         });
     }
 
@@ -139,7 +129,14 @@ public class DeviceScreensModel extends ModelObject {
         updateDeviceScreensDescription(deviceScreensDescription);
     }
 
-    public void updateDeviceScreensDescription(DeviceScreensDescription deviceScreensDescription) {
+    /**
+     * Separates the device screens into local and remote and sets the remote on
+     * the server.
+     * 
+     * @param deviceScreensDescription
+     *            the device screens description to set
+     */
+    private void updateDeviceScreensDescription(DeviceScreensDescription deviceScreensDescription) {
 
         DeviceScreensDescription remoteDevices = new DeviceScreensDescription();
 

--- a/base/uk.ac.stfc.isis.ibex.devicescreens/src/uk/ac/stfc/isis/ibex/devicescreens/DeviceScreensModel.java
+++ b/base/uk.ac.stfc.isis.ibex.devicescreens/src/uk/ac/stfc/isis/ibex/devicescreens/DeviceScreensModel.java
@@ -71,6 +71,7 @@ public class DeviceScreensModel extends ModelObject {
         this.writableDeviceScreenDescriptions = new SameTypeWriter<DeviceScreensDescription>() {
             @Override
             public void onCanWriteChanged(boolean canWrite) {
+                super.onCanWriteChanged(canWrite);
                 setCanWriteRemote(canWrite);
             };
         };


### PR DESCRIPTION
### Description of work

Call the parent method in `onCanWriteChanged`, otherwise the base property `canWrite` will never be updated and will stay at the default `false`. This will mean:

```
writableDeviceScreenDescriptions.canWrite()
```

is never true and the remote device screens won't be set.

I've checked and not found the same pattern elsewhere in the code so this should be an isolated problem. Worth bringing up at the sprint review though.

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2420

### Acceptance criteria

- [ ] Device screens saved to server are retained between runs

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there automated [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
    - Manual system tests for the functionality should be added if there are no automated tests
    - Manual system tests can be removed from the template if they are covered by suitable automated tests
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [ ] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
- [ ] Have any new plugins been added to the appropriate feature.xml? You can check if this is needed by validating plugins as per method at  https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Common-Eclipse-Issues

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

