### PR TITLE
Ticket2443 dae perspective layout

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
@@ -236,7 +236,6 @@ public class DaeView extends ViewPart implements TabIsShownAction {
         Point titleSize = titleComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT);
         Point compositeSize = new Point(tabSize.x + titleSize.x, tabSize.y + titleSize.y);
 
-        // size.y += 20;
         scrolledComposite.setMinSize(compositeSize);
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
@@ -221,9 +221,6 @@ public class DaeView extends ViewPart implements TabIsShownAction {
 		
 		vetosPanel = new VetosPanel(vetosComposite, SWT.NONE);
 		vetosPanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-		
-        GridData tabFolderGridData = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
-        tabFolder.setLayoutData(tabFolderGridData);
 
 		createActions();
 		initializeToolBar();
@@ -231,11 +228,11 @@ public class DaeView extends ViewPart implements TabIsShownAction {
 		
 		setModel(DaeUI.getDefault().viewModel());
 		tabFolder.setSelection(0);
+        tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 
         Point tabSize = tabFolder.computeSize(SWT.DEFAULT, SWT.DEFAULT);
         Point titleSize = titleComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT);
         Point compositeSize = new Point(tabSize.x + titleSize.x, tabSize.y + titleSize.y);
-
         scrolledComposite.setMinSize(compositeSize);
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
@@ -159,7 +159,6 @@ public class DaeView extends ViewPart implements TabIsShownAction {
 		lblTitle.setText("DAE Control Program");
 		
 		CTabFolder tabFolder = new CTabFolder(container, SWT.BORDER);
-		tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 		tabFolder.setSelectionBackground(Display.getCurrent().getSystemColor(SWT.COLOR_TITLE_INACTIVE_BACKGROUND_GRADIENT));
         TabIsShownListener.createAndRegister(this, tabFolder, this);
 
@@ -179,8 +178,9 @@ public class DaeView extends ViewPart implements TabIsShownAction {
 		
 		Composite experimentalSetupComposite = new Composite(tabFolder, SWT.NONE);
 		tbtmExperimentSetup.setControl(experimentalSetupComposite);
-		experimentalSetupComposite.setLayout(new FillLayout(SWT.HORIZONTAL));
+        experimentalSetupComposite.setLayout(new GridLayout(1, false));
 		experimentSetup = new ExperimentSetup(experimentalSetupComposite, SWT.NONE);
+        experimentSetup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 		
 		CTabItem tbtmRunInformation = new CTabItem(tabFolder, SWT.NONE);
 		tbtmRunInformation.setImage(ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui.dae", "icons/info.png"));
@@ -222,26 +222,17 @@ public class DaeView extends ViewPart implements TabIsShownAction {
 		vetosPanel = new VetosPanel(vetosComposite, SWT.NONE);
 		vetosPanel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 		
-		
+        GridData tabFolderGridData = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
+        tabFolder.setLayoutData(tabFolderGridData);
+
 		createActions();
 		initializeToolBar();
 		initializeMenu();
 		
 		setModel(DaeUI.getDefault().viewModel());
 		tabFolder.setSelection(0);
-        scrolledComposite.setMinSize(new Point(600, 500));
-		
-		Composite composite = new Composite(container, SWT.NONE);
-		composite.setLayout(new GridLayout(1, false));
-		GridData gdComposite = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
-		gdComposite.widthHint = 600;
-		composite.setLayoutData(gdComposite);
-		
-		Label label = new Label(composite, SWT.NONE);
-		label.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-		new Label(container, SWT.NONE);
-		new Label(container, SWT.NONE);
-
+        Point size = tabFolder.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+        scrolledComposite.setMinSize(size);
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/DaeView.java
@@ -231,8 +231,13 @@ public class DaeView extends ViewPart implements TabIsShownAction {
 		
 		setModel(DaeUI.getDefault().viewModel());
 		tabFolder.setSelection(0);
-        Point size = tabFolder.computeSize(SWT.DEFAULT, SWT.DEFAULT);
-        scrolledComposite.setMinSize(size);
+
+        Point tabSize = tabFolder.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+        Point titleSize = titleComposite.computeSize(SWT.DEFAULT, SWT.DEFAULT);
+        Point compositeSize = new Point(tabSize.x + titleSize.x, tabSize.y + titleSize.y);
+
+        // size.y += 20;
+        scrolledComposite.setMinSize(compositeSize);
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -69,9 +69,9 @@ public class ExperimentSetup extends Composite {
 	public ExperimentSetup(Composite parent, int style) {
 		super(parent, SWT.NONE);
 		GridLayout gridLayout = new GridLayout(1, false);
-		gridLayout.marginHeight = 0;
-		gridLayout.verticalSpacing = 0;
-		gridLayout.marginWidth = 0;
+        gridLayout.marginHeight = 0;
+        gridLayout.verticalSpacing = 5;
+        gridLayout.marginWidth = 0;
 		gridLayout.horizontalSpacing = 0;
 		setLayout(gridLayout);
 		
@@ -108,23 +108,19 @@ public class ExperimentSetup extends Composite {
         // disappearing
         tabFolderGridData.minimumHeight = tabFolder.computeSize(SWT.DEFAULT, SWT.DEFAULT).y;
         tabFolder.setLayoutData(tabFolderGridData);
-		
-		Composite sendChangesComposite = new Composite(this, SWT.NONE);
-        sendChangesComposite.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-		sendChangesComposite.setLayout(new GridLayout(1, false));
-		
-		RunSummaryViewModel rsvm = DaeUI.getDefault().viewModel().runSummary();
-		SendChangesButton btnSendChanges = new SendChangesButton(sendChangesComposite, SWT.NONE, rsvm.actions().begin);
-		btnSendChanges.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				if (viewModel != null) {
+
+        RunSummaryViewModel rsvm = DaeUI.getDefault().viewModel().runSummary();
+        SendChangesButton btnSendChanges = new SendChangesButton(this, SWT.NONE, rsvm.actions().begin);
+        btnSendChanges.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                if (viewModel != null) {
                     viewModel.updateDae();
-				}
-				sendingChanges.open();
-			}
-		});
-		btnSendChanges.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+                }
+                sendingChanges.open();
+            }
+        });
+        btnSendChanges.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
         btnSendChanges.setText("Apply Changes");
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -50,6 +50,12 @@ public class ExperimentSetup extends Composite {
 	
 	private final int timeToDisplayDialog = 2;
 	
+    /**
+     * SWT isn't good at computing the height of this control and so truncates
+     * it if the screen gets too small. This is the number of pixels to add to
+     * the computed size to make sure that doesn't happen.
+     */
+
 	private SendingChangesDialog sendingChanges = new SendingChangesDialog(getShell(), timeToDisplayDialog);
 	
     /**
@@ -70,7 +76,6 @@ public class ExperimentSetup extends Composite {
 		setLayout(gridLayout);
 		
 		CTabFolder tabFolder = new CTabFolder(this, SWT.BORDER);
-		tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 		tabFolder.setSelectionBackground(Display.getCurrent().getSystemColor(SWT.COLOR_TITLE_INACTIVE_BACKGROUND_GRADIENT));
 		
 		CTabItem tbtmTimeChannels = new CTabItem(tabFolder, SWT.NONE);
@@ -98,9 +103,14 @@ public class ExperimentSetup extends Composite {
 		periods = new PeriodsPanel(periodsComposite, SWT.NONE);
 		
 		tabFolder.setSelection(0);
+        GridData tabFolderGridData = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
+        // Don't let the tab folder shrink vertically or controls can start
+        // disappearing
+        tabFolderGridData.minimumHeight = tabFolder.computeSize(SWT.DEFAULT, SWT.DEFAULT).y;
+        tabFolder.setLayoutData(tabFolderGridData);
 		
 		Composite sendChangesComposite = new Composite(this, SWT.NONE);
-		sendChangesComposite.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        sendChangesComposite.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
 		sendChangesComposite.setLayout(new GridLayout(1, false));
 		
 		RunSummaryViewModel rsvm = DaeUI.getDefault().viewModel().runSummary();

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -49,13 +49,6 @@ public class ExperimentSetup extends Composite {
 	private PeriodsPanel periods;
 	
 	private final int timeToDisplayDialog = 2;
-	
-    /**
-     * SWT isn't good at computing the height of this control and so truncates
-     * it if the screen gets too small. This is the number of pixels to add to
-     * the computed size to make sure that doesn't happen.
-     */
-
 	private SendingChangesDialog sendingChanges = new SendingChangesDialog(getShell(), timeToDisplayDialog);
 	
     /**


### PR DESCRIPTION
### Description of work

I've done some rework on the layouts of the controls in the DAE perspective. I think the way the experimental setup tabs are embedded in the experiment setup tab look a bit nicer. Primarily though, the changes make it so that the experiment setup tab and its controls (esp. data acquisition) don't disappear when the GUI is shrunk

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2443

### Acceptance criteria

- [x] The DAE perspective looks sensible at all possible sizes. No need to change screen resolution. Just resize the window and check the controls look appropriate. The key ones to look out for are the data acquisition tab. Make sure the muon controls and apply changes button aren't cut off

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Have no new checkstyle warnings been introduced? Check via Jenkins
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there automated [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
    - Manual system tests for the functionality should be added if there are no automated tests
    - Manual system tests can be removed from the template if they are covered by suitable automated tests
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [ ] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
- [ ] Have any new plugins been added to the appropriate feature.xml? You can check if this is needed by validating plugins as per method at  https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Common-Eclipse-Issues

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

