### PR TITLE
Ticket2615: OPI checker script fails for existing OPIs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
@@ -19,6 +19,9 @@ logs_directory = r"./check_OPI_format_logs/"
 # Single file
 single_file = ""
 
+class CapitalisationError(Exception):
+    pass
+
 class CheckOpiFormat:
 
     # If a word contains any of the following, the whole word will be ignored
@@ -71,59 +74,50 @@ class CheckOpiFormat:
                 + "\n... " + error_message
             self.errors.append(err)
 
-    def check_title_case(self, root, xpath, error_message):
+    def check_case(self, root, xpath, error_message, title_case):
         for name in root.xpath(xpath):
-            capitalisation_error = False
+            try:
+                if name.text is None:
+                    raise CapitalisationError("No text identified")
 
-            # Special case for the manager mode indicator
-            if "manager mode" in name.text.lower():
-                continue;
+                words = name.text.split()
+                if len(words)==0:
+                    raise CapitalisationError("Text is empty")
 
-            words = name.text.split()
+                # Special case for the manager mode indicator
+                if title_case and "manager mode" in name.text.lower():
+                    continue;
 
-            # Handle special case of first word (which should be capitalised regardless of length)
-            word = words[0]
-            if not word.title() == word and not any(s in word for s in self.ignore):
-                capitalisation_error = True
+                # Handle special case of first word (which should be capitalised regardless of length)
+                word = words[0]
+                if not word.title() == word and not any(s in word for s in self.ignore):
+                    raise CapitalisationError("First word is not capitalised")
 
             # Ignore words less than 4 characters as these are probably prepositions
             # Also don't check first word as that is a special case handled above
-            for word in words:
-                if len(word) > self.ignore_short_words_limit \
-                        and not word == words[0] \
-                        and word.title() != word \
-                        and not any(s in word for s in self.ignore):
-                    capitalisation_error = True
+                for i, word in enumerate(words):
+                    is_long_word = len(word) > self.ignore_short_words_limit
+                    is_first_word = i==0
+                    is_ignored = any(s in word for s in self.ignore)
+                    if is_long_word and not is_first_word and not is_ignored:
+                        if title_case and word.title() != word:
+                            raise CapitalisationError("Word '{}' is not in title case".format(word))
+                        elif not title_case and word.lower() != word:
+                            raise CapitalisationError("Word '{}' is not in sentence case".format(word))
 
-            if capitalisation_error:
-                err = "Error on line " + str(name.sourceline) + ": " + etree.tostring(name) \
-                      + "\n... " + error_message
+            except CapitalisationError as caps_err:
+                err = "Error on line {source}, {name}: {broad_message}\n    {fine_message}".format(
+                    source=name.sourceline,
+                    name=etree.tostring(name),
+                    broad_message=error_message,
+                    fine_message=caps_err)
                 self.errors.append(err)
+
+    def check_title_case(self, root, xpath, error_message):
+        self.check_case(root, xpath, error_message, True)
 
     def check_sentence_case(self, root, xpath, error_message):
-
-        for name in root.xpath(xpath):
-            capitalisation_error = False
-            words = name.text.split()
-
-            # Handle special case of first word (which should be capitalised regardless of length)
-            word = words[0]
-            if not word.title() == word and not any(s in word for s in self.ignore):
-                capitalisation_error = True
-
-            # Ignore words less than 4 characters as these are probably prepositions
-            # Also don't check first word as that is a special case handled above
-            for word in words:
-                if len(word) > self.ignore_short_words_limit \
-                        and not word == words[0] \
-                        and not word.lower() == word \
-                        and not any(s in word for s in self.ignore):
-                    capitalisation_error = True
-
-            if capitalisation_error:
-                err = "Error on line " + str(name.sourceline) + ": " + etree.tostring(name) \
-                      + "\n... " + error_message
-                self.errors.append(err)
+        self.check_case(root, xpath, error_message, False)
 
     def check_plot_area_background(self, root):
 
@@ -237,11 +231,16 @@ class CheckOpiFormat:
                              "/" + self.widget_xpath + "Label']/text"
 
         for name in root.xpath(container_name_xpath):
-            words = name.text
+            text = name.text
+            if text is None or len(text)==0:
+                continue
 
             # Check last character in the string is a colon
-            if words[-1:] != ":" and words[-3:] != "..." and not words.isdigit() \
-                and not any(s in words for s in self.ignore):
+            last_character_is_colon = text[-1:] != ":"
+            ends_in_ellipsis = len(text)>= 3 and text[-3:]=="..."
+            text_is_numeric = text.isdigit()
+            is_ignored = any(s==text for s in self.ignore)
+            if  not last_character_is_colon and not ends_in_ellipsis and not text_is_numeric and not is_ignored:
                     err = "Error on line " + str(name.sourceline) + ": " + etree.tostring(name) \
                         + "\n... Labels should usually have a colon at the end, unless this is a tabular layout"
                     self.errors.append(err)

--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_format_tests.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_format_tests.py
@@ -545,7 +545,7 @@ class TestCheckOpiFormatMethods(unittest.TestCase):
         # Assert
         self.assertEqual(len(self.checker.errors), 1)
 
-    def test_that_if_a_label_outside_a_grouping_container_is_capitalised_in_title_case_is_causes_no_errors(self):
+    def test_that_if_a_label_outside_a_grouping_container_is_capitalised_in_title_case_it_causes_no_errors(self):
         # Arrange
         
         xml = '<widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">' \
@@ -559,11 +559,25 @@ class TestCheckOpiFormatMethods(unittest.TestCase):
         # Assert
         self.assertEqual(len(self.checker.errors), 0)
 
-    def test_that_if_a_label_outside_a_grouping_container_is_not_capitalised_in_title_case_is_causes_one_error(self):
+    def test_that_if_a_label_outside_a_grouping_container_is_not_capitalised_in_title_case_it_causes_one_error(self):
         # Arrange
         
         xml = '<widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">' \
               '<text>This is not in title case and should cause an error</text>' \
+              '</widget>'
+        root = etree.fromstring(xml)
+
+        # Act
+        self.checker.check_capitals_for_labels_outside_grouping_containers(root)
+
+        # Assert
+        self.assertEqual(len(self.checker.errors), 1)
+
+    def test_that_if_a_label_outside_a_grouping_container_is_empty_it_causes_one_error(self):
+        # Arrange
+
+        xml = '<widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">' \
+              '<text></text>' \
               '</widget>'
         root = etree.fromstring(xml)
 


### PR DESCRIPTION
### Description of work

The script checker was failing on OPIs with empty text with NoneType errors. I've done 

- Some refactoring to eliminate duplicate code
- Improved error handling logic
- Improved code readability
- Added a test for empty text

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2615

### Acceptance criteria

- [x] OPI checker script runs for existing OPIs
- [x] OPI checker still generates lots of errors as before (previous script got at least as far as the Julabo)
- [x] OPI checker tests pass whereas the new test would have failed before

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Have no new checkstyle warnings been introduced? Check via Jenkins
- [x] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there automated [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
    - Manual system tests for the functionality should be added if there are no automated tests
    - Manual system tests can be removed from the template if they are covered by suitable automated tests
- [ ] Did any existing system test break as a result of the current changes? 
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
- [ ] Have any new plugins been added to the appropriate feature.xml? You can check if this is needed by validating plugins as per method at  https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Common-Eclipse-Issues

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

