### PR TITLE
Blocks display purple border when PV alarm state is "INVALID"

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/displaying/DisplayBlock.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/displaying/DisplayBlock.java
@@ -84,7 +84,7 @@ public class DisplayBlock extends ModelObject {
     /**
      * Saves the last alarm state (to restore after disconnect).
      */
-    private BlockState lastAlarmState = BlockState.DEFAULT;
+    private BlockState lastBlockState = BlockState.DEFAULT;
 
     private final BaseObserver<String> valueAdapter = new BaseObserver<String>() {
         @Override
@@ -104,7 +104,7 @@ public class DisplayBlock extends ModelObject {
                 setValue("disconnected");
                 setBlockState(BlockState.DISCONNECTED);
             } else {
-                setBlockState(lastAlarmState);
+                setBlockState(lastBlockState);
             }
             setRuncontrolState(checkRuncontrolState());
         }
@@ -134,21 +134,24 @@ public class DisplayBlock extends ModelObject {
 
         @Override
         public void onValue(AlarmState value) {
-            BlockState alarm = BlockState.DEFAULT;
+            BlockState state = BlockState.DEFAULT;
             if (value.name().equals("MINOR")) {
-                alarm = BlockState.MINOR_ALARM;
+                state = BlockState.MINOR_ALARM;
             } else if (value.name().equals("MAJOR")) {
-                alarm = BlockState.MAJOR_ALARM;
+                state = BlockState.MAJOR_ALARM;
+            } else if (value.name().equals("INVALID")) {
+                state = BlockState.DISCONNECTED;
             }
-            lastAlarmState = alarm;
-            setBlockState(alarm);
+
+            lastBlockState = state;
+            setBlockState(state);
         }
 
         @Override
         public void onError(Exception e) {
-            BlockState alarm = BlockState.MINOR_ALARM;
-            lastAlarmState = alarm;
-            setBlockState(alarm);
+            BlockState state = BlockState.MINOR_ALARM;
+            lastBlockState = state;
+            setBlockState(state);
         }
 
         @Override


### PR DESCRIPTION
### Description of work

Blocks in the blocks overview display a purple border when the underlying PV goes into an INVALID-alarm state. 
### To test

https://github.com/ISISComputingGroup/IBEX/issues/2604

### Acceptance criteria

An INVALID state is reflected with a purple border around the relevant block. `SimpleIOC` has a PV `VALUE1` which is in an INVALID state by default, you can use this for testing.


---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Does the code conform to the [coding standards](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/GUI-Coding-Conventions)? Is it well structured with small focussed classes/methods/functions?
- [ ] Have no new checkstyle warnings been introduced? Check via Jenkins
- [ ] Are there unit tests in place? Are the unit tests small and test the a class in isolation?
- [ ] Are there automated [system tests](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/System-Testing-with-RCPTT) in place? Do they test a minimal set of functionality and leave the gui as close as possible to its original state?
- [ ] Has the [manual system tests spreadsheet](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Manual-system-tests) been updated?
    - Manual system tests for the functionality should be added if there are no automated tests
    - Manual system tests can be removed from the template if they are covered by suitable automated tests
- [ ] Did any existing system test break as a result of the current changes? 
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev). If so, do they describe the changes appropriately?
- [ ] If an OPI has been modified, does it conform to the [style guidelines](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/OPI-Creation)? There is a script called `check_opi_format.py` to help with this.

### Functional Tests

- [x] Do changes function as described? Add comments below that describe the tests performed.
- [x] How do the changes handle unexpected situations, e.g. bad input?
- [ ] Has developer documentation been updated if required?
- [ ] Have any new plugins been added to the appropriate feature.xml? You can check if this is needed by validating plugins as per method at  https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Common-Eclipse-Issues

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

