### PR TITLE
Add indicator for disconnected sensor to OPI

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm.opi
@@ -6,7 +6,7 @@
   <show_grid>true</show_grid>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <scripts />
-  <height>600</height>
+  <height>620</height>
   <macros>
     <include_parent_macros>false</include_parent_macros>
     <IOC_NUM>01</IOC_NUM>
@@ -43,7 +43,7 @@
       <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </tab_6_background_color>
     <tab_6_title>Sensor 7</tab_6_title>
-    <height>511</height>
+    <height>531</height>
     <tab_6_foreground_color>
       <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </tab_6_foreground_color>
@@ -207,7 +207,7 @@
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>482</height>
+      <height>502</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -246,7 +246,7 @@
         <wuid>6892be24:156313795e2:-7d1e</wuid>
         <auto_size>false</auto_size>
         <scripts />
-        <height>475</height>
+        <height>495</height>
         <border_width>1</border_width>
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -289,7 +289,7 @@
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>482</height>
+      <height>502</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -371,7 +371,7 @@
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>482</height>
+      <height>502</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -453,7 +453,7 @@
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>482</height>
+      <height>502</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -535,7 +535,7 @@
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>482</height>
+      <height>502</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -617,7 +617,7 @@
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>482</height>
+      <height>502</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -699,7 +699,7 @@
       <transparent>true</transparent>
       <lock_children>false</lock_children>
       <scripts />
-      <height>482</height>
+      <height>502</height>
       <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
@@ -6,7 +6,7 @@
   <show_grid>true</show_grid>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <scripts />
-  <height>470</height>
+  <height>490</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
     <PV_ROOT_EURO>$(P)$(EURO):A0$(EURO_NUM)</PV_ROOT_EURO>
@@ -63,7 +63,7 @@
     <width>277</width>
     <x>504</x>
     <name>Control and Tuning</name>
-    <y>289</y>
+    <y>309</y>
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
@@ -845,7 +845,7 @@ $(pv_value)</tooltip>
     <width>250</width>
     <x>6</x>
     <name>Lookup and Ramp</name>
-    <y>306</y>
+    <y>326</y>
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
@@ -1288,7 +1288,7 @@ $(trace_0_y_pv_value)</tooltip>
     <axis_0_maximum>120.0</axis_0_maximum>
     <trace_1_y_axis_index>1</trace_1_y_axis_index>
     <trace_2_name>HEATER OUTPUT</trace_2_name>
-    <height>295</height>
+    <height>315</height>
     <trace_2_visible>true</trace_2_visible>
     <trigger_pv_value />
     <axis_1_grid_color>
@@ -1387,7 +1387,7 @@ $(trace_0_y_pv_value)</tooltip>
     <transparent>false</transparent>
     <lock_children>false</lock_children>
     <scripts />
-    <height>235</height>
+    <height>255</height>
     <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -2289,6 +2289,64 @@ else:
         <opifont.name fontName="Segoe UI" height="9" style="1">ISIS_Label_NEW</opifont.name>
       </font>
     </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0">
+      <border_style>0</border_style>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <precision>3</precision>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <horizontal_alignment>0</horizontal_alignment>
+      <rules>
+        <rule name="Visibility" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0==0">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT_EURO):SENSOR_DISCONNECTED</pv>
+        </rule>
+      </rules>
+      <enabled>true</enabled>
+      <wuid>-be59e48:15f96cc8aac:-7b8c</wuid>
+      <transparent>false</transparent>
+      <pv_value />
+      <auto_size>false</auto_size>
+      <text>Sensor disconnected. Ramping is disabled.</text>
+      <rotation_angle>0.0</rotation_angle>
+      <scripts />
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <show_units>false</show_units>
+      <height>19</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <visible>true</visible>
+      <pv_name></pv_name>
+      <vertical_alignment>1</vertical_alignment>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <precision_from_pv>false</precision_from_pv>
+      <widget_type>Text Update</widget_type>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <wrap_words>false</wrap_words>
+      <format_type>0</format_type>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <width>227</width>
+      <x>14</x>
+      <name>Sensor_disconnected_label</name>
+      <y>207</y>
+      <foreground_color>
+        <color name="Minor" red="255" green="128" blue="0" />
+      </foreground_color>
+      <actions hook="false" hook_all="false" />
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_Value_NEW</opifont.name>
+      </font>
+    </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0">
     <border_style>13</border_style>
@@ -2452,7 +2510,7 @@ $(pv_value)</tooltip>
     <width>250</width>
     <x>255</x>
     <name>Sensor Calibration</name>
-    <y>306</y>
+    <y>326</y>
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
@@ -1684,7 +1684,30 @@ $(pv_value)</tooltip>
       <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
       <tooltip>$(pv_name)
 $(pv_value)</tooltip>
-      <rules />
+      <rules>
+        <rule name="Off_Colour" prop_id="off_color" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>
+              <color name="ISIS_Red_LED_Off" red="102" green="0" blue="0" />
+            </value>
+          </exp>
+          <pv trig="true">$(PV_ROOT_EURO):SENSOR_DISCONNECTED</pv>
+        </rule>
+        <rule name="On_Colour" prop_id="on_color" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>
+              <color name="ISIS_Red_LED_On" red="255" green="100" blue="100" />
+            </value>
+          </exp>
+          <pv trig="true">$(PV_ROOT_EURO):SENSOR_DISCONNECTED</pv>
+        </rule>
+        <rule name="Target_PV" prop_id="pv_name" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>$(PV_ROOT_EURO):RAMPON:CACHE</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT_EURO):SENSOR_DISCONNECTED</pv>
+        </rule>
+      </rules>
       <effect_3d>true</effect_3d>
       <bit>-1</bit>
       <enabled>true</enabled>


### PR DESCRIPTION
### Description of work

Added an indicator for a disconnected sensor to the Eurotherm OPI. 

Related PR: https://github.com/ISISComputingGroup/EPICS-ioc/pull/194

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2653

### Acceptance criteria

* Warning is hidden while sensor is connected
* Warning is displayed while sensor is disconnected
* OPI layout still looks good

### Unit tests

N/A

### System tests

N/A

### Documentation

N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

