### PR TITLE
Ticket2758 ieg negative pressure

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/ieg_system.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/ieg_system.opi
@@ -124,7 +124,7 @@
     <transparent>false</transparent>
     <lock_children>false</lock_children>
     <scripts />
-    <height>85</height>
+    <height>61</height>
     <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -142,7 +142,7 @@
     <background_color>
       <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </background_color>
-    <width>307</width>
+    <width>217</width>
     <x>6</x>
     <name>Readings</name>
     <y>78</y>
@@ -163,7 +163,7 @@
       <wuid>-3495742c:15dcbe01bf4:-7d40</wuid>
       <transparent>false</transparent>
       <auto_size>false</auto_size>
-      <text>Sample pressure:</text>
+      <text>IVC pressure:</text>
       <scripts />
       <height>20</height>
       <border_width>1</border_width>
@@ -182,8 +182,8 @@
       <background_color>
         <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
       </background_color>
-      <width>96</width>
-      <x>6</x>
+      <width>79</width>
+      <x>0</x>
       <name>Label_2</name>
       <y>6</y>
       <foreground_color>
@@ -234,102 +234,10 @@ $(pv_value)</tooltip>
       <background_color>
         <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
       </background_color>
-      <width>139</width>
-      <x>132</x>
+      <width>103</width>
+      <x>84</x>
       <name>Text Update_1</name>
       <y>6</y>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_Value_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <horizontal_alignment>2</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>4bb8b3c4:15ddfc9071e:-78c2</wuid>
-      <transparent>false</transparent>
-      <auto_size>false</auto_size>
-      <text>Sample bin pressure:</text>
-      <scripts />
-      <height>20</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>Label</widget_type>
-      <wrap_words>true</wrap_words>
-      <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-      </background_color>
-      <width>115</width>
-      <x>6</x>
-      <name>Label_2</name>
-      <y>30</y>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <show_scrollbar>false</show_scrollbar>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="1">ISIS_Label_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0">
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <precision>0</precision>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <horizontal_alignment>0</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>4bb8b3c4:15ddfc9071e:-78c1</wuid>
-      <transparent>true</transparent>
-      <pv_value />
-      <auto_size>false</auto_size>
-      <text>######</text>
-      <rotation_angle>0.0</rotation_angle>
-      <scripts />
-      <border_alarm_sensitive>true</border_alarm_sensitive>
-      <show_units>true</show_units>
-      <height>20</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <pv_name>$(P)$(TPG26X):$(TPGGAUGE):PRESSURE</pv_name>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
-      </border_color>
-      <precision_from_pv>true</precision_from_pv>
-      <widget_type>Text Update</widget_type>
-      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-      <wrap_words>false</wrap_words>
-      <format_type>0</format_type>
-      <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-      </background_color>
-      <width>139</width>
-      <x>132</x>
-      <name>Text Update_1</name>
-      <y>30</y>
       <foreground_color>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
@@ -366,10 +274,10 @@ $(pv_value)</tooltip>
     <background_color>
       <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </background_color>
-    <width>307</width>
+    <width>391</width>
     <x>6</x>
     <name>Operation Mode</name>
-    <y>162</y>
+    <y>138</y>
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
@@ -381,13 +289,13 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
       <border_style>0</border_style>
       <tooltip></tooltip>
-      <horizontal_alignment>0</horizontal_alignment>
+      <horizontal_alignment>2</horizontal_alignment>
       <rules />
       <enabled>true</enabled>
       <wuid>-3495742c:15dcbe01bf4:-7d8e</wuid>
       <transparent>false</transparent>
       <auto_size>false</auto_size>
-      <text>Mode:</text>
+      <text>Operating state:</text>
       <scripts />
       <height>20</height>
       <border_width>1</border_width>
@@ -406,8 +314,8 @@ $(pv_value)</tooltip>
       <background_color>
         <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
       </background_color>
-      <width>49</width>
-      <x>6</x>
+      <width>97</width>
+      <x>36</x>
       <name>Label_2</name>
       <y>6</y>
       <foreground_color>
@@ -459,7 +367,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
       </background_color>
       <width>211</width>
-      <x>60</x>
+      <x>144</x>
       <name>Text Update</name>
       <y>6</y>
       <foreground_color>
@@ -473,13 +381,13 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
       <border_style>0</border_style>
       <tooltip></tooltip>
-      <horizontal_alignment>0</horizontal_alignment>
+      <horizontal_alignment>2</horizontal_alignment>
       <rules />
       <enabled>true</enabled>
       <wuid>-3495742c:15dcbe01bf4:-7d26</wuid>
       <transparent>false</transparent>
       <auto_size>false</auto_size>
-      <text>Status:</text>
+      <text>Error:</text>
       <scripts />
       <height>20</height>
       <border_width>1</border_width>
@@ -499,7 +407,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
       </background_color>
       <width>49</width>
-      <x>6</x>
+      <x>84</x>
       <name>Label_3</name>
       <y>36</y>
       <foreground_color>
@@ -551,7 +459,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
       </background_color>
       <width>211</width>
-      <x>60</x>
+      <x>144</x>
       <name>Text Update_2</name>
       <y>36</y>
       <foreground_color>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -914,14 +914,6 @@
 						<name>IEG</name>
 						<description>The gas exchange system PV prefix (e.g. IEG_01).</description>
 					</macro>
-					<macro>
-						<name>TPG26X</name>
-						<description>The TPG (bin presure reading) PV prefix (e.g. TPG26X_01).</description>
-					</macro>
-					<macro>
-						<name>TPGGAUGE</name>
-						<description>The TPG pressure gauge being used for bin pressure (e.g. 1).</description>
-					</macro>
 				</macros>
 			</value>
 		</entry>


### PR DESCRIPTION
### Description of work

As per ticket:

- Rename labels as described by Matt North
- Remove IEG sample bin pressure
- Remove macros associated with sample bin pressure

### To test

https://github.com/ISISComputingGroup/IBEX/issues/2758

### Acceptance criteria

- Labels match description requested by Matt North
- Display of values for the IVC pressure appropriate for:
    - `<0`
    - `0`
    - `(0,350)`
    - `350`
    - `>350`

### Unit tests

- No unit test changes necessary

### System tests

- Added system tests for IVC pressures listed above, except `>350` which already existed

### Documentation

- No documentation changes required

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

