### PR TITLE
Add access security indicator

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Mk3Chopper/single_chopper_control_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Mk3Chopper/single_chopper_control_panel.opi
@@ -1290,4 +1290,52 @@ $(trace_1_y_pv_value)</tooltip>
       <opifont.name fontName="Segoe UI" height="12" style="1">ISIS_Header3_NEW</opifont.name>
     </font>
   </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
+    <border_style>0</border_style>
+    <tooltip></tooltip>
+    <horizontal_alignment>0</horizontal_alignment>
+    <rules>
+      <rule name="Rule" prop_id="visible" out_exp="false">
+        <exp bool_exp="pv0 != 0">
+          <value>true</value>
+        </exp>
+        <pv trig="true">$(PV_ROOT)MANAGERMODE</pv>
+      </rule>
+    </rules>
+    <enabled>true</enabled>
+    <wuid>13eff7be:15fba719f40:-7a4f</wuid>
+    <transparent>false</transparent>
+    <auto_size>false</auto_size>
+    <text>To control this device, enable manager mode!</text>
+    <scripts />
+    <height>49</height>
+    <border_width>1</border_width>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <visible>false</visible>
+    <vertical_alignment>1</vertical_alignment>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <widget_type>Label</widget_type>
+    <wrap_words>true</wrap_words>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <width>223</width>
+    <x>264</x>
+    <name>Label_15</name>
+    <y>60</y>
+    <foreground_color>
+      <color name="Major" red="255" green="0" blue="0" />
+    </foreground_color>
+    <actions hook="false" hook_all="false" />
+    <show_scrollbar>false</show_scrollbar>
+    <font>
+      <opifont.name fontName="Segoe UI" height="14" style="1">ISIS_Header2_NEW</opifont.name>
+    </font>
+  </widget>
 </display>


### PR DESCRIPTION
### Description of work

Adds the standard "manager mode required" indicator to the MK3 chopper OPI.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2718

### Acceptance criteria

- [ ] Indicator does not appear if access security is not set up
- [ ] Indicator appears if access security is set up and manager mode is not enabled.
- [ ] Indicator does not appear if access security is set up and manager mode is enabled.

### Unit tests

No unit tests - OPI change only.

### System tests

System tests not available for OPIs

### Documentation

No additional documentation was added, generic manager mode documentation exists at https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-access-security

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

