### PR TITLE
Ticket2687 absolute spectra count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ base/workspace/.metadata/.log
 base/uk.ac.stfc.isis.ibex.opis/check_OPI_format_logs
 *.prefs
 .metadata/
+.recommenders/

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ base/workspace/.metadata/.log
 base/uk.ac.stfc.isis.ibex.opis/check_OPI_format_logs
 *.prefs
 .metadata/
-.recommenders/*.pyc
+.recommenders/
+*.pyc
 *.iml
 .idea/*
 

--- a/base/uk.ac.stfc.isis.ibex.dae.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.dae.tests/META-INF/MANIFEST.MF
@@ -5,4 +5,5 @@ Bundle-SymbolicName: uk.ac.stfc.isis.ibex.dae.tests
 Bundle-Version: 1.0.0.qualifier
 Fragment-Host: uk.ac.stfc.isis.ibex.dae;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.junit;bundle-version="4.10.0"
+Require-Bundle: org.junit;bundle-version="4.10.0",
+ org.mockito

--- a/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/spectra/SpectrumTests.java
+++ b/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/spectra/SpectrumTests.java
@@ -1,0 +1,75 @@
+package uk.ac.stfc.isis.ibex.dae.tests.spectra;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.dae.spectra.Spectrum;
+import uk.ac.stfc.isis.ibex.dae.spectra.SpectrumYAxisTypes;
+
+public class SpectrumTests {
+	
+	private final double[] CONSTANT_BIN_WIDTH_X_DATA = {1, 2, 3, 4, 5};
+	private final double[] VARIABLE_BIN_WIDTH_X_DATA = {1, 2, 4, 8, 16};
+	
+	private final double[] Y_DATA = {1, 2, 1, 2, 1};
+	
+	private Spectrum spectrum;
+	
+	@Before
+	public void setUp() {
+		
+		if (CONSTANT_BIN_WIDTH_X_DATA.length != VARIABLE_BIN_WIDTH_X_DATA.length || VARIABLE_BIN_WIDTH_X_DATA.length != Y_DATA.length) {
+			fail("All test data should have the same length.");
+		}
+		
+		spectrum = new Spectrum();
+	}
+
+	@Test
+	public void test_GIVEN_y_axis_type_is_count_rate_WHEN_new_data_arrives_THEN_it_is_not_changed_when_set() {
+		spectrum.setTypeSelectionIndex(Arrays.asList(SpectrumYAxisTypes.values()).indexOf(SpectrumYAxisTypes.COUNT_RATE));
+		spectrum.setXData(Arrays.copyOf(CONSTANT_BIN_WIDTH_X_DATA, CONSTANT_BIN_WIDTH_X_DATA.length));
+		spectrum.setYData(Arrays.copyOf(Y_DATA, Y_DATA.length));
+		
+		assertArrayEquals(Y_DATA, spectrum.yData(), 0);
+	}
+	
+
+	@Test
+	public void test_GIVEN_y_axis_type_is_absolute_counts_WHEN_new_data_arrives_THEN_it_is_not_changed_if_the_bin_widths_are_constant_and_one_except_for_the_last_element_being_set_to_zero() {
+		spectrum.setTypeSelectionIndex(Arrays.asList(SpectrumYAxisTypes.values()).indexOf(SpectrumYAxisTypes.ABSOLUTE_COUNTS));
+		spectrum.setXData(Arrays.copyOf(CONSTANT_BIN_WIDTH_X_DATA, CONSTANT_BIN_WIDTH_X_DATA.length));
+		spectrum.setYData(Arrays.copyOf(Y_DATA, Y_DATA.length));
+		
+		// Loop from 0 to length - 1 because the last element is special 
+		// (always zero because "bin width" can't be calculated for it).
+		for (int i=0; i<Y_DATA.length - 1; i++){
+			assertEquals(Y_DATA[i], spectrum.yData()[i], 0);
+		}
+		
+		// Assert the last element has been set to zero.
+		assertEquals(0, spectrum.yData()[spectrum.yData().length - 1], 0);
+	}
+	
+
+	@Test
+	public void test_GIVEN_y_axis_type_is_absolute_counts_WHEN_new_data_arrives_THEN_it_is_scaled_by_the_bin_widths() {
+		spectrum.setTypeSelectionIndex(Arrays.asList(SpectrumYAxisTypes.values()).indexOf(SpectrumYAxisTypes.ABSOLUTE_COUNTS));
+		spectrum.setXData(Arrays.copyOf(VARIABLE_BIN_WIDTH_X_DATA, VARIABLE_BIN_WIDTH_X_DATA.length));
+		spectrum.setYData(Arrays.copyOf(Y_DATA, Y_DATA.length));
+		
+		// Loop from 0 to length - 1 because the last element is special 
+		// (always zero because "bin width" can't be calculated for it).
+		for (int i=0; i<Y_DATA.length - 1; i++){
+			assertEquals(Y_DATA[i] * Math.abs(spectrum.xData()[i] - spectrum.xData()[i+1]), spectrum.yData()[i], 0);
+		}
+		
+		// Assert the last element has been set to zero.
+		assertEquals(0, spectrum.yData()[spectrum.yData().length - 1], 0);
+	}
+
+}

--- a/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/spectra/SpectrumTests.java
+++ b/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/spectra/SpectrumTests.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.osgi.service.prefs.Preferences;
 
 import uk.ac.stfc.isis.ibex.dae.spectra.Spectrum;
 import uk.ac.stfc.isis.ibex.dae.spectra.SpectrumYAxisTypes;
@@ -22,11 +24,16 @@ public class SpectrumTests {
 	@Before
 	public void setUp() {
 		
-		if (CONSTANT_BIN_WIDTH_X_DATA.length != VARIABLE_BIN_WIDTH_X_DATA.length || VARIABLE_BIN_WIDTH_X_DATA.length != Y_DATA.length) {
+		if (CONSTANT_BIN_WIDTH_X_DATA.length != VARIABLE_BIN_WIDTH_X_DATA.length 
+				|| VARIABLE_BIN_WIDTH_X_DATA.length != Y_DATA.length) {
 			fail("All test data should have the same length.");
 		}
 		
-		spectrum = new Spectrum();
+		Preferences preferenceMock = Mockito.mock(Preferences.class);
+		Mockito.doNothing().when(preferenceMock).putInt(Mockito.anyString(), Mockito.anyInt());
+		Mockito.when(preferenceMock.getInt(Mockito.anyString(), Mockito.anyInt())).thenReturn(0);
+		
+		spectrum = new Spectrum(preferenceMock);
 	}
 
 	@Test

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
@@ -32,6 +32,9 @@ import uk.ac.stfc.isis.ibex.epics.observing.Subscription;
 import uk.ac.stfc.isis.ibex.epics.pv.Closable;
 import org.osgi.service.prefs.Preferences;
 
+/**
+ * An observed spectrum.
+ */
 public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
 		
 	private final DaeObservables observables;
@@ -71,11 +74,19 @@ public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
     private ForwardingObservable<float[]> xValObservable;
     private ForwardingObservable<float[]> yValObservable;
 
+    /**
+     * Constructor.
+     * @param preferenceStore the preference store to use
+     * @param observables the dae observables to use
+     */
     public ObservedSpectrum(Preferences preferenceStore, DaeObservables observables) {
     	super(preferenceStore);
 		this.observables = observables;
 	}
 	
+    /**
+     * {@inheritDoc}
+     */
 	@Override
 	public void update() {
 		updateSubscriptions();
@@ -99,6 +110,9 @@ public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
         ySubscription = yData.addObserver(yDataObserver);
     }
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void close() {
         closeObservables();

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
@@ -57,21 +57,7 @@ public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
 	private final DataObserver yDataObserver = new DataObserver() {
 		@Override
         public void onValue(Pair<Integer, float[]> value) {
-			double[] data = toDoubleArray(value.second, value.first);
-			
-			if (true) {
-				for (int i = 0; i<value.first; i++) {
-					try {
-						data[i] *= Math.abs(xData.getValue().second[i+1] - xData.getValue().second[i]);
-					} catch (ArrayIndexOutOfBoundsException e){
-						System.out.println("AIOOB");
-						data[i] = 0;
-					}
-				}
-			}
-			
-			
-            setYData(data);
+            setYData(toDoubleArray(value.second, value.first));
         }
 	};
 

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
@@ -30,6 +30,7 @@ import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.Pair;
 import uk.ac.stfc.isis.ibex.epics.observing.Subscription;
 import uk.ac.stfc.isis.ibex.epics.pv.Closable;
+import org.osgi.service.prefs.Preferences;
 
 public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
 		
@@ -70,7 +71,8 @@ public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
     private ForwardingObservable<float[]> xValObservable;
     private ForwardingObservable<float[]> yValObservable;
 
-    public ObservedSpectrum(DaeObservables observables) {
+    public ObservedSpectrum(Preferences preferenceStore, DaeObservables observables) {
+    	super(preferenceStore);
 		this.observables = observables;
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/ObservedSpectrum.java
@@ -57,7 +57,21 @@ public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
 	private final DataObserver yDataObserver = new DataObserver() {
 		@Override
         public void onValue(Pair<Integer, float[]> value) {
-            setYData(toDoubleArray(value.second, value.first));
+			double[] data = toDoubleArray(value.second, value.first);
+			
+			if (true) {
+				for (int i = 0; i<value.first; i++) {
+					try {
+						data[i] *= Math.abs(xData.getValue().second[i+1] - xData.getValue().second[i]);
+					} catch (ArrayIndexOutOfBoundsException e){
+						System.out.println("AIOOB");
+						data[i] = 0;
+					}
+				}
+			}
+			
+			
+            setYData(data);
         }
 	};
 
@@ -72,16 +86,6 @@ public class ObservedSpectrum extends UpdatableSpectrum implements Closable {
 
     public ObservedSpectrum(DaeObservables observables) {
 		this.observables = observables;
-	}
-	
-	@Override
-	public void setNumber(int value) {
-		super.setNumber(value);
-	}
-
-	@Override
-	public void setPeriod(int value) {
-		super.setPeriod(value);
 	}
 	
 	@Override

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectra.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectra.java
@@ -49,7 +49,7 @@ public class Spectra extends Closer {
 	private void addSpectrum(int spectrum, int period) {
 		
 		Preferences preferenceStore = ConfigurationScope.INSTANCE
-				.getNode("uk.ac.stfc.isis.ibex.instrument").node("spectrapreferences" + spectrum);
+				.getNode("uk.ac.stfc.isis.ibex.dae.spectra").node("preferences" + spectrum);
 		
 		UpdatableSpectrum spec = registerForClose(new ObservedSpectrum(preferenceStore, observables));
 		

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectra.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectra.java
@@ -22,6 +22,9 @@ package uk.ac.stfc.isis.ibex.dae.spectra;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.osgi.service.prefs.Preferences;
+
 import uk.ac.stfc.isis.ibex.dae.DaeObservables;
 import uk.ac.stfc.isis.ibex.epics.pv.Closer;
 
@@ -43,10 +46,13 @@ public class Spectra extends Closer {
 		return spectra;
 	}
 
-	private void addSpectrum(int spectrum, int period) {	
-		UpdatableSpectrum spec = registerForClose(new ObservedSpectrum(observables));
-		spec.setNumber(spectrum);
-		spec.setPeriod(period);
+	private void addSpectrum(int spectrum, int period) {
+		
+		Preferences preferenceStore = ConfigurationScope.INSTANCE
+				.getNode("uk.ac.stfc.isis.ibex.instrument").node("spectrapreferences" + spectrum);
+		
+		UpdatableSpectrum spec = registerForClose(new ObservedSpectrum(preferenceStore, observables));
+		
 		spec.update();
 		
 		spectra.add(spec);

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectra.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectra.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.osgi.service.prefs.Preferences;
 
+import uk.ac.stfc.isis.ibex.dae.Dae;
 import uk.ac.stfc.isis.ibex.dae.DaeObservables;
 import uk.ac.stfc.isis.ibex.epics.pv.Closer;
 
@@ -48,8 +49,10 @@ public class Spectra extends Closer {
 
 	private void addSpectrum(int spectrum, int period) {
 		
+		// This breaks if it tries to use it's own preference store so
+		// it has to share the one from uk.ac.stfc.isis.ibex.instrument
 		Preferences preferenceStore = ConfigurationScope.INSTANCE
-				.getNode("uk.ac.stfc.isis.ibex.dae.spectra").node("preferences" + spectrum);
+				.getNode("uk.ac.stfc.isis.ibex.instrument").node("spectrumPreferences" + spectrum);
 		
 		UpdatableSpectrum spec = registerForClose(new ObservedSpectrum(preferenceStore, observables));
 		

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
@@ -27,6 +27,7 @@ public class Spectrum extends ModelObject {
 	private int period;
 	private double[] xData = new double[2];
 	private double[] yData = new double[2];
+	private int spectrumYAxisTypeSelectionIndex = 0;
 	
 	public int getNumber() {
 		return number;
@@ -52,11 +53,31 @@ public class Spectrum extends ModelObject {
 		return yData;
 	}
 	
+	public void setTypeSelectionIndex(int type) {
+		System.out.println("Set the thing to " + type);
+		firePropertyChange("typeSelectionIndex", spectrumYAxisTypeSelectionIndex, spectrumYAxisTypeSelectionIndex = type);
+	}
+	
+	public int getTypeSelectionIndex() {
+		return spectrumYAxisTypeSelectionIndex;
+	}
+
+	
 	protected void setXData(double[] value) {
 		firePropertyChange("xData", xData, xData = value);
 	}
 	
 	protected void setYData(double[] value) {
+		System.out.println("Setting data, " + spectrumYAxisTypeSelectionIndex);
+		if (spectrumYAxisTypeSelectionIndex == 0) {
+			for (int i = 0; i<value.length; i++) {
+				try {
+					value[i] *= Math.abs(xData[i+1] - xData[i]);
+				} catch (ArrayIndexOutOfBoundsException e){
+					value[i] = 0;
+				}
+			}
+		}
 		firePropertyChange("yData", yData, yData = value);
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
@@ -94,7 +94,22 @@ public class Spectrum extends ModelObject {
 	 * @return the Y data.
 	 */
 	public double[] yData() {
-		return yData;
+		double[] value = yData.clone();
+		if (SpectrumYAxisTypes.values()[spectrumYAxisTypeSelectionIndex] == SpectrumYAxisTypes.ABSOLUTE_COUNTS) {
+			if (value.length != xData.length) {
+				for (int i=0; i<value.length; i++) {
+					// Can't calculate widths if the lengths aren't the same.
+					// Just set everything to zero
+					value[i] = 0;
+				}
+			} else {
+				for (int i=0; i<value.length - 1; i++) {
+					value[i] *= Math.abs(xData[i+1] - xData[i]);
+				}
+				value[value.length - 1] = 0;
+			}
+		}
+		return value;
 	}
 	
 	/**
@@ -132,21 +147,6 @@ public class Spectrum extends ModelObject {
 	 * @param value the data to set.
 	 */
 	public void setYData(double[] value) {
-		if (SpectrumYAxisTypes.values()[spectrumYAxisTypeSelectionIndex] == SpectrumYAxisTypes.ABSOLUTE_COUNTS) {
-			
-			if (value.length != xData.length) {
-				for (int i=0; i<value.length; i++) {
-					// Can't calculate widths if the lengths aren't the same.
-					// Just set everything to zero
-					value[i] = 0;
-				}
-			} else {
-				for (int i=0; i<value.length - 1; i++) {
-					value[i] *= Math.abs(xData[i+1] - xData[i]);
-				}
-				value[value.length - 1] = 0;
-			}
-		}
 		firePropertyChange("yData", yData, yData = value);
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
@@ -27,6 +27,7 @@ public class Spectrum extends ModelObject {
 	private int period;
 	private double[] xData = new double[2];
 	private double[] yData = new double[2];
+	
 	private int spectrumYAxisTypeSelectionIndex = 0;
 	
 	public int getNumber() {
@@ -54,7 +55,6 @@ public class Spectrum extends ModelObject {
 	}
 	
 	public void setTypeSelectionIndex(int type) {
-		System.out.println("Set the thing to " + type);
 		firePropertyChange("typeSelectionIndex", spectrumYAxisTypeSelectionIndex, spectrumYAxisTypeSelectionIndex = type);
 	}
 	
@@ -68,8 +68,7 @@ public class Spectrum extends ModelObject {
 	}
 	
 	protected void setYData(double[] value) {
-		System.out.println("Setting data, " + spectrumYAxisTypeSelectionIndex);
-		if (spectrumYAxisTypeSelectionIndex == 0) {
+		if (SpectrumYAxisTypes.values()[spectrumYAxisTypeSelectionIndex] == SpectrumYAxisTypes.ABSOLUTE_COUNTS) {
 			for (int i = 0; i<value.length; i++) {
 				try {
 					value[i] *= Math.abs(xData[i+1] - xData[i]);

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
@@ -21,6 +21,9 @@ package uk.ac.stfc.isis.ibex.dae.spectra;
 
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
+/**
+ * The view model for a single spectrum plot.
+ */
 public class Spectrum extends ModelObject {
 
 	private int number;
@@ -30,44 +33,88 @@ public class Spectrum extends ModelObject {
 	
 	private int spectrumYAxisTypeSelectionIndex = 0;
 	
+	/**
+	 * Gets the spectrum number.
+	 * @return the spectrum number
+	 */
 	public int getNumber() {
 		return number;
 	}
 	
+	/**
+	 * Sets the spectrum number.
+	 * @param value the new spectrum number
+	 */
 	public void setNumber(int value) {
 		firePropertyChange("number", number, number = value);
 	}
 	
+	/**
+	 * Gets the period of this spectrum.
+	 * @return the period
+	 */
 	public int getPeriod() {
 		return period;
 	}
 	
+	/**
+	 * The period of this spectrum.
+	 * @param value the new period
+	 */
 	public void setPeriod(int value) {
 		firePropertyChange("period", period, period = value);
 	}
 	
+	/**
+	 * The X data of this spectrum.
+	 * @return the X data.
+	 */
 	public double[] xData() {
 		return xData;
 	}
 		
+	/**
+	 * The Y data of this spectrum.
+	 * @return the Y data.
+	 */
 	public double[] yData() {
 		return yData;
 	}
 	
+	/**
+	 * Sets the selection index of the Y axis type.
+	 * 
+	 * This is an index into the {@link SpectrumYAxisTypes} enum.
+	 */
 	public void setTypeSelectionIndex(int type) {
 		firePropertyChange("typeSelectionIndex", spectrumYAxisTypeSelectionIndex, spectrumYAxisTypeSelectionIndex = type);
 	}
 	
+	/**
+	 * Gets the selection index of the Y axis type.
+	 * 
+	 * This is an index into the {@link SpectrumYAxisTypes} enum.
+	 * 
+	 * @return the type selection index
+	 */
 	public int getTypeSelectionIndex() {
 		return spectrumYAxisTypeSelectionIndex;
 	}
 
-	
-	protected void setXData(double[] value) {
+
+	/**
+	 * Sets the X data array for this spectrum.
+	 * @param value the data to set.
+	 */
+	public void setXData(double[] value) {
 		firePropertyChange("xData", xData, xData = value);
 	}
 	
-	protected void setYData(double[] value) {
+	/**
+	 * Sets the Y data array for this spectrum.
+	 * @param value the data to set.
+	 */
+	public void setYData(double[] value) {
 		if (SpectrumYAxisTypes.values()[spectrumYAxisTypeSelectionIndex] == SpectrumYAxisTypes.ABSOLUTE_COUNTS) {
 			for (int i = 0; i<value.length; i++) {
 				try {

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
@@ -133,12 +133,18 @@ public class Spectrum extends ModelObject {
 	 */
 	public void setYData(double[] value) {
 		if (SpectrumYAxisTypes.values()[spectrumYAxisTypeSelectionIndex] == SpectrumYAxisTypes.ABSOLUTE_COUNTS) {
-			for (int i = 0; i<value.length; i++) {
-				try {
-					value[i] *= Math.abs(xData[i+1] - xData[i]);
-				} catch (ArrayIndexOutOfBoundsException e){
+			
+			if (value.length != xData.length) {
+				for (int i=0; i<value.length; i++) {
+					// Can't calculate widths if the lengths aren't the same.
+					// Just set everything to zero
 					value[i] = 0;
 				}
+			} else {
+				for (int i=0; i<value.length - 1; i++) {
+					value[i] *= Math.abs(xData[i+1] - xData[i]);
+				}
+				value[value.length - 1] = 0;
 			}
 		}
 		firePropertyChange("yData", yData, yData = value);

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/Spectrum.java
@@ -19,6 +19,8 @@
 
 package uk.ac.stfc.isis.ibex.dae.spectra;
 
+import org.osgi.service.prefs.Preferences;
+
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
 /**
@@ -32,6 +34,18 @@ public class Spectrum extends ModelObject {
 	private double[] yData = new double[2];
 	
 	private int spectrumYAxisTypeSelectionIndex = 0;
+	private Preferences preferences;
+	
+	/**
+	 * Constructor.
+	 * @param preferenceStore the preference store to use.
+	 */
+	public Spectrum(Preferences preferenceStore) {
+		this.preferences = preferenceStore;
+		setNumber(preferences.getInt("spectrumNumber", 1));
+		setPeriod(preferences.getInt("period", 1));
+		setTypeSelectionIndex(preferences.getInt("typeSelectionIndex", 0));
+	}
 	
 	/**
 	 * Gets the spectrum number.
@@ -47,6 +61,7 @@ public class Spectrum extends ModelObject {
 	 */
 	public void setNumber(int value) {
 		firePropertyChange("number", number, number = value);
+		preferences.putInt("spectrumNumber", number);
 	}
 	
 	/**
@@ -63,6 +78,7 @@ public class Spectrum extends ModelObject {
 	 */
 	public void setPeriod(int value) {
 		firePropertyChange("period", period, period = value);
+		preferences.putInt("period", period);
 	}
 	
 	/**
@@ -88,8 +104,9 @@ public class Spectrum extends ModelObject {
 	 */
 	public void setTypeSelectionIndex(int type) {
 		firePropertyChange("typeSelectionIndex", spectrumYAxisTypeSelectionIndex, spectrumYAxisTypeSelectionIndex = type);
+		preferences.putInt("typeSelectionIndex", spectrumYAxisTypeSelectionIndex);
 	}
-	
+
 	/**
 	 * Gets the selection index of the Y axis type.
 	 * 

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
@@ -1,0 +1,8 @@
+package uk.ac.stfc.isis.ibex.dae.spectra;
+
+public enum SpectrumYAxisTypes {
+	/* Enum constant indicating the Y axis is a count rate, in counts per microsecond. */
+	COUNT_RATE,
+	/* Enum constant indicating the Y axis is showing cumulative counts. */
+	ABSOLUTE_COUNTS
+}

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
@@ -1,8 +1,10 @@
 package uk.ac.stfc.isis.ibex.dae.spectra;
 
+import uk.ac.stfc.isis.ibex.ui.Utils;
+
 public enum SpectrumYAxisTypes {
 	/* Enum constant indicating the Y axis is a count rate, in counts per microsecond. */
-	COUNT_RATE("Counts /s"),
+	COUNT_RATE("Counts (/" + Utils.MU + "s)"),
 	/* Enum constant indicating the Y axis is showing cumulative counts. */
 	ABSOLUTE_COUNTS("Counts");
 	

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
@@ -7,7 +7,7 @@ import uk.ac.stfc.isis.ibex.ui.Utils;
  */
 public enum SpectrumYAxisTypes {
 	/* Enum constant indicating the Y axis is a count rate, in counts per microsecond. */
-	COUNT_RATE("Counts (/" + Utils.MU + "s)"),
+	COUNT_RATE("Counts/" + Utils.MU + "s"),
 	/* Enum constant indicating the Y axis is showing cumulative counts. */
 	ABSOLUTE_COUNTS("Counts");
 	

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
@@ -2,6 +2,9 @@ package uk.ac.stfc.isis.ibex.dae.spectra;
 
 import uk.ac.stfc.isis.ibex.ui.Utils;
 
+/**
+ * Enum representing the possible Y axes on a spectrum plot.
+ */
 public enum SpectrumYAxisTypes {
 	/* Enum constant indicating the Y axis is a count rate, in counts per microsecond. */
 	COUNT_RATE("Counts (/" + Utils.MU + "s)"),
@@ -14,6 +17,9 @@ public enum SpectrumYAxisTypes {
 		this.name = name;
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	public String toString() {
 		return this.name;
 	}

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
@@ -2,7 +2,17 @@ package uk.ac.stfc.isis.ibex.dae.spectra;
 
 public enum SpectrumYAxisTypes {
 	/* Enum constant indicating the Y axis is a count rate, in counts per microsecond. */
-	COUNT_RATE,
+	COUNT_RATE("Counts /s"),
 	/* Enum constant indicating the Y axis is showing cumulative counts. */
-	ABSOLUTE_COUNTS
+	ABSOLUTE_COUNTS("Counts");
+	
+	private String name;
+	
+	private SpectrumYAxisTypes(String name) {
+		this.name = name;
+	}
+	
+	public String toString() {
+		return this.name;
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/UpdatableSpectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/UpdatableSpectrum.java
@@ -21,28 +21,48 @@ package uk.ac.stfc.isis.ibex.dae.spectra;
 
 import org.osgi.service.prefs.Preferences;
 
+/**
+ * An updatable spectrum.
+ */
 public class UpdatableSpectrum extends Spectrum {
 
 	private boolean requiresUpdate;
 	
+	/**
+	 * Constructor.
+	 * @param preferenceStore the preference store to use.
+	 */
 	public UpdatableSpectrum(Preferences preferenceStore){
 		super(preferenceStore);
 	}
 
+	/**
+	 * Whether the spectrum requires an update.
+	 * @return true if it requires an update, false otherwise
+	 */
 	public boolean getRequiresUpdate() {
 		return requiresUpdate;
 	}
 	
+	/**
+	 * Trigger an update of the spectrum.
+	 */
 	public void update() {
 		firePropertyChange("requiresUpdate", requiresUpdate, requiresUpdate = false);
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void setNumber(int value) {
 		super.setNumber(value);
 		firePropertyChange("requiresUpdate", requiresUpdate, requiresUpdate = true);
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void setPeriod(int value) {
 		super.setPeriod(value);

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/UpdatableSpectrum.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/UpdatableSpectrum.java
@@ -19,9 +19,15 @@
 
 package uk.ac.stfc.isis.ibex.dae.spectra;
 
+import org.osgi.service.prefs.Preferences;
+
 public class UpdatableSpectrum extends Spectrum {
 
 	private boolean requiresUpdate;
+	
+	public UpdatableSpectrum(Preferences preferenceStore){
+		super(preferenceStore);
+	}
 
 	public boolean getRequiresUpdate() {
 		return requiresUpdate;

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectraPlotsPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectraPlotsPanel.java
@@ -19,6 +19,7 @@
 
 package uk.ac.stfc.isis.ibex.ui.dae.spectra;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.swt.SWT;
@@ -34,10 +35,8 @@ import uk.ac.stfc.isis.ibex.dae.spectra.UpdatableSpectrum;
 @SuppressWarnings("checkstyle:magicnumber")
 public class SpectraPlotsPanel extends Composite {
 
-	private SpectrumView plot1;
-	private SpectrumView plot2;
-	private SpectrumView plot3;
-	private SpectrumView plot4;
+	private static final int NUMBER_OF_SPECTRA = 4;
+	private List<SpectrumView> spectraPlots = new ArrayList<>(NUMBER_OF_SPECTRA);
 	private Composite plots;
 	
     /**
@@ -53,36 +52,30 @@ public class SpectraPlotsPanel extends Composite {
 		setLayout(new GridLayout(1, false));
 		
 		plots = new Composite(this, SWT.NONE);
-		plots.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+		plots.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 		plots.setLayout(new GridLayout(2, false));
 		
-		plot1 = new SpectrumView(plots, SWT.NONE);
-		plot1.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-		plot1.setSize(398, 258);
-		
-		plot2 = new SpectrumView(plots, SWT.NONE);
-		plot2.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-		plot2.setSize(399, 258);
-		
-		plot3 = new SpectrumView(plots, SWT.NONE);
-		plot3.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-		plot3.setSize(398, 258);
-		
-		plot4 = new SpectrumView(plots, SWT.NONE);
-		plot4.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-		plot4.setSize(399, 258);
+		for (int i=0; i<NUMBER_OF_SPECTRA; i++){
+			SpectrumView plot = new SpectrumView(plots, SWT.NONE);
+			plot.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+			spectraPlots.add(plot);
+		}
 	}
 	
     /**
      * Set the model which the spectra graphs are updated from.
      * 
      * @param spectra
-     *            A list of four updating spectrum
+     *            A list of NUMBER_OF_SPECTRA updating spectrum
      */
 	public void setModel(List<? extends UpdatableSpectrum> spectra) {
-		plot1.setModel(spectra.get(0));
-		plot2.setModel(spectra.get(1));
-		plot3.setModel(spectra.get(2));
-		plot4.setModel(spectra.get(3));
+		
+		if (spectra.size() != NUMBER_OF_SPECTRA) {
+			throw new RuntimeException("The number of spectra view models should be the same as the number of spectra!");
+		}
+		
+		for (int i=0; i<NUMBER_OF_SPECTRA; i++) {
+			spectraPlots.get(i).setModel(spectra.get(i));
+		}
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumPlot.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumPlot.java
@@ -79,6 +79,7 @@ public class SpectrumPlot extends Canvas {
 		@Override
 		public void propertyChange(PropertyChangeEvent e) {
 			updateYAxisTitle();
+			setYData();
 		}
 	};
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumPlot.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumPlot.java
@@ -35,6 +35,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 
 import uk.ac.stfc.isis.ibex.dae.spectra.Spectrum;
+import uk.ac.stfc.isis.ibex.dae.spectra.SpectrumYAxisTypes;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.ui.Utils;
 
@@ -73,6 +74,13 @@ public class SpectrumPlot extends Canvas {
 			setYData();
 		}
 	};
+
+	private final PropertyChangeListener typeSelectionIndexListener =  new PropertyChangeListener() {	
+		@Override
+		public void propertyChange(PropertyChangeEvent e) {
+			updateYAxisTitle();
+		}
+	};
 	
     /**
      * Instantiates a new spectrum plot.
@@ -107,7 +115,7 @@ public class SpectrumPlot extends Canvas {
         plot.getPrimaryXAxis().setAutoScaleThreshold(0);
         plot.getPrimaryXAxis().setFormatPattern("0");
 
-        plot.getPrimaryYAxis().setTitle("Count (/" + Utils.MU + "s)");
+        plot.getPrimaryYAxis().setTitle("");
 		plot.getPrimaryYAxis().setDashGridLine(true);
 		plot.getPrimaryYAxis().setAutoScale(true);
         plot.getPrimaryYAxis().setAutoScaleThreshold(0);
@@ -125,19 +133,28 @@ public class SpectrumPlot extends Canvas {
 		if (spectrum != null) {
 			spectrum.removePropertyChangeListener(xDataListener);
 			spectrum.removePropertyChangeListener(yDataListener);
+			spectrum.removePropertyChangeListener(typeSelectionIndexListener);
 		}
 		
 		spectrum = newSpectrum;
 		spectrum.addPropertyChangeListener("xData", xDataListener);
 		spectrum.addPropertyChangeListener("yData", yDataListener);
+		spectrum.addPropertyChangeListener("typeSelectionIndex", typeSelectionIndexListener);
 
 		if (spectrum.xData().length > DAE_SPECTRUM_BUFFER_SIZE || spectrum.yData().length > DAE_SPECTRUM_BUFFER_SIZE) {
             LOG.warn("DAE graph is clipped because DAE_SPECTRUM_BUFFER_SIZE is not large enough.");
 		}
 		
 		traceDataProvider.clearTrace();
+		
+		updateYAxisTitle();
         
 		updateData();
+	}
+	
+	private void updateYAxisTitle() {
+		plot.getPrimaryYAxis().setTitle(
+				SpectrumYAxisTypes.values()[spectrum.getTypeSelectionIndex()].toString());
 	}
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumPlot.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumPlot.java
@@ -98,20 +98,21 @@ public class SpectrumPlot extends Canvas {
         traceDataProvider.setConcatenate_data(false);
         traceDataProvider.setUpdateMode(UpdateMode.X_OR_Y);
 
-		trace = new Trace("Spectrum", plot.primaryXAxis, plot.primaryYAxis, traceDataProvider);
+		trace = new Trace("Spectrum", plot.getPrimaryXAxis(), plot.getPrimaryYAxis(), traceDataProvider);
 		trace.setAntiAliasing(true);
 		
-        plot.primaryXAxis.setTitle("Time-of-flight (" + Utils.MU + "s)");
-		plot.primaryXAxis.setDashGridLine(true);
-		plot.primaryXAxis.setAutoScale(true);
-        plot.primaryXAxis.setAutoScaleThreshold(0);
-        plot.primaryXAxis.setFormatPattern("0");
-				
-        plot.primaryYAxis.setTitle("Count (/" + Utils.MU + "s)");
-		plot.primaryYAxis.setDashGridLine(true);
-		plot.primaryYAxis.setAutoScale(true);
-        plot.primaryYAxis.setAutoScaleThreshold(0);
-        plot.primaryYAxis.setFormatPattern("0");
+        plot.getPrimaryXAxis().setTitle("Time-of-flight (" + Utils.MU + "s)");
+		plot.getPrimaryXAxis().setDashGridLine(true);
+		plot.getPrimaryXAxis().setAutoScale(true);
+        plot.getPrimaryXAxis().setAutoScaleThreshold(0);
+        plot.getPrimaryXAxis().setFormatPattern("0");
+
+        plot.getPrimaryYAxis().setTitle("Count (/" + Utils.MU + "s)");
+		plot.getPrimaryYAxis().setDashGridLine(true);
+		plot.getPrimaryYAxis().setAutoScale(true);
+        plot.getPrimaryYAxis().setAutoScaleThreshold(0);
+        plot.getPrimaryYAxis().setFormatPattern("0");
+        
 		plot.addTrace(trace);
 	}
 
@@ -142,7 +143,7 @@ public class SpectrumPlot extends Canvas {
     /**
      * Update both the x and y data.
      */
-    public void updateData() {
+    private void updateData() {
         setXData();
 		setYData();
     }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumView.java
@@ -90,15 +90,12 @@ public class SpectrumView extends Composite {
         period.setMinimum(0);
         period.setMaximum(MAXIMUM_MONITOR_SPECTRUM);
         
-        spectrumType = new Combo(this, SWT.BORDER);
+        spectrumType = new Combo(this, SWT.BORDER | SWT.DROP_DOWN | SWT.READ_ONLY);
         String[] s = new String[SpectrumYAxisTypes.values().length];
         for (int i = 0; i<SpectrumYAxisTypes.values().length; i++) {
         	s[i] = SpectrumYAxisTypes.values()[i].toString();
         }
         spectrumType.setItems(s);
-
-		new Label(this, SWT.NONE);
-		new Label(this, SWT.NONE);
 
 		spectrumFigure = new SpectrumPlot(this, SWT.NONE);
         spectrumFigure.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 6, 1));
@@ -115,9 +112,8 @@ public class SpectrumView extends Composite {
 		bindingContext = new DataBindingContext();
 		bindingContext.bindValue(WidgetProperties.selection().observe(number), BeanProperties.value("number").observe(updatableSpectrum));
 		bindingContext.bindValue(WidgetProperties.selection().observe(period), BeanProperties.value("period").observe(updatableSpectrum));		
-		bindingContext.bindValue(WidgetProperties.singleSelectionIndex().observe(spectrumType), BeanProperties.value("typeSelectionIndex").observe(updatableSpectrum));
-
-		System.out.println("Bound the thing.");
+		bindingContext.bindValue(WidgetProperties.singleSelectionIndex().observe(spectrumType), 
+				BeanProperties.value("typeSelectionIndex").observe(updatableSpectrum));
 
         spectrum.addPropertyChangeListener(new PropertyChangeListener() {
             @Override

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/spectra/SpectrumView.java
@@ -30,10 +30,12 @@ import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Spinner;
 
+import uk.ac.stfc.isis.ibex.dae.spectra.SpectrumYAxisTypes;
 import uk.ac.stfc.isis.ibex.dae.spectra.UpdatableSpectrum;
 
 /**
@@ -43,6 +45,7 @@ public class SpectrumView extends Composite {
 	
     private Spinner number;
     private Spinner period;
+    private Combo spectrumType;
 	private SpectrumPlot spectrumFigure;
     private Timer timer = new Timer();
     private TimerTask timerTask;
@@ -86,6 +89,13 @@ public class SpectrumView extends Composite {
 		period.setLayoutData(gd_period);
         period.setMinimum(0);
         period.setMaximum(MAXIMUM_MONITOR_SPECTRUM);
+        
+        spectrumType = new Combo(this, SWT.BORDER);
+        String[] s = new String[SpectrumYAxisTypes.values().length];
+        for (int i = 0; i<SpectrumYAxisTypes.values().length; i++) {
+        	s[i] = SpectrumYAxisTypes.values()[i].toString();
+        }
+        spectrumType.setItems(s);
 
 		new Label(this, SWT.NONE);
 		new Label(this, SWT.NONE);
@@ -104,7 +114,10 @@ public class SpectrumView extends Composite {
 		
 		bindingContext = new DataBindingContext();
 		bindingContext.bindValue(WidgetProperties.selection().observe(number), BeanProperties.value("number").observe(updatableSpectrum));
-		bindingContext.bindValue(WidgetProperties.selection().observe(period), BeanProperties.value("period").observe(updatableSpectrum));
+		bindingContext.bindValue(WidgetProperties.selection().observe(period), BeanProperties.value("period").observe(updatableSpectrum));		
+		bindingContext.bindValue(WidgetProperties.singleSelectionIndex().observe(spectrumType), BeanProperties.value("typeSelectionIndex").observe(updatableSpectrum));
+
+		System.out.println("Bound the thing.");
 
         spectrum.addPropertyChangeListener(new PropertyChangeListener() {
             @Override


### PR DESCRIPTION
### Description of work

Adds the ability to select whether to display the DAE spectra plots in "counts /s" (same as what we currently have) or "counts" (which SANDALS want).

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2687

### Acceptance criteria

- [x] Can select between the two different spectra modes
- [x] Spectra look the same as before in "counts /s" mode
- [x] Spectra look appropriate in "counts" mode
  * The easiest way to see this is to find an instrument with a discontinuity in their time channel binnings, and check that this translates to a discontinuity on the spectra plots.
- [x] The Y-axis label on the spectra plot updates based on the mode that is selected
- [x] Spectra settings are saved in the eclipse preference store. To test this:
  * Start an ibex client
  * Select a few different settings on the spectra screen for spectrum numbers, period and axis types
  * Restart the client
  * Verify that the settings are the same as you just set.

### Unit tests

I've added some unit tests to check that a test spectra gets scaled appropriately when in absolute counts mode, and is unchanged when in count rate mode.

### System tests

Discussed RCPTT with @John-Holt-Tessella but we decided this was too hard for minimal gain. I have modified the manual system test speadsheet to explicitly include a test for the new functionality (Test 6-20).

### Documentation

No new documentation added - not needed for this change.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

