### PR TITLE
Fix DAE buttons being greyed out in setup

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/actions/DaeAction.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/actions/DaeAction.java
@@ -123,12 +123,12 @@ public abstract class DaeAction extends Action implements Closable {
 	}
 
 	@Override
-	public void execute() {
+	public synchronized void execute() {
 	    actionWriter.uncheckedWrite("1");
 	}
 
 	@Override
-	public void close() {
+	public synchronized void close() {
 		runStateSubscription.removeObserver();
 		transitionSubscription.removeObserver();
 		targetSubscribtion.removeObserver();
@@ -145,22 +145,22 @@ public abstract class DaeAction extends Action implements Closable {
      */
 	protected abstract boolean allowed(DaeRunState runState);
 	
-	private void setCanWrite(boolean canWrite) {
+	private synchronized void setCanWrite(boolean canWrite) {
 		this.canWrite = canWrite;
 		setCanExecute(canExecute());
 	}
 	
-	private void setInTransition(boolean inTransition) {
+	private synchronized void setInTransition(boolean inTransition) {
 		this.inTransition = inTransition;
 		setCanExecute(canExecute());
 	}
 	
-	private void setRunState(DaeRunState runState) {
+	private synchronized void setRunState(DaeRunState runState) {
 		this.runState = runState;
 		setCanExecute(canExecute());
 	}
 	
-	private boolean canExecute() {
+	private synchronized boolean canExecute() {
 		return canWrite && !inTransition && allowed(runState);
 	}
 }


### PR DESCRIPTION
### Description of work

Fixes a case where (I think) two threads were entering the same non-threadsafe method simultaneously, causing some DAE buttons to be in the incorrect state. This applies to all the DAE buttons (Start run, stop run, apply changes, etc).

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2643

### Acceptance criteria

- [x] Cannot reproduce the issue with DAE buttons being greyed out. Testing method described below:

Firstly, set up your ICP so that it won't die when doing many runs:
- In `C:\Instrument\Apps\EPICS\ICP_Binaries\isisicp.properties`, add the line `isisicp.asyncend = false`
- In `C:\Instrument\Apps\EPICS\ICP_Binaries\icp_config.xml` set CRPTSize to 60000000
- Stop the ISISDAE ioc
- Kill the ISISICP process from task manager
- Restart the ISISDAE ioc (this will automatically restart ICP)
- Ensure you have valid wiring/spectra tables etc so that you are able to start a run.

Using the master branch:
- Run `C:\Instrument\Dev\ibex_gui\build\build.bat`
- Verify that the RCPTT test sometimes fails with "Control is disabled" (you may need to run it more than once). If the test says "Execution timed out after 300s" then the test has passed - rerun it until it fails with the disabled control error.

Using this branch:
- Run `C:\Instrument\Dev\ibex_gui\build\build.bat`
- Verify that the RCPTT test always passes (note, if the test says "execution timeout after 300 seconds" this is treated as a pass - I tried increasing the overall timeout but it didn't work for me. A failure would be "control is disabled").

### Unit tests

This change is not possible to unit test.

### System tests

I've added a "helper" RCPTT test to start and stop many runs in quick succession. This test should (sometimes) fail with the old GUI and always pass with this change. However I don't think that this is appropriate to include in the main test suite as the test takes a long time and fails inconsistently even on the old version of the GUI.

### Documentation

None added for this minimal change - I think the ticket is sufficient to document the issue we had.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

