### PR TITLE
Add manager mode indicators

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/mymotor.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/mymotor.opi
@@ -1577,4 +1577,52 @@ $(pv_value)</tooltip>
       </font>
     </widget>
   </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
+    <border_style>0</border_style>
+    <tooltip></tooltip>
+    <horizontal_alignment>0</horizontal_alignment>
+    <rules>
+      <rule name="Rule" prop_id="visible" out_exp="false">
+        <exp bool_exp="pv0 != 0">
+          <value>true</value>
+        </exp>
+        <pv trig="true">$(P)$(MM):MANAGERMODE</pv>
+      </rule>
+    </rules>
+    <enabled>true</enabled>
+    <wuid>-1ffaaef:1602b08f77f:-7efb</wuid>
+    <transparent>false</transparent>
+    <auto_size>false</auto_size>
+    <text>To control this device, enable manager mode!</text>
+    <scripts />
+    <height>37</height>
+    <border_width>1</border_width>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <visible>false</visible>
+    <vertical_alignment>1</vertical_alignment>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <widget_type>Label</widget_type>
+    <wrap_words>true</wrap_words>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <width>443</width>
+    <x>2</x>
+    <name>Label_15</name>
+    <y>268</y>
+    <foreground_color>
+      <color name="Major" red="255" green="0" blue="0" />
+    </foreground_color>
+    <actions hook="false" hook_all="false" />
+    <show_scrollbar>false</show_scrollbar>
+    <font>
+      <opifont.name fontName="Segoe UI" height="14" style="1">ISIS_Header2_NEW</opifont.name>
+    </font>
+  </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/mymotor_v2.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/mymotor_v2.opi
@@ -1712,4 +1712,52 @@ $(pv_value)</tooltip>
       </font>
     </widget>
   </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
+    <border_style>0</border_style>
+    <tooltip></tooltip>
+    <horizontal_alignment>0</horizontal_alignment>
+    <rules>
+      <rule name="Rule" prop_id="visible" out_exp="false">
+        <exp bool_exp="pv0 != 0">
+          <value>true</value>
+        </exp>
+        <pv trig="true">$(P)$(MM):MANAGERMODE</pv>
+      </rule>
+    </rules>
+    <enabled>true</enabled>
+    <wuid>-1ffaaef:1602b08f77f:-7ea7</wuid>
+    <transparent>false</transparent>
+    <auto_size>false</auto_size>
+    <text>To control this device, enable manager mode!</text>
+    <scripts />
+    <height>37</height>
+    <border_width>1</border_width>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <visible>false</visible>
+    <vertical_alignment>1</vertical_alignment>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <widget_type>Label</widget_type>
+    <wrap_words>true</wrap_words>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <width>443</width>
+    <x>2</x>
+    <name>Label_15</name>
+    <y>245</y>
+    <foreground_color>
+      <color name="Major" red="255" green="0" blue="0" />
+    </foreground_color>
+    <actions hook="false" hook_all="false" />
+    <show_scrollbar>false</show_scrollbar>
+    <font>
+      <opifont.name fontName="Segoe UI" height="14" style="1">ISIS_Header2_NEW</opifont.name>
+    </font>
+  </widget>
 </display>


### PR DESCRIPTION
### Description of work

Adds access security indicator to galil OPI as per https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-access-security

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2789

### Acceptance criteria

- Access security is set up.
- Indicator displays when access security is set up and not enabled
- Indicator does not display at other times.

### Unit tests

Not applicable

### System tests

Not applicable

### Documentation

Documentation at https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/IOC-access-security is sufficient

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

