### PR TITLE
Get content directory from DAE PVs, rather than building in place

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
@@ -242,6 +242,7 @@
 		<module>../uk.ac.stfc.isis.ibex.ui.configserver.tests</module>
 		<module>../uk.ac.stfc.isis.ibex.ui.scriptgenerator</module>
 		<module>../uk.ac.stfc.isis.ibex.scriptgenerator</module>
+		<module>../uk.ac.stfc.isis.ibex.ui.dae.tests</module>
 		<module>../uk.ac.stfc.isis.ibex.ui.dashboard.tests</module>
 		<module>../uk.ac.stfc.isis.ibex.ui.tests</module>
 		<module>../uk.ac.stfc.isis.ibex.ui.devicescreens.tests</module>

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeObservables.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeObservables.java
@@ -49,6 +49,31 @@ public class DaeObservables {
     public final ForwardingObservable<String> instrumentName;
 
     /**
+     * An observable on the name of the instrument.
+     */
+    public final ForwardingObservable<String> periodFilesDir;
+
+    /**
+     * An observable on the name of the instrument.
+     */
+    public final ForwardingObservable<String> timeChannelsDir;
+
+    /**
+     * An observable on the name of the instrument.
+     */
+    public final ForwardingObservable<String> wiringTablesDir;
+
+    /**
+     * An observable on the name of the instrument.
+     */
+    public final ForwardingObservable<String> detectorTablesDir;
+
+    /**
+     * An observable on the name of the instrument.
+     */
+    public final ForwardingObservable<String> spectraTablesDir;
+
+    /**
      * An observable on the status of the run.
      */
     public final ForwardingObservable<DaeRunState> runState;
@@ -364,6 +389,16 @@ public class DaeObservables {
                 InstrumentUtils.addPrefix(DAE.endWith("MONITORTO")));
         npRatio = obsFactory.getSwitchableObservable(new DoubleChannel(),
                 InstrumentUtils.addPrefix(DAE.endWith("NPRATIO")));
+        periodFilesDir = obsFactory.getSwitchableObservable(new CharWaveformChannel(),
+                InstrumentUtils.addPrefix(DAE.endWith("PERIOD_DIR")));
+        timeChannelsDir = obsFactory.getSwitchableObservable(new CharWaveformChannel(),
+                InstrumentUtils.addPrefix(DAE.endWith("TCB_DIR")));
+        wiringTablesDir = obsFactory.getSwitchableObservable(new CharWaveformChannel(),
+                InstrumentUtils.addPrefix(DAE.endWith("WIRING_DIR")));
+        detectorTablesDir = obsFactory.getSwitchableObservable(new CharWaveformChannel(),
+                InstrumentUtils.addPrefix(DAE.endWith("DETECTOR_DIR")));
+        spectraTablesDir = obsFactory.getSwitchableObservable(new CharWaveformChannel(),
+                InstrumentUtils.addPrefix(DAE.endWith("SPECTRA_DIR")));
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeObservables.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeObservables.java
@@ -49,27 +49,27 @@ public class DaeObservables {
     public final ForwardingObservable<String> instrumentName;
 
     /**
-     * An observable on the name of the instrument.
+     * An observable on the directory containing the period files.
      */
     public final ForwardingObservable<String> periodFilesDir;
 
     /**
-     * An observable on the name of the instrument.
+     * An observable on the directory containing the time channel files.
      */
     public final ForwardingObservable<String> timeChannelsDir;
 
     /**
-     * An observable on the name of the instrument.
+     * An observable on the directory containing the wiring tables.
      */
     public final ForwardingObservable<String> wiringTablesDir;
 
     /**
-     * An observable on the name of the instrument.
+     * An observable on the directory containing the detector tables.
      */
     public final ForwardingObservable<String> detectorTablesDir;
 
     /**
-     * An observable on the name of the instrument.
+     * An observable on the directory containing the spectra tables.
      */
     public final ForwardingObservable<String> spectraTablesDir;
 

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/ExperimentSetup.java
@@ -198,45 +198,45 @@ public class ExperimentSetup extends Closer  {
     }
 
     /**
-     * Returns an Observable for the name of the current instrument.
+     * Returns an Observable for the directory containing the period files.
      * 
-     * @return The instrument name.
+     * @return The directory.
      */
     public ForwardingObservable<String> getPeriodFilesDir() {
         return periodFilesDir;
     }
 
     /**
-     * Returns an Observable for the name of the current instrument.
+     * Returns an Observable for the directory containing the time channel files.
      * 
-     * @return The instrument name.
+     * @return The directory.
      */
     public ForwardingObservable<String> getTimeChannelsDir() {
         return timeChannelsDir;
     }
 
     /**
-     * Returns an Observable for the name of the current instrument.
+     * Returns an Observable for the directory containing the wiring tables.
      * 
-     * @return The instrument name.
+     * @return The directory.
      */
     public ForwardingObservable<String> getWiringTablesDir() {
         return wiringTablesDir;
     }
 
     /**
-     * Returns an Observable for the name of the current instrument.
+     * Returns an Observable for the directory containing the detector tables.
      * 
-     * @return The instrument name.
+     * @return The directory.
      */
     public ForwardingObservable<String> getDetectorTablesDir() {
         return detectorTablesDir;
     }
 
     /**
-     * Returns an Observable for the name of the current instrument.
+     * Returns an Observable for the directory containing the spectra tables.
      * 
-     * @return The instrument name.
+     * @return The directory.
      */
     public ForwardingObservable<String> getSpectraTablesDir() {
         return spectraTablesDir;

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/experimentsetup/ExperimentSetup.java
@@ -53,7 +53,14 @@ public class ExperimentSetup extends Closer  {
 	private final UpdatedObservableAdapter<Collection<String>> wiringTables;
 	private final UpdatedObservableAdapter<Collection<String>> periodFiles;
     private final UpdatedObservableAdapter<Collection<String>> timeChannelFiles;
+    
     private final ForwardingObservable<String> instrumentName;
+    
+    private final ForwardingObservable<String> periodFilesDir;
+    private final ForwardingObservable<String> timeChannelsDir;
+    private final ForwardingObservable<String> wiringTablesDir;
+    private final ForwardingObservable<String> detectorTablesDir;
+    private final ForwardingObservable<String> spectraTablesDir;
 
     /**
      * Model of the experiment setup including DAE, period, time channel and
@@ -67,6 +74,12 @@ public class ExperimentSetup extends Closer  {
 		periodSettings = registerForClose(new ObservingPeriodSettings(observables.hardwarePeriods, writables.hardwarePeriods));
 		updateSettings = registerForClose(new ObservingUpdateSettings(observables.updateSettings, writables.updateSettings));
 		timeChannels = registerForClose(new ObservingTimeChannels(observables.timeChannelSettings, writables.timeChannelSettings));
+
+        periodFilesDir = observables.periodFilesDir;
+        timeChannelsDir = observables.timeChannelsDir;
+        wiringTablesDir = observables.wiringTablesDir;
+        detectorTablesDir = observables.detectorTablesDir;
+        spectraTablesDir = observables.spectraTablesDir;
 		
         instrumentName = observables.instrumentName;
 
@@ -182,5 +195,50 @@ public class ExperimentSetup extends Closer  {
      */
     public ForwardingObservable<String> getInstrumentName() {
         return instrumentName;
+    }
+
+    /**
+     * Returns an Observable for the name of the current instrument.
+     * 
+     * @return The instrument name.
+     */
+    public ForwardingObservable<String> getPeriodFilesDir() {
+        return periodFilesDir;
+    }
+
+    /**
+     * Returns an Observable for the name of the current instrument.
+     * 
+     * @return The instrument name.
+     */
+    public ForwardingObservable<String> getTimeChannelsDir() {
+        return timeChannelsDir;
+    }
+
+    /**
+     * Returns an Observable for the name of the current instrument.
+     * 
+     * @return The instrument name.
+     */
+    public ForwardingObservable<String> getWiringTablesDir() {
+        return wiringTablesDir;
+    }
+
+    /**
+     * Returns an Observable for the name of the current instrument.
+     * 
+     * @return The instrument name.
+     */
+    public ForwardingObservable<String> getDetectorTablesDir() {
+        return detectorTablesDir;
+    }
+
+    /**
+     * Returns an Observable for the name of the current instrument.
+     * 
+     * @return The instrument name.
+     */
+    public ForwardingObservable<String> getSpectraTablesDir() {
+        return spectraTablesDir;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/adapters/TextUpdatedObservableAdapter.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/adapters/TextUpdatedObservableAdapter.java
@@ -39,8 +39,7 @@ public class TextUpdatedObservableAdapter extends UpdatedObservableAdapter<Strin
 		super(new ForwardingObservable<>(observable));
 	}
 	
-	public TextUpdatedObservableAdapter(
-			ForwardingObservable<String> observable) {
+	public TextUpdatedObservableAdapter(ForwardingObservable<String> observable) {
 		super(observable);
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/.classpath
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/.classpath
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/.project
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>uk.ac.stfc.isis.ibex.ui.dae.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tests
+Bundle-SymbolicName: uk.ac.stfc.isis.ibex.ui.dae.tests
+Bundle-Version: 1.0.0.qualifier
+Fragment-Host: uk.ac.stfc.isis.ibex.ui.dashboard;bundle-version="1.0.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Require-Bundle: org.junit;bundle-version="4.11.0",
+ org.mockito;bundle-version="1.9.5"
+Import-Package: uk.ac.stfc.isis.ibex.ui.dae.experimentsetup

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/META-INF/MANIFEST.MF
@@ -7,4 +7,6 @@ Fragment-Host: uk.ac.stfc.isis.ibex.ui.dashboard;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.mockito;bundle-version="1.9.5"
-Import-Package: uk.ac.stfc.isis.ibex.ui.dae.experimentsetup
+Import-Package: uk.ac.stfc.isis.ibex.epics.observing,
+ uk.ac.stfc.isis.ibex.model,
+ uk.ac.stfc.isis.ibex.ui.dae.experimentsetup

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/build.properties
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>uk.ac.stfc.isis.ibex.ui.dashboard.tests</artifactId>
+  <artifactId>uk.ac.stfc.isis.ibex.ui.dae.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
   <parent>
   	<groupId>CSS_ISIS</groupId>

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>uk.ac.stfc.isis.ibex.ui.dashboard.tests</artifactId>
+  <packaging>eclipse-test-plugin</packaging>
+  <parent>
+  	<groupId>CSS_ISIS</groupId>
+  	<artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
+  	<version>1.0.0-SNAPSHOT</version>
+  	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
+  </parent>
+</project>

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/src/uk/ac/stfc/isis/ibex/ui/dae/tests/DAEComboContentProviderTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/src/uk/ac/stfc/isis/ibex/ui/dae/tests/DAEComboContentProviderTest.java
@@ -22,14 +22,12 @@
  */
 package uk.ac.stfc.isis.ibex.ui.dae.tests;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.stream.Collectors;
 
 import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
@@ -72,7 +70,14 @@ public class DAEComboContentProviderTest {
         String[] content = contentProvider.getContent(null, "mock");
 
         // Assert
-        assertTrue(Arrays.asList(content).stream().map(String::toLowerCase).collect(Collectors.joining(" ")).contains("error"));
+        boolean containsError = false;
+        for (String line : content) {
+        	if (line.toLowerCase().contains("error")) {
+        		containsError = true;
+        		break;
+        	}
+        }
+        assertTrue(containsError);
     }
 
     @Test
@@ -87,7 +92,14 @@ public class DAEComboContentProviderTest {
         String[] content = contentProvider.getContent(mockFileList, "mock");
 
         // Assert
-        assertTrue(Arrays.asList(content).stream().map(String::toString).collect(Collectors.joining(" ")).contains(MOCK_TABLE_DIR));
+        boolean containsDir = false;
+        for (String line : content) {
+        	if (line.contains(MOCK_TABLE_DIR)) {
+        		containsDir = true;
+        		break;
+        	}
+        }
+        assertTrue(containsDir);
     }
 
     @Test

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/src/uk/ac/stfc/isis/ibex/ui/dae/tests/DAEComboContentProviderTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/src/uk/ac/stfc/isis/ibex/ui/dae/tests/DAEComboContentProviderTest.java
@@ -1,0 +1,64 @@
+
+/*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.ui.dae.tests;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
+import uk.ac.stfc.isis.ibex.ui.dae.experimentsetup.DAEComboContentProvider;
+
+@SuppressWarnings({ "unchecked", "checkstyle:methodname", "checkstyle:magicnumber" })
+public class DAEComboContentProviderTest {
+
+	private static final String MOCK_TABLE_DIR = "C:\\Instrument\\Settings\\config\\NDXMOCK\\tables";
+    private ForwardingObservable<String> mockSource;
+
+    @Before
+    public void setUp() {
+        // Arrange
+        mockSource = mock(ForwardingObservable.class);
+        when(mockSource.currentError()).thenReturn(null);
+        when(mockSource.isConnected()).thenReturn(true);
+    }
+
+    @Test
+    public void
+            GIVEN_no_list_WHEN_content_requested_THEN_returned_value_contains_error_text() {
+    	
+    	// Arrange
+    	DAEComboContentProvider contentProvider = new DAEComboContentProvider(mockSource);
+    	
+        // Act
+        String[] content = contentProvider.getContent(null, "mock");
+
+        // Assert
+        assertTrue(Arrays.asList(content).stream().map(String::toLowerCase).collect(Collectors.joining(" ")).contains("error"));
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.dae.tests/src/uk/ac/stfc/isis/ibex/ui/dae/tests/DAEComboContentProviderTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae.tests/src/uk/ac/stfc/isis/ibex/ui/dae/tests/DAEComboContentProviderTest.java
@@ -39,6 +39,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 final class FileListStub extends UpdatedValue<Collection<String>> {
+	// Done with a stub rather than a mock because getValue returns a final that Mockito can't handle
+	
 	@Override
 	public void setValue(Collection<String> value) {
 		super.setValue(value);

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/META-INF/MANIFEST.MF
@@ -27,4 +27,5 @@ Require-Bundle: org.eclipse.ui,
  uk.ac.stfc.isis.ibex.logger;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Export-Package: uk.ac.stfc.isis.ibex.ui.dae
+Export-Package: uk.ac.stfc.isis.ibex.ui.dae,
+ uk.ac.stfc.isis.ibex.ui.dae.experimentsetup

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DAEComboContentProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DAEComboContentProvider.java
@@ -56,7 +56,7 @@ public class DAEComboContentProvider {
      * @return the resulting array.
      */
     private String[] valueOrEmpty(UpdatedValue<Collection<String>> updated) {
-        Collection<String> value = updated.getValue();
+    	Collection<String> value = updated != null ? updated.getValue() : null;
         return value != null ? value.toArray(new String[0]) : new String[0];
     }
 

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DAEComboContentProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DAEComboContentProvider.java
@@ -35,16 +35,17 @@ import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 public class DAEComboContentProvider {
     
     String instrumentName;
+    String dir;
 
     /**
-     * Constructor. Binds the name of the current instrument to display in
-     * messages.
+     * Constructor. Binds the directory containing the content to display in messages.
      * 
-     * @param instrument The instrument name.
+     * @param dir The directory where the content is
      */
-    public DAEComboContentProvider(ForwardingObservable<String> instrument) {
-        this.instrumentName = instrument.getValue();
-        instrument.addObserver(instrumentAdapter);
+    public DAEComboContentProvider(ForwardingObservable<String> dir) {
+        this.dir = dir.getValue();
+        dir.addObserver(dirAdapter);
+        
     }
 
     /**
@@ -94,10 +95,9 @@ public class DAEComboContentProvider {
 
             // Use a sensible default if the instrument name PV is not available
             // yet.
-            String instrument = this.instrumentName == null ? "<instrument>" : this.instrumentName;
+            String displayDir = this.dir != null ? this.dir : "C:\\Instrument\\Setting\\Config\\<instrument>\\...";
 
-            tables = new String[] { "None found in C:\\Instrument\\Settings\\config\\" + instrument
-                    + "\\configurations\\tables\\ (file name must contain \"" + pattern + "\")." };
+            tables = new String[] { "None found in " + displayDir + " (file name must contain \"" + pattern + "\")." };
         }
 
         return addBlank(tables);
@@ -109,14 +109,14 @@ public class DAEComboContentProvider {
      * 
      * @param instrumentName the name of the new instrument.
      */
-    private void setInstrumentName(String instrumentName) {
-        this.instrumentName = instrumentName;
+    private void setDir(String dir) {
+    	this.dir = dir;
     }
 
-    private final BaseObserver<String> instrumentAdapter = new BaseObserver<String>() {
+    private final BaseObserver<String> dirAdapter = new BaseObserver<String>() {
         @Override
         public void onValue(String value) {
-            setInstrumentName(value);
+            setDir(value);
         }
     };
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DataAcquisitionViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DataAcquisitionViewModel.java
@@ -41,7 +41,9 @@ public class DataAcquisitionViewModel extends ModelObject {
 
 	private DaeSettings settings;
 	private UpdateSettings updateSettings;
-    private DAEComboContentProvider comboContentProvider;
+    private DAEComboContentProvider wiringComboContentProvider;
+    private DAEComboContentProvider detectorComboContentProvider;
+    private DAEComboContentProvider spectraComboContentProvider;
 	private UpdatedValue<Collection<String>> wiringTables;
 	private UpdatedValue<Collection<String>> detectorTables;
 	private UpdatedValue<Collection<String>> spectraTables;
@@ -189,7 +191,7 @@ public class DataAcquisitionViewModel extends ModelObject {
      * @return the list of wiring tables.
      */
     public String[] getWiringTableList() {
-        return comboContentProvider.getContent(wiringTables, "wiring");
+        return wiringComboContentProvider.getContent(wiringTables, "wiring");
     }
 
     /**
@@ -217,7 +219,7 @@ public class DataAcquisitionViewModel extends ModelObject {
      * @return the list of detector tables.
      */
 	public String[] getDetectorTableList() {
-        return comboContentProvider.getContent(detectorTables, "det");
+        return detectorComboContentProvider.getContent(detectorTables, "det");
     }
 
     /**
@@ -245,7 +247,7 @@ public class DataAcquisitionViewModel extends ModelObject {
      * @return the list of detector tables.
      */
 	public String[] getSpectraTableList() {
-        return comboContentProvider.getContent(spectraTables, "spec");
+        return spectraComboContentProvider.getContent(spectraTables, "spec");
 	}
 
     /**
@@ -532,7 +534,10 @@ public class DataAcquisitionViewModel extends ModelObject {
      * 
      * @param provider The content provider.
      */
-    public void setComboContentProvider(DAEComboContentProvider provider) {
-        this.comboContentProvider = provider;
+    public void setComboContentProvider(DAEComboContentProvider wiringProvider, 
+    		DAEComboContentProvider detectorProvider, DAEComboContentProvider spectraProvider) {
+        this.wiringComboContentProvider = wiringProvider;
+        this.detectorComboContentProvider = detectorProvider;
+        this.spectraComboContentProvider = spectraProvider;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DataAcquisitionViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DataAcquisitionViewModel.java
@@ -30,6 +30,7 @@ import uk.ac.stfc.isis.ibex.dae.dataacquisition.DaeTimingSource;
 import uk.ac.stfc.isis.ibex.dae.dataacquisition.MuonCerenkovPulse;
 import uk.ac.stfc.isis.ibex.dae.updatesettings.AutosaveUnit;
 import uk.ac.stfc.isis.ibex.dae.updatesettings.UpdateSettings;
+import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 
@@ -84,9 +85,11 @@ public class DataAcquisitionViewModel extends ModelObject {
      * Sets the list of wiring tables currently available on the instrument.
      * 
      * @param tables the list of tables.
+     * @param dir the directory containing the wiring tables
      */
-	public void setWiringTableList(UpdatedValue<Collection<String>> tables) {
+	public void setWiringTableList(UpdatedValue<Collection<String>> tables, ForwardingObservable<String> dir) {
 		wiringTables = tables;
+		wiringComboContentProvider = new DAEComboContentProvider(dir);
 		
 		wiringTables.addPropertyChangeListener(new PropertyChangeListener() {		
 			@Override
@@ -101,9 +104,11 @@ public class DataAcquisitionViewModel extends ModelObject {
      * Sets the list of detector tables currently available on the instrument.
      * 
      * @param tables the list of tables.
+     * @param dir the directory containing the detector tables
      */
-	public void setDetectorTableList(UpdatedValue<Collection<String>> tables) {
+	public void setDetectorTableList(UpdatedValue<Collection<String>> tables, ForwardingObservable<String> dir) {
 		detectorTables = tables;
+		detectorComboContentProvider = new DAEComboContentProvider(dir);
 		
 		detectorTables.addPropertyChangeListener(new PropertyChangeListener() {		
 			@Override
@@ -118,9 +123,11 @@ public class DataAcquisitionViewModel extends ModelObject {
      * Sets the list of spectra tables currently available on the instrument.
      * 
      * @param tables the list of tables.
+     * @param dir the directory containing the spectra tables
      */
-	public void setSpectraTableList(UpdatedValue<Collection<String>> tables) {
+	public void setSpectraTableList(UpdatedValue<Collection<String>> tables, ForwardingObservable<String> dir) {
 		spectraTables = tables;
+		spectraComboContentProvider = new DAEComboContentProvider(dir);
 		
 		spectraTables.addPropertyChangeListener(new PropertyChangeListener() {		
 			@Override
@@ -527,17 +534,4 @@ public class DataAcquisitionViewModel extends ModelObject {
 	private static BinaryChoice vetoIsActive(Boolean selected) {
 		return BinaryChoice.values()[selected ? 1 : 0];
 	}
-
-    /**
-     * Sets the object responsible for filling the file selection combo boxes
-     * with appropriate options.
-     * 
-     * @param provider The content provider.
-     */
-    public void setComboContentProvider(DAEComboContentProvider wiringProvider, 
-    		DAEComboContentProvider detectorProvider, DAEComboContentProvider spectraProvider) {
-        this.wiringComboContentProvider = wiringProvider;
-        this.detectorComboContentProvider = detectorProvider;
-        this.spectraComboContentProvider = spectraProvider;
-    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetupViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetupViewModel.java
@@ -34,7 +34,6 @@ public class ExperimentSetupViewModel {
 	private DataAcquisitionViewModel daeSettings = new DataAcquisitionViewModel();
 	private TimeChannelsViewModel timeChannels = new TimeChannelsViewModel();
 	private PeriodsViewModel periodSettings = new PeriodsViewModel();
-    private DAEComboContentProvider comboContentProvider;
 
     /**
      * Sets all view models used in the experiment setup perspective to the
@@ -43,22 +42,23 @@ public class ExperimentSetupViewModel {
      * @param model the model of the experiment setup.
      */
 	public void setModel(ExperimentSetup model) {
-		this.model = model;	
-        comboContentProvider = new DAEComboContentProvider(model.getInstrumentName());
-		
+		this.model = model;			
 		daeSettings.setModel(model.daeSettings());
-        daeSettings.setComboContentProvider(comboContentProvider);
 		daeSettings.setUpdateSettings(model.updateSettings());
+        daeSettings.setComboContentProvider(
+        		new DAEComboContentProvider(model.getWiringTablesDir()),
+        		new DAEComboContentProvider(model.getDetectorTablesDir()),
+        		new DAEComboContentProvider(model.getSpectraTablesDir()));
 		daeSettings.setWiringTableList(model.wiringList());
 		daeSettings.setDetectorTableList(model.detectorTables());
 		daeSettings.setSpectraTableList(model.spectraTables());
 		
 		timeChannels.setModel(model.timeChannels());
-        timeChannels.setComboContentProvider(comboContentProvider);
+        timeChannels.setComboContentProvider(new DAEComboContentProvider(model.getTimeChannelsDir()));
         timeChannels.setTimeChannelFileList(model.timeChannelFiles());
 		
 		periodSettings.setSettings(model.periodSettings());
-        periodSettings.setComboContentProvider(comboContentProvider);
+        periodSettings.setComboContentProvider(new DAEComboContentProvider(model.getPeriodFilesDir()));
 		periodSettings.setPeriodFilesList(model.periodFiles());
 
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetupViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetupViewModel.java
@@ -50,12 +50,10 @@ public class ExperimentSetupViewModel {
 		daeSettings.setSpectraTableList(model.spectraTables(), model.getSpectraTablesDir());
 		
 		timeChannels.setModel(model.timeChannels());
-        timeChannels.setComboContentProvider(new DAEComboContentProvider(model.getTimeChannelsDir()));
-        timeChannels.setTimeChannelFileList(model.timeChannelFiles());
+        timeChannels.setTimeChannelFileList(model.timeChannelFiles(), model.getTimeChannelsDir());
 		
 		periodSettings.setSettings(model.periodSettings());
-        periodSettings.setComboContentProvider(new DAEComboContentProvider(model.getPeriodFilesDir()));
-		periodSettings.setPeriodFilesList(model.periodFiles());
+		periodSettings.setPeriodFilesList(model.periodFiles(), model.getPeriodFilesDir());
 
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetupViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetupViewModel.java
@@ -45,13 +45,9 @@ public class ExperimentSetupViewModel {
 		this.model = model;			
 		daeSettings.setModel(model.daeSettings());
 		daeSettings.setUpdateSettings(model.updateSettings());
-        daeSettings.setComboContentProvider(
-        		new DAEComboContentProvider(model.getWiringTablesDir()),
-        		new DAEComboContentProvider(model.getDetectorTablesDir()),
-        		new DAEComboContentProvider(model.getSpectraTablesDir()));
-		daeSettings.setWiringTableList(model.wiringList());
-		daeSettings.setDetectorTableList(model.detectorTables());
-		daeSettings.setSpectraTableList(model.spectraTables());
+		daeSettings.setWiringTableList(model.wiringList(), model.getWiringTablesDir());
+		daeSettings.setDetectorTableList(model.detectorTables(), model.getDetectorTablesDir());
+		daeSettings.setSpectraTableList(model.spectraTables(), model.getSpectraTablesDir());
 		
 		timeChannels.setModel(model.timeChannels());
         timeChannels.setComboContentProvider(new DAEComboContentProvider(model.getTimeChannelsDir()));

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/periods/PeriodsViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/periods/PeriodsViewModel.java
@@ -28,6 +28,7 @@ import uk.ac.stfc.isis.ibex.dae.experimentsetup.periods.Period;
 import uk.ac.stfc.isis.ibex.dae.experimentsetup.periods.PeriodControlType;
 import uk.ac.stfc.isis.ibex.dae.experimentsetup.periods.PeriodSettings;
 import uk.ac.stfc.isis.ibex.dae.experimentsetup.periods.PeriodSetupSource;
+import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 import uk.ac.stfc.isis.ibex.ui.dae.experimentsetup.DAEComboContentProvider;
@@ -64,9 +65,11 @@ public class PeriodsViewModel extends ModelObject {
      * Sets the list of period files currently available to the instrument.
      * 
      * @param files the list of currently available period files.
+     * @param dir the directory containing the files
      */
-	public void setPeriodFilesList(UpdatedValue<Collection<String>> files) {
+	public void setPeriodFilesList(UpdatedValue<Collection<String>> files, ForwardingObservable<String> dir) {
 		periodFiles = files;
+		comboContentProvider = new DAEComboContentProvider(dir);
 		
 		periodFiles.addPropertyChangeListener(new PropertyChangeListener() {		
 			@Override

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/timechannels/TimeChannelsViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/timechannels/TimeChannelsViewModel.java
@@ -28,6 +28,7 @@ import uk.ac.stfc.isis.ibex.dae.experimentsetup.timechannels.CalculationMethod;
 import uk.ac.stfc.isis.ibex.dae.experimentsetup.timechannels.TimeChannels;
 import uk.ac.stfc.isis.ibex.dae.experimentsetup.timechannels.TimeRegime;
 import uk.ac.stfc.isis.ibex.dae.experimentsetup.timechannels.TimeUnit;
+import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 import uk.ac.stfc.isis.ibex.ui.dae.experimentsetup.DAEComboContentProvider;
@@ -128,9 +129,11 @@ public class TimeChannelsViewModel extends ModelObject {
      * Sets the list of time channel configuration files available.
      * 
      * @param files a collection containing the available time channel files
+     * @param dir the directory containing the files
      */
-    public void setTimeChannelFileList(UpdatedValue<Collection<String>> files) {
+    public void setTimeChannelFileList(UpdatedValue<Collection<String>> files, ForwardingObservable<String> dir) {
         model.setTimeChannelFileList(files);
+        comboContentProvider = new DAEComboContentProvider(dir);
     }
 
     /**


### PR DESCRIPTION
### Description of work

I've updated the DAE perspective to get the directory path for error messages concerning missing tables from the DAE rather than constructing it in place. The previous path builder gave incorrect values.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2825

### Acceptance criteria

- [x] When no TCB/wiring/spectra/detector/period tables are available then the error message in the GUI is correct for NDX/NDW machines
- [x] The error messages are still correct on switching instrument

### Unit tests

Added some unit tests for the combo box logic

### System tests

Automated system tests are currently on hold owing to framework changes. I've added a test to the manual system tests

### Documentation

No changes

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

