### PR TITLE
Ticket2755: Synoptic editor can select select all blocks

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlockNameValidatorTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlockNameValidatorTest.java
@@ -68,7 +68,7 @@ public class BlockNameValidatorTest {
 		blockList.add(testEditableBlock);
 		
 		mockConfig = mock(EditableConfiguration.class);
-        when(mockConfig.getOtherBlocks()).thenReturn(blockList);
+        when(mockConfig.getAllBlocks()).thenReturn(blockList);
 		
 		validator = new BlockNameValidator(mockConfig, testBlock);
 	}

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlockNameValidatorTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlockNameValidatorTest.java
@@ -68,7 +68,7 @@ public class BlockNameValidatorTest {
 		blockList.add(testEditableBlock);
 		
 		mockConfig = mock(EditableConfiguration.class);
-        when(mockConfig.getAvailableBlocks()).thenReturn(blockList);
+        when(mockConfig.getOtherBlocks()).thenReturn(blockList);
 		
 		validator = new BlockNameValidator(mockConfig, testBlock);
 	}

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlocksTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlocksTest.java
@@ -102,7 +102,7 @@ public class BlocksTest extends EditableConfigurationTest {
         block2.setName(block1.getName());
 
         // Assert
-        assertTrue(!edited.getEditableBlocks().contains(block2));
+        assertTrue(!edited.getAllBlocks().contains(block2));
         
     }
 	@Test
@@ -112,7 +112,7 @@ public class BlocksTest extends EditableConfigurationTest {
 		EditableConfiguration edited = edit(config());
 		
 		// Act
-		EditableBlock gapx = getFirst(edited.getEditableBlocks());
+		EditableBlock gapx = getFirst(edited.getAllBlocks());
 		edited.removeBlock(gapx);
 		
 		// Assert
@@ -127,7 +127,7 @@ public class BlocksTest extends EditableConfigurationTest {
 		EditableConfiguration edited = edit(config());
 		
 		// Act
-		Collection<EditableBlock> returnedBlocks = edited.getEditableBlocks();
+		Collection<EditableBlock> returnedBlocks = edited.getAllBlocks();
 		edited.removeBlocks(new ArrayList<EditableBlock>(returnedBlocks));
 		
 		// Assert

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
@@ -22,6 +22,7 @@ package uk.ac.stfc.isis.ibex.configserver.tests.editing;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -53,8 +54,9 @@ public class EditableConfigurationTest {
 	protected static final EditableIoc GALIL01 = new EditableIoc("GALIL_01");
     protected static final Block GAPX = new Block("GAPX", "ADDRESS", true, true);
     protected static final Block GAPY = new Block("GAPY", "ADDRESS", true, true);
-	protected static final Group JAWS = new Group("JAWS");
-	protected static final Group TEMPERATURE = new Group("TEMPERATURE");
+	protected static final Group JAWS = new Group("JAWS", Arrays.asList("GAPX"), null);
+	protected static final Group EMPTY_GROUP_01 = new Group("EMPTY_GROUP_01");
+	protected static final Group EMPTY_GROUP_02 = new Group("EMPTY_GROUP_02");
     protected static final Configuration MOTOR_DETAILS = new Configuration("MOTOR", "DESCRIPTION");
     protected static final ComponentInfo MOTOR = new ComponentInfo(MOTOR_DETAILS);
 
@@ -95,11 +97,11 @@ public class EditableConfigurationTest {
 		assertEquals("Components", expected.getComponents(), actual.getComponents());
 	}
 	
-	public static void assertBlocksAreEqual(Collection<Block> expected, Collection<Block> actual) {
+	public static void assertBlocksAreEqual(Collection<Block> expected, Collection<? extends Block> actual) {
 		assertEquals(expected.size(), actual.size());
 		
 		Iterator<Block> itrExp = expected.iterator();
-		Iterator<Block> itrAct = actual.iterator();
+		Iterator<? extends Block> itrAct = actual.iterator();
 		
 	    while (itrExp.hasNext()) {
 	    	Block exp = itrExp.next();

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/GroupsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/GroupsTest.java
@@ -93,7 +93,7 @@ public class GroupsTest extends EditableConfigurationTest {
 		groups.add(JAWS);
 		EditableConfiguration edited = edit(config());
 		
-		List<EditableBlock> availableBlocks = (List<EditableBlock>) edited.getAvailableBlocks();
+		List<EditableBlock> availableBlocks = (List<EditableBlock>) edited.getOtherBlocks();
 
 		assertEquals(availableBlocks.size(), 1);
 		assertEquals(availableBlocks.get(0).getName(), "GAPY");

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/GroupsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/GroupsTest.java
@@ -21,10 +21,13 @@ package uk.ac.stfc.isis.ibex.configserver.tests.editing;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.junit.Test;
 
+import uk.ac.stfc.isis.ibex.configserver.configuration.Group;
+import uk.ac.stfc.isis.ibex.configserver.editing.EditableBlock;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableGroup;
 
@@ -42,10 +45,10 @@ public class GroupsTest extends EditableConfigurationTest {
 	
 	@Test
 	public void a_group_can_be_removed() {
-		groups.add(JAWS);
+		groups.add(EMPTY_GROUP_01);
 		EditableConfiguration edited = edit(config());
 
-		assertContains(edited.asConfiguration().getGroups(), JAWS);
+		assertContains(edited.asConfiguration().getGroups(), EMPTY_GROUP_01);
 		
 		EditableGroup jaws = getFirst(edited.getEditableGroups());
 		edited.removeGroup(jaws);		
@@ -54,8 +57,8 @@ public class GroupsTest extends EditableConfigurationTest {
 	
 	@Test
 	public void two_groups_can_be_swapped() {
-		groups.add(JAWS);
-		groups.add(TEMPERATURE);
+		groups.add(EMPTY_GROUP_01);
+		groups.add(EMPTY_GROUP_02);
 		EditableConfiguration edited = edit(config());
 		
 		List<EditableGroup> grps = (List<EditableGroup>) edited.getEditableGroups();
@@ -64,8 +67,48 @@ public class GroupsTest extends EditableConfigurationTest {
 		
 		grps = (List<EditableGroup>) edited.getEditableGroups();
 			
-		assertEquals(grps.get(0).getName(), "TEMPERATURE");
-		assertEquals(grps.get(1).getName(), "JAWS");
+		assertEquals(grps.get(0).getName(), "EMPTY_GROUP_02");
+		assertEquals(grps.get(1).getName(), "EMPTY_GROUP_01");
+	}
+	
+	@Test
+	public void GIVEN_group_with_one_block_THEN_editable_group_contains_block() {
+		blocks.add(GAPX);
+		groups.add(JAWS);
+		EditableConfiguration edited = edit(config());
 		
+		List<Group> grps = (List<Group>) edited.asConfiguration().getGroups();
+
+		assertContains(grps, JAWS);
+		assertContains(grps.get(0).getBlocks(), "GAPX");
+		
+		Collection<EditableBlock> selectedBlocks = getFirst(edited.getEditableGroups()).getSelectedBlocks();
+		assertBlocksAreEqual(blocks, selectedBlocks);
+	}
+	
+	@Test
+	public void GIVEN_group_with_one_block_THEN_block_not_in_config_available_blocks() {
+		blocks.add(GAPY);
+		blocks.add(GAPX);
+		groups.add(JAWS);
+		EditableConfiguration edited = edit(config());
+		
+		List<EditableBlock> availableBlocks = (List<EditableBlock>) edited.getAvailableBlocks();
+
+		assertEquals(availableBlocks.size(), 1);
+		assertEquals(availableBlocks.get(0).getName(), "GAPY");
+	}
+	
+	@Test
+	public void GIVEN_group_with_one_block_THEN_other_block_in_groups_unselected_blocks() {
+		blocks.add(GAPY);
+		blocks.add(GAPX);
+		groups.add(JAWS);
+		EditableConfiguration edited = edit(config());
+		
+		List<EditableBlock> selectedBlocks = (List<EditableBlock>) getFirst(edited.getEditableGroups()).getUnselectedBlocks();
+
+		assertEquals(selectedBlocks.size(), 1);
+		assertEquals(selectedBlocks.get(0).getName(), "GAPY");
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/GroupsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/GroupsTest.java
@@ -87,7 +87,7 @@ public class GroupsTest extends EditableConfigurationTest {
 	}
 	
 	@Test
-	public void GIVEN_group_with_one_block_THEN_block_not_in_config_available_blocks() {
+	public void GIVEN_group_with_one_block_THEN_block_not_in_other_group() {
 		blocks.add(GAPY);
 		blocks.add(GAPX);
 		groups.add(JAWS);

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/BlockNameValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/BlockNameValidator.java
@@ -128,7 +128,7 @@ public class BlockNameValidator {
     }
 
     private boolean nameInBase(String name) {
-        for (EditableBlock block : config.getAvailableBlocks()) {
+        for (EditableBlock block : config.getOtherBlocks()) {
             if (isNotSelectedBlock(block) && block.getName().equalsIgnoreCase(name)) {
                 return true;
             }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/BlockNameValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/BlockNameValidator.java
@@ -124,27 +124,9 @@ public class BlockNameValidator {
     }
 
     private boolean nameIsDuplicated(String name) {
-        return nameInBase(name) || nameInComps(name);
-    }
-
-    private boolean nameInBase(String name) {
-        for (EditableBlock block : config.getOtherBlocks()) {
+        for (EditableBlock block : config.getAllBlocks()) {
             if (isNotSelectedBlock(block) && block.getName().equalsIgnoreCase(name)) {
                 return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean nameInComps(String name) {
-        if (config.getEditableComponents() == null) {
-            return false;
-        }
-        for (Configuration comp : config.getEditableComponents().getSelected()) {
-            for (Block block : comp.getBlocks()) {
-                if (block.getName().equalsIgnoreCase(name)) {
-                    return true;
-                }
             }
         }
         return false;

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -22,6 +22,7 @@ package uk.ac.stfc.isis.ibex.configserver.editing;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,13 +89,10 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
     private final List<EditableIoc> componentIocs = new ArrayList<>();
     /** The groups associated with the configuration. */
     private List<EditableGroup> editableGroups = new ArrayList<>();
-    /** The blocks associated with the configuration. */
-    private final List<EditableBlock> editableBlocks = new ArrayList<>();
-    /**
-     * The blocks that are available to the configuration (i.e. including those
-     * associated with components.
-     */
-    private final List<EditableBlock> availableBlocks = new ArrayList<>();
+    /** All of the blocks associated with the configuration (including those associated with components). */
+    private final List<EditableBlock> allBlocks = new ArrayList<>();
+    /** The blocks in the configuration that are not in a group (including those associated with components). */
+    private final List<EditableBlock> otherBlocks = new ArrayList<>();
     /** The components associated with the configuration. */
     private final EditableComponents editableComponents;
     /** Dates when the configuration has been changed. */
@@ -162,7 +160,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
 
         for (Block block : config.getBlocks()) {
             EditableBlock eb = new EditableBlock(block);
-            editableBlocks.add(eb);
+            allBlocks.add(eb);
             if (!block.hasComponent()) {
                 makeBlockAvailable(eb);
             }
@@ -323,7 +321,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * @return The blocks associated with the configuration
      */
     Collection<Block> transformBlocks() {
-        return Lists.newArrayList(Iterables.transform(editableBlocks, new Function<EditableBlock, Block>() {
+        return Lists.newArrayList(Iterables.transform(allBlocks, new Function<EditableBlock, Block>() {
             @Override
             public Block apply(EditableBlock block) {
                 return block;
@@ -448,17 +446,17 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
     }
 
     /**
-     * @return The editable blocks associated with the configuration
+     * @return All of the blocks associated with the configuration, including those from components.
      */
-    public Collection<EditableBlock> getEditableBlocks() {
-        return new ArrayList<>(editableBlocks);
+    public Collection<EditableBlock> getAllBlocks() {
+        return new ArrayList<>(allBlocks);
     }
 
     /**
-     * @return All of the blocks available to the configuration
+     * @return All of the blocks in the configuration that are not in a group
      */
-    public Collection<EditableBlock> getAvailableBlocks() {
-        return new ArrayList<>(availableBlocks);
+    public Collection<EditableBlock> getOtherBlocks() {
+        return new ArrayList<>(otherBlocks);
     }
 
     /**
@@ -488,7 +486,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
     public void addNewBlock(EditableBlock block) throws DuplicateBlockNameException {
         if (blockNameIsUnique(block.getName())) {
             Collection<Block> blocksBeforeAdd = transformBlocks();
-            editableBlocks.add(0, block);
+            allBlocks.add(0, block);
             makeBlockAvailable(block);
             addRenameListener(block);
             firePropertyChange("blocks", blocksBeforeAdd, transformBlocks());
@@ -505,8 +503,8 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            the name whose uniqueness is checked
      * @return whether the name is unique as boolean
      */
-    public boolean blockNameIsUnique(String name) {
-        for (EditableBlock existingBlock : editableBlocks) {
+    private boolean blockNameIsUnique(String name) {
+        for (EditableBlock existingBlock : allBlocks) {
             if (existingBlock.getName().equals(name)) {
                 return false;
             }
@@ -521,7 +519,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            the block to make unavailable
      */
     public void makeBlockUnavailable(EditableBlock block) {
-        availableBlocks.remove(block);
+        otherBlocks.remove(block);
     }
 
     /**
@@ -531,8 +529,8 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            the block to make available
      */
     public void makeBlockAvailable(EditableBlock block) {
-        if (!availableBlocks.contains(block)) {
-            availableBlocks.add(0, block);
+        if (!otherBlocks.contains(block)) {
+            otherBlocks.add(0, block);
         }
     }
 
@@ -543,10 +541,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            the block to remove
      */
     public void removeBlock(EditableBlock block) {
-        Collection<Block> blocksBefore = transformBlocks();
-        editableBlocks.remove(block);
-        makeBlockUnavailable(block);
-        firePropertyChange("blocks", blocksBefore, transformBlocks());
+    	removeBlocks(Arrays.asList(block));
     }
 
     /**
@@ -558,7 +553,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
     public void removeBlocks(List<EditableBlock> blocks) {
         Collection<Block> blocksBefore = transformBlocks();
         for (EditableBlock block : blocks) {
-            editableBlocks.remove(block);
+            allBlocks.remove(block);
             makeBlockUnavailable(block);
         }
         firePropertyChange("blocks", blocksBefore, transformBlocks());

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableGroup.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableGroup.java
@@ -41,18 +41,15 @@ import uk.ac.stfc.isis.ibex.configserver.internal.DisplayUtils;
 public class EditableGroup extends Group {
 
 	private final List<EditableBlock> blocksInGroup;
-	private List<EditableBlock> availableBlocks;
 	private final EditableConfiguration config;
 
 	public EditableGroup(final EditableConfiguration configuration, Group group) {
 		super(group);
 
 		config = configuration;
-		List<EditableBlock> selectedBlocks = lookupBlocksByName(config.getEditableBlocks(), group.getBlocks());
-		blocksInGroup = selectedBlocks;
-		availableBlocks = (List<EditableBlock>) config.getAvailableBlocks();
-		for (EditableBlock block : selectedBlocks) {
-			availableBlocks.remove(block);
+		blocksInGroup = lookupBlocksByName(config.getEditableBlocks(), group.getBlocks());
+
+		for (EditableBlock block : blocksInGroup) {
 			if (!group.getName().equals("NONE")) {
 				config.makeBlockUnavailable(block);
 			}
@@ -142,7 +139,6 @@ public class EditableGroup extends Group {
 		Collection<String> blocksBefore = getBlocks();
 
 		removeDeletedBlocks(config);
-		addNewBlocks(config);
 
 		firePropertyChange("selectedBlocks", selectedBefore, getSelectedBlocks());
 		// Force the unselected blocks property change to trigger
@@ -158,10 +154,6 @@ public class EditableGroup extends Group {
 				iterator.remove();
 			}
 		}
-	}
-
-	private void addNewBlocks(EditableConfiguration config) {
-		availableBlocks = (List<EditableBlock>) config.getAvailableBlocks();
 	}
 
 	private List<String> blockNames(Collection<? extends Block> blocks) {

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableGroup.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableGroup.java
@@ -22,6 +22,7 @@ package uk.ac.stfc.isis.ibex.configserver.editing;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -47,7 +48,7 @@ public class EditableGroup extends Group {
 		super(group);
 
 		config = configuration;
-		blocksInGroup = lookupBlocksByName(config.getEditableBlocks(), group.getBlocks());
+		blocksInGroup = lookupBlocksByName(config.getAllBlocks(), group.getBlocks());
 
 		for (EditableBlock block : blocksInGroup) {
 			if (!group.getName().equals("NONE")) {
@@ -78,7 +79,7 @@ public class EditableGroup extends Group {
 	}
 
 	public Collection<EditableBlock> getUnselectedBlocks() {
-		return new ArrayList<>(config.getAvailableBlocks());
+		return new ArrayList<>(config.getOtherBlocks());
 	}
 
 	public Collection<EditableBlock> getSelectedBlocks() {
@@ -147,7 +148,7 @@ public class EditableGroup extends Group {
 	}
 
 	private void removeDeletedBlocks(EditableConfiguration config) {
-		Collection<EditableBlock> configBlocks = config.getEditableBlocks();
+		Collection<EditableBlock> configBlocks = config.getAllBlocks();
 		for (Iterator<EditableBlock> iterator = blocksInGroup.iterator(); iterator.hasNext();) {
 			EditableBlock block = iterator.next();
 			if (!configBlocks.contains(block)) {
@@ -179,13 +180,7 @@ public class EditableGroup extends Group {
 	}
 
 	private EditableBlock lookupBlockByName(Collection<EditableBlock> blocks, final String name) {
-        EditableBlock block = new EditableBlock(new Block(name, "", true, true));
-		List<String> allBlockNames = blockNames(blocks);
-		int blockIndex = allBlockNames.indexOf(name);
-		if (blockIndex >= 0) {
-			block = Iterables.get(blocks, blockIndex);
-		}
-		return block;
+		return lookupBlocksByName(blocks, Arrays.asList(name)).get(0);
 	}
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
@@ -137,16 +137,6 @@ public class ConfigEditorPanel extends Composite {
 	}
 
     /**
-     * Opens the dialog box for editing a specific block.
-     * 
-     * @param blockName
-     *            The name of the block to edit.
-     */
-    public void openEditBlockDialog(String blockName) {
-        blocks.openEditBlockDialog(blockName);
-    }
-
-    /**
      * Selects the block tab within the configuration editor panel.
      */
     public void selectBlocksTab() {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -152,7 +152,7 @@ public class BlocksEditorPanel extends Composite {
 	}
 
 	private void setBlocks(EditableConfiguration config) {
-		table.setRows(config.getEditableBlocks());
+		table.setRows(config.getAllBlocks());
 		table.refresh();
 	}
 	
@@ -219,15 +219,5 @@ public class BlocksEditorPanel extends Composite {
     private void openEditBlockDialog(EditableBlock toEdit) {
         EditBlockDialog dialog = new EditBlockDialog(getShell(), toEdit, config);
         dialog.open();
-    }
-
-    public void openEditBlockDialog(String blockName) {
-        for (EditableBlock block : config.getEditableBlocks()) {
-            if (block.getName().equals(blockName)) {
-                openEditBlockDialog(block);
-                return;
-            }
-        }
-
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/EditBlockDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/EditBlockDialog.java
@@ -111,7 +111,7 @@ public class EditBlockDialog extends TitleAreaDialog {
 		blockRunControlViewModel.updateBlock();
         blockLogSettingsViewModel.updateBlock();
         try {
-            if (!config.getEditableBlocks().contains(this.block)) {
+            if (!config.getAllBlocks().contains(this.block)) {
                 config.addNewBlock(this.block);
             }
             super.okPressed();

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/blockselector/BlockSelector.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/blockselector/BlockSelector.java
@@ -51,7 +51,7 @@ public class BlockSelector extends DisablingConfigHandler<Configuration> {
      */
 	@Override
     public void safeExecute(ExecutionEvent event) {
-        Collection<EditableBlock> availableBlocks = EDITING.currentConfig().getValue().getAvailableBlocks();
+        Collection<EditableBlock> availableBlocks = EDITING.currentConfig().getValue().getOtherBlocks();
 		
         BlockSelectorDialog dialog = new BlockSelectorDialog(null, availableBlocks);
 		if (dialog.open() == Window.OK) {

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/blockselector/BlockSelector.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/blockselector/BlockSelector.java
@@ -51,7 +51,7 @@ public class BlockSelector extends DisablingConfigHandler<Configuration> {
      */
 	@Override
     public void safeExecute(ExecutionEvent event) {
-        Collection<EditableBlock> availableBlocks = EDITING.currentConfig().getValue().getOtherBlocks();
+        Collection<EditableBlock> availableBlocks = EDITING.currentConfig().getValue().getAllBlocks();
 		
         BlockSelectorDialog dialog = new BlockSelectorDialog(null, availableBlocks);
 		if (dialog.open() == Window.OK) {


### PR DESCRIPTION
### Description of work

There was some confusion between different methods in the EditableConfiguration, I improved their names and made sure they were used correctly everywhere.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2755

### Acceptance criteria

* Create a config which includes blocks inside groups, blocks outside groups and blocks from components.
* Confirm that you cannot add a block with the same name as any of the above (this was refactored)
* Go to the synoptic editor screen and add a block to a synoptic component
* Confirm that all blocks appear in the dialog box

### Unit tests

Added some tests to improve coverage of how groups work.

### Documentation
No change to documentation other than comments

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

