### PR TITLE
Ticket2843: Break degeneracy in OPI label generation for generic sample stack

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/sample_stack/setMotorMacros.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/sample_stack/setMotorMacros.py
@@ -1,15 +1,16 @@
 from org.csstudio.opibuilder.scriptUtil import PVUtil
-from org.csstudio.opibuilder.scriptUtil import ConsoleUtil
 from time import sleep
 
 MACRO_ROOT = "AXIS_PV_"
+
 
 def is_unexpanded_macro(value):
     """
     Is the value of the form "$(...)"?
     """
-    return len(value)>=3 and value[:2]=="$(" and value[-1]==")"
-    
+    return len(value) >= 3 and value[:2] == "$(" and value[-1] == ")"
+
+
 def get_pv_value(pv, max_wait=1.0):
     """
     Gets the value of a PV as a string. Returns None if no value available
@@ -21,22 +22,25 @@ def get_pv_value(pv, max_wait=1.0):
         except:
             sleep(max_wait/steps)
     return None
-    
+
+
 def reload_widgets(count):
     """
     Reload all the motor widgets. We have 'count' of them
     """
     for motor_index in range(1, count+1):
-        reload_widget(display.getWidget("Motor_" + str(motor_index)) )
-    
+        reload_widget(display.getWidget("Motor_" + str(motor_index)))
+
+
 def reload_widget(widget):
     """
     We have to reload the widget to update the macros. Done by unsetting and resetting the
     target OPI.
     """
-    widget.setPropertyValue("opi_file","null.opi");
-    widget.setPropertyValue("opi_file","motor_control.opi");
-    
+    widget.setPropertyValue("opi_file", "null.opi")
+    widget.setPropertyValue("opi_file", "motor_control.opi")
+
+
 def _add_macro(motor_index, name, value):
     """
     Add the macro with name to a motor widget with value. 
@@ -46,10 +50,12 @@ def _add_macro(motor_index, name, value):
     motor_macros = motor_widget.getPropertyValue("macros")
     motor_macros.put(name, value)
     motor_widget.setPropertyValue("macros", motor_macros)
-    
+
+
 def _get_axis_pv(index):
     return display.getMacroValue(MACRO_ROOT + str(index))
-    
+
+
 def add_motor_macro(motor_index, pv):
     """
     Add the $(MOTOR) macro to a motor widget. Widgets are identified as "Motor_n"
@@ -62,7 +68,8 @@ def add_motor_macro(motor_index, pv):
         if not motor_address.startswith("MOT:"):
             motor_address = "MOT:" + motor_address
         _add_macro(motor_index, "MOTOR", motor_address)
-    
+
+
 def add_label_macro(motor_index, label):
     """
     Add the $(LABEL) macro to a motor widget. Widgets are identified as "Motor_n"
@@ -70,13 +77,15 @@ def add_label_macro(motor_index, label):
     """
     _add_macro(motor_index, "LABEL", label)
 
+
 def add_name_macro(motor_index):
     """
     Add the $(NAME) macro to a motor widget. Widgets are identified as "Motor_n"
     for n in [1,8] in the parent OPI
     """
     _add_macro(motor_index, "NAME", _get_axis_pv(motor_index))
-    
+
+
 def get_motor_pvs():
     """
     Get the PVs containing the names of the motors associated with the specified soft motors
@@ -85,41 +94,44 @@ def get_motor_pvs():
     
     for name in [PVUtil.getString(pv) for pv in pvs[1:]]:  # pvs[0] is for the number of motors
     
-        if is_unexpanded_macro(name) or len(name)==0:
+        if is_unexpanded_macro(name) or len(name) == 0:
             motor_pvs.append(None)            
         else:                
             # Associate all PVs with the top-level display for ease. Shouldn't be any conflict
             motor_pvs.append(PVUtil.createPV(display.getMacroValue("P") + name + ":MOTOR", display))
             
     return motor_pvs
-    
+
+
 def number_of_overlapping_final_elements(pv1, pv2):
-    if pv1==None or pv2==None or pv1==pv2:
+    if pv1 is None or pv2 is None or pv1 == pv2:
         return 0       
 
     list1 = pv1.split(":")
     list2 = pv2.split(":")
     overlap = 0
     for i in range(min(len(list1), len(list2))):
-         if list1[-1-i]==list2[-1-i]:
-             overlap += 1
-         else:
-             break
+        if list1[-1-i] == list2[-1-i]:
+            overlap += 1
+        else:
+            break
     return overlap
-        
+
+
 def generate_labels():
     labels = []
-    pvs = [_get_axis_pv(i+1) for i in range(8)]
-    for this_pv in pvs:
+    _pvs = [_get_axis_pv(i+1) for i in range(len(pvs) - 1)]
+    for this_pv in _pvs:
         max_overlap = 0
         if this_pv is not None:
-            for other_pv in pvs:
+            for other_pv in _pvs:
                 max_overlap = max(max_overlap, number_of_overlapping_final_elements(this_pv, other_pv))
             label = " ".join(this_pv.split(":")[-1-max_overlap:])
         else:
             label = None
         labels.append(label)
     return labels
+
 
 def main():
     naxes = 0

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/sample_stack/setMotorMacros.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/sample_stack/setMotorMacros.py
@@ -48,7 +48,7 @@ def _add_macro(motor_index, name, value):
     motor_widget.setPropertyValue("macros", motor_macros)
     
 def _get_axis_pv(index):
-	return display.getMacroValue(MACRO_ROOT + str(index))
+    return display.getMacroValue(MACRO_ROOT + str(index))
     
 def add_motor_macro(motor_index, pv):
     """
@@ -59,16 +59,16 @@ def add_motor_macro(motor_index, pv):
     motor_address = get_pv_value(pv)
     
     if motor_address is not None:
-    	if not motor_address.startswith("MOT:"):
-        	motor_address = "MOT:" + motor_address
+        if not motor_address.startswith("MOT:"):
+            motor_address = "MOT:" + motor_address
         _add_macro(motor_index, "MOTOR", motor_address)
     
-def add_label_macro(motor_index):
+def add_label_macro(motor_index, label):
     """
     Add the $(LABEL) macro to a motor widget. Widgets are identified as "Motor_n"
     for n in [1,8] in the parent OPI
     """
-    _add_macro(motor_index, "LABEL", _get_axis_pv(motor_index).split(":")[-1])
+    _add_macro(motor_index, "LABEL", label)
 
 def add_name_macro(motor_index):
     """
@@ -92,14 +92,43 @@ def get_motor_pvs():
             motor_pvs.append(PVUtil.createPV(display.getMacroValue("P") + name + ":MOTOR", display))
             
     return motor_pvs
+    
+def number_of_overlapping_final_elements(pv1, pv2):
+    if pv1==None or pv2==None or pv1==pv2:
+        return 0       
+
+    list1 = pv1.split(":")
+    list2 = pv2.split(":")
+    overlap = 0
+    for i in range(min(len(list1), len(list2))):
+         if list1[-1-i]==list2[-1-i]:
+             overlap += 1
+         else:
+             break
+    return overlap
+        
+def generate_labels():
+    labels = []
+    pvs = [_get_axis_pv(i+1) for i in range(8)]
+    for this_pv in pvs:
+        max_overlap = 0
+        if this_pv is not None:
+            for other_pv in pvs:
+                max_overlap = max(max_overlap, number_of_overlapping_final_elements(this_pv, other_pv))
+            label = " ".join(this_pv.split(":")[-1-max_overlap:])
+        else:
+            label = None
+        labels.append(label)
+    return labels
 
 def main():
     naxes = 0
+    labels = generate_labels()
     # enumerate( , 1) not supported in CSS Python
     for i, pv in enumerate(get_motor_pvs()): 
         if pv is not None:
             add_motor_macro(i+1, pv)
-            add_label_macro(i+1)
+            add_label_macro(i+1, labels[i])
             add_name_macro(i+1)
             naxes = i+1
     pvs[0].setValue(naxes)


### PR DESCRIPTION
### Description of work

I've added some extra methods so that if you have multiple axes with the same suffix (e.g. CHOP:Z, STACK:Z) then the generic sample stack OPI will detect it and make sure to generate different labels

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2843

### Acceptance criteria

- Create a sample stack OPI (e.g. in device screens)
- Add various combinations of macros, where some of them overlap in the description above
- The OPI should always generate unique, sensible labels for the axes

Note that this can be done without a motor IOC running but there's a delay when opening the IOC because it waits for all the PVs it's looking for to time out.

### Unit tests

None. OPI

### System tests

None. OPI

### Documentation

Not needed

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

