### PR TITLE
Display PVPrefix in Help -> About

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.help/src/uk/ac/stfc/isis/ibex/help/Help.java
+++ b/base/uk.ac.stfc.isis.ibex.help/src/uk/ac/stfc/isis/ibex/help/Help.java
@@ -46,7 +46,6 @@ public class Help extends Closer implements BundleActivator {
 	private Observables observables;
 	private UpdatedValue<String> serverRevision;
 	private UpdatedValue<String> date;
-    private String pvprefix;
 	
     /**
      * Constructor that creates and registers the observables.
@@ -98,8 +97,7 @@ public class Help extends Closer implements BundleActivator {
 		return date;
 	}
 
-    public String GetPVPrefix() {
-        pvprefix = Instrument.getInstance().getPvPrefix();
-        return pvprefix;
+    public String GetPvPrefix() {
+        return Instrument.getInstance().getPvPrefix();
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.help/src/uk/ac/stfc/isis/ibex/help/Help.java
+++ b/base/uk.ac.stfc.isis.ibex.help/src/uk/ac/stfc/isis/ibex/help/Help.java
@@ -97,7 +97,10 @@ public class Help extends Closer implements BundleActivator {
 		return date;
 	}
 
-    public String GetPvPrefix() {
+    /**
+     * @return Returns the PV Prefix of the active Instrument.
+     */
+    public String getPvPrefix() {
         return Instrument.getInstance().getPvPrefix();
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.help/src/uk/ac/stfc/isis/ibex/help/Help.java
+++ b/base/uk.ac.stfc.isis.ibex.help/src/uk/ac/stfc/isis/ibex/help/Help.java
@@ -25,6 +25,7 @@ import org.osgi.framework.BundleContext;
 import uk.ac.stfc.isis.ibex.epics.adapters.TextUpdatedObservableAdapter;
 import uk.ac.stfc.isis.ibex.epics.pv.Closer;
 import uk.ac.stfc.isis.ibex.help.internal.Observables;
+import uk.ac.stfc.isis.ibex.instrument.Instrument;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 
 /**
@@ -45,6 +46,7 @@ public class Help extends Closer implements BundleActivator {
 	private Observables observables;
 	private UpdatedValue<String> serverRevision;
 	private UpdatedValue<String> date;
+    private String pvprefix;
 	
     /**
      * Constructor that creates and registers the observables.
@@ -83,7 +85,7 @@ public class Help extends Closer implements BundleActivator {
 	}
 	
     /**
-     * @return An updating sting that holds the server revision.
+     * @return An updating string that holds the server revision.
      */
 	public UpdatedValue<String> revision() {
 		return serverRevision;
@@ -95,4 +97,9 @@ public class Help extends Closer implements BundleActivator {
 	public UpdatedValue<String> date() {
 		return date;
 	}
+
+    public String GetPVPrefix() {
+        pvprefix = Instrument.getInstance().getPvPrefix();
+        return pvprefix;
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/AboutDialogBox.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/AboutDialogBox.java
@@ -38,7 +38,7 @@ public class AboutDialogBox extends TitleAreaDialog {
     /** Dialog width. */
     public static final int WIDTH = 300;
     /** Dialog height. */
-    private static final int HEIGHT = 240;
+    private static final int HEIGHT = 260;
 
     /**
      * Construct a new about Ibex dialog box.

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
@@ -33,6 +33,7 @@ import org.eclipse.swt.widgets.Label;
 
 import uk.ac.stfc.isis.ibex.help.Help;
 
+
 /**
  * A panel showing the Ibex client and server version numbers.
  */
@@ -48,6 +49,8 @@ public class VersionPanel extends Composite {
     private Label javaVersion;
     /** The path to the Java that the client is using */
     private Label javaPathLabel;
+    /** The PV prefix the client is using */
+    private Label clientPVPrefix;
 
     /**
      * Construct a new version panel.
@@ -59,26 +62,36 @@ public class VersionPanel extends Composite {
 	public VersionPanel(Composite parent, int style) {
 		super(parent, style);
 		setLayout(new GridLayout(2, false));
-		
-		Label lblClientVersion = new Label(this, SWT.NONE);
-		lblClientVersion.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-		lblClientVersion.setText("Client Version:");
-		
-		clientVersion = new Label(this, SWT.NONE);
-		clientVersion.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+
+        Label lblClientVersion = new Label(this, SWT.NONE);
+        lblClientVersion.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblClientVersion.setText("Client Version:");
+
+        clientVersion = new Label(this, SWT.NONE);
+        clientVersion.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
         // Not bound as fixed
         final String versionText = Platform.getBundle(versionBundleId).getVersion().toString();
         clientVersion.setText(versionText);
-		
+
+        Label lblPVPrefix = new Label(this, SWT.NONE);
+        lblPVPrefix.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblPVPrefix.setText("Client PV Prefix:");
+
+        clientPVPrefix = new Label(this, SWT.NONE);
+        clientPVPrefix.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+        // Not bound as fixed
+        final String PVPrefix = Help.getInstance().GetPVPrefix();
+        clientPVPrefix.setText(PVPrefix);
+
 		Label lblServerVersion = new Label(this, SWT.NONE);
 		lblServerVersion.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
 		lblServerVersion.setText("Server Version:");
-		
+
 		serverVersion = new Label(this, SWT.NONE);
 		GridData serverVersionGd = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
 		serverVersionGd.widthHint = AboutDialogBox.WIDTH;
 		serverVersion.setLayoutData(serverVersionGd);
-		
+
         Label lblJavaVersion = new Label(this, SWT.NONE);
         lblJavaVersion.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
         lblJavaVersion.setText("Java Version:");

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
@@ -80,7 +80,7 @@ public class VersionPanel extends Composite {
         clientPvPrefix = new Label(this, SWT.NONE);
         clientPvPrefix.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
         // Not bound as fixed
-        final String PvPrefix = Help.getInstance().GetPvPrefix();
+        final String PvPrefix = Help.getInstance().getPvPrefix();
         clientPvPrefix.setText(PvPrefix);
 
 		Label lblServerVersion = new Label(this, SWT.NONE);

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
@@ -50,7 +50,7 @@ public class VersionPanel extends Composite {
     /** The path to the Java that the client is using */
     private Label javaPathLabel;
     /** The PV prefix the client is using */
-    private Label clientPVPrefix;
+    private Label clientPvPrefix;
 
     /**
      * Construct a new version panel.
@@ -73,15 +73,15 @@ public class VersionPanel extends Composite {
         final String versionText = Platform.getBundle(versionBundleId).getVersion().toString();
         clientVersion.setText(versionText);
 
-        Label lblPVPrefix = new Label(this, SWT.NONE);
-        lblPVPrefix.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-        lblPVPrefix.setText("Client PV Prefix:");
+        Label lblPvPrefix = new Label(this, SWT.NONE);
+        lblPvPrefix.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblPvPrefix.setText("Client PV Prefix:");
 
-        clientPVPrefix = new Label(this, SWT.NONE);
-        clientPVPrefix.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+        clientPvPrefix = new Label(this, SWT.NONE);
+        clientPvPrefix.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
         // Not bound as fixed
-        final String PVPrefix = Help.getInstance().GetPVPrefix();
-        clientPVPrefix.setText(PVPrefix);
+        final String PvPrefix = Help.getInstance().GetPvPrefix();
+        clientPvPrefix.setText(PvPrefix);
 
 		Label lblServerVersion = new Label(this, SWT.NONE);
 		lblServerVersion.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));


### PR DESCRIPTION
### Description of work
Add the current PVPrefix into the Help -> About menu.
This will change according to the selected instrument.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/2419

### Acceptance criteria

- [x] The PV Prefix being used by the client can be seen somewhere (help > about?)

### System tests
Added to manual system test template

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section


  