### PR TITLE
Add regex to check for double colons in PV and a test for it

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/PvValidatorTest.java
+++ b/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/PvValidatorTest.java
@@ -134,6 +134,21 @@ public class PvValidatorTest {
      * .
      */
     @Test
+    public void GIVEN_pv_address_with_double_colon_WHEN_validate_THEN_error() {
+        // Arrange
+        String testAddress = "IN::SOMETHING:";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertFalse(addressValid.validatePvAddress(testAddress));
+    }
+
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#validatePvAddress(java.lang.String)}
+     * .
+     */
+    @Test
     public void invalid_pv_address() {
         // Arrange
         String testAddress = "invalid@";

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/PvValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/PvValidator.java
@@ -63,7 +63,8 @@ public class PvValidator {
 
         if (pvAddress.isEmpty()) {
             setErrorMessage(ADDRESS_EMPTY);
-        } else if (!(pvAddress.matches("^[a-zA-Z0-9_\\-:]+(\\.[a-zA-Z0-9_:\\-]+)?$"))) {
+        } else if (!(pvAddress.matches("^[a-zA-Z0-9_\\-:]+(\\.[a-zA-Z0-9_:\\-]+)?$"))
+                || pvAddress.matches(".*(:)\\1+.*")) {
             setErrorMessage(ADDRESS_FORMAT);
         } else {
             isValid = true;


### PR DESCRIPTION
### Description of work

Added a check to the PV validator to 

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2644

### Acceptance criteria

Validator catches PV Addresses that have a double colon, for example `INS::SOMETHING:`

### Unit tests

Added a specific test for double colons.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

