### PR TITLE
Ticket2812 e4 beamstatus view

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -121,8 +121,16 @@
         </children>
       </children>
       <children xsi:type="basic:PartSashContainer" xmi:id="_HX2EYIcuEeeB45r8U07FRg" elementId="uk.ac.stfc.isis.ibex.e4.client.partsashcontainer.4" containerData="70" horizontal="true">
-        <children xsi:type="basic:PartStack" xmi:id="_IZXy0IcuEeeB45r8U07FRg" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.2">
-          <children xsi:type="basic:Part" xmi:id="_Wtrl8IcuEeeB45r8U07FRg" elementId="uk.ac.stfc.isis.ibex.e4.ui.beamStatusView" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.beamstatus/uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamStatusView" label="Beam Status"/>
+        <children xsi:type="basic:PartStack" xmi:id="_IZXy0IcuEeeB45r8U07FRg" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.2" containerData="70">
+          <children xsi:type="basic:Part" xmi:id="_Wtrl8IcuEeeB45r8U07FRg" elementId="uk.ac.stfc.isis.ibex.e4.ui.beamgraph" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.beamstatus/uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamGraphView" label="Beam Current"/>
+        </children>
+        <children xsi:type="basic:PartSashContainer" xmi:id="_ZEDrcOY5Eee0yf7w-lF8_g" elementId="uk.ac.stfc.isis.ibex.e4.client.partsashcontainer.17" containerData="30">
+          <children xsi:type="basic:PartStack" xmi:id="_ayRgwOY5Eee0yf7w-lF8_g" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.21" containerData="30">
+            <children xsi:type="basic:Part" xmi:id="_dCUQwOY5Eee0yf7w-lF8_g" elementId="uk.ac.stfc.isis.ibex.e4.ui.mcrnews" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.beamstatus/uk.ac.stfc.isis.ibex.ui.beamstatus.views.McrNewsPanel" label="MCR News"/>
+          </children>
+          <children xsi:type="basic:PartStack" xmi:id="_bL_BQOY5Eee0yf7w-lF8_g" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.30" containerData="70">
+            <children xsi:type="basic:Part" xmi:id="_dR0FUOY5Eee0yf7w-lF8_g" elementId="uk.ac.stfc.isis.ibex.e4.ui.beaminfo" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.beamstatus/uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamInfoView" label="Beam Information"/>
+          </children>
         </children>
       </children>
     </children>

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/plugin.xml
@@ -12,8 +12,8 @@
             name="Beam Status Graph"
             icon="icons/sample.gif"
             category="uk.ac.stfc.isis.ibex.ui.beamstatus"
-            class="uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamStatusView"
-            id="uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamStatusView">
+            class="uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamGraphView"
+            id="uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamGraphView">
       </view>
    </extension>
    <extension
@@ -31,7 +31,7 @@
             targetID="uk.ac.stfc.isis.ibex.ui.beamstatus.perspective">
          <view
                closeable="false"
-               id="uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamStatusView"
+               id="uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamGraphView"
                minimized="false"
                moveable="false"
                ratio="1.0f"

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamGraphView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamGraphView.java
@@ -123,7 +123,6 @@ public class BeamGraphView implements ModelListener {
      */
     @PostConstruct 
     public void createPartControl(final Composite parent) {
-        
     	// Remember what shell we're using
         shell = parent.getShell();
         
@@ -138,7 +137,10 @@ public class BeamGraphView implements ModelListener {
         createTimeRangeRadioButtons(parent);
         
         // Create the basic plot
-        createBeamStatusPlot(parent);
+        Composite plotComposite = new Composite(parent, SWT.NONE);
+        plotComposite.setLayout(new GridLayout(1, false));
+        plotComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        modelPlot = new ModelBasedPlot(plotComposite);
 
         // TODO Disabled until connection to archive engine is fixed
         // for (String pv : Arrays.asList(TS1_BEAM_CURRENT_PV, TS2_BEAM_CURRENT_PV, SYNCH_BEAM_CURRENT_PV)) {
@@ -153,6 +155,7 @@ public class BeamGraphView implements ModelListener {
             MessageDialog.openError(shell, Messages.Error, NLS.bind(Messages.ErrorFmt, ex.toString()));
         }
 
+        createBeamStatusPlot();
     }
 
     private void createTimeRangeRadioButtons(final Composite parent) {
@@ -181,17 +184,10 @@ public class BeamGraphView implements ModelListener {
 
     }
 
-    private void createBeamStatusPlot(final Composite parent) {
-        Composite plotComposite = new Composite(parent, SWT.NONE);
-        plotComposite.setLayout(new GridLayout(1, false));
-        plotComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-                
-        // Create plot with basic configuration
-        modelPlot = new ModelBasedPlot(plotComposite);
+    private void createBeamStatusPlot() {
         RTTimePlot rtPlot = modelPlot.getPlot();
         rtPlot.setTitle(Optional.of(PLOT_TITLE));
         rtPlot.setEnabled(false);
-        // TODO: Doesn't seem to actually hide the toolbar. Can we do that?
         rtPlot.showToolbar(false);
         rtPlot.showLegend(true);
         rtPlot.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
@@ -267,7 +263,6 @@ public class BeamGraphView implements ModelListener {
      *            PV to add to the plot
      */
     protected void addTrace(final PVItem newItem) {
-
         // PV unknown or plot does not exist
         if (newItem == null || modelPlot == null) {
             return;

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamGraphView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamGraphView.java
@@ -57,7 +57,7 @@ import org.eclipse.swt.widgets.Shell;
  * Always used as derived classes that specify the time duration of the plot
  * (e.g. hourly, daily)
  */
-public class BeamStatusView implements ModelListener {
+public class BeamGraphView implements ModelListener {
 	
     /** View ID registered in plugin.xml. */
     public static final String ID = "uk.ac.stfc.isis.ibex.ui.beamstatus.views.BeamStatusGraphView"; //$NON-NLS-1$
@@ -116,6 +116,11 @@ public class BeamStatusView implements ModelListener {
     /** Title for the plot. */
     private static final String PLOT_TITLE = "Beam Current";
 
+    /**
+     * Creates the Beam Graph view.
+     * 
+     * @param parent The parent container obtained via dependency injection
+     */
     @PostConstruct 
     public void createPartControl(final Composite parent) {
         
@@ -342,6 +347,9 @@ public class BeamStatusView implements ModelListener {
         return getCalendarSpec(getTimeRangeInMilliseconds());
     }
     
+    /**
+     * Disposes of the model before disposing of this view.
+     */
     @PreDestroy
     public void dispose() {
     	if (model != null) {

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoView.java
@@ -29,17 +29,16 @@ import org.eclipse.swt.widgets.ExpandBar;
 import org.eclipse.swt.widgets.ExpandItem;
 
 /**
- * The parent composite for the beam statistics widgets.
+ * The parent composite for the beam information widgets.
  */
-public class StatsPanel {
+public class BeamInfoView {
 
     /**
-     * The constructor.
+     * Creates the Beam Info view.
      * 
-     * @param parent the parent
-     * @param style the SWT style
-     * @return 
+     * @param parent The parent container obtained via dependency injection
      */
+    @SuppressWarnings("checkstyle:magicnumber")
 	@PostConstruct
     public void createPartControl(Composite parent) {
         parent.setLayout(new GridLayout(1, false));

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/McrNewsPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/McrNewsPanel.java
@@ -55,13 +55,11 @@ public class McrNewsPanel {
     private static final long TEXT_REFRESH_PERIOD_MS = 30000; // milliseconds
 
     private Text newsText;
-    
+
     /**
-     * Constructor for the MCR News Panel.
+     * Creates the MCR News view.
      * 
-     * @param parent Parent composite
-     * @param style SWT Style
-     * @return 
+     * @param parent The parent container obtained via dependency injection
      */
     @PostConstruct
     public void createPartControl(Composite parent) {


### PR DESCRIPTION
### Description of work

Continued the migration of the beam status perspective to Eclipse 4: 
- added viewparts for MCR News and Beam Stats
- hidden toolbar on beam status graph

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2812

### Acceptance criteria

- [x] The beam status perspective looks equivalent to the one in the E3 build.

### Unit tests

/

### System tests

/

### Documentation

Removed relevant TODOs in https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Eclipse-4-Migration-TODOs

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

