### PR TITLE
Increase buffer size to be the same as temperature

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/check_OPI_format_utils/xy_graph.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_OPI_format_utils/xy_graph.py
@@ -1,0 +1,33 @@
+"""
+Check properties of the graph xy widget
+"""
+
+XY_GRAPH_WIDGETS_XPATH = r"//widget['org.csstudio.opibuilder.widgets.xyGraph']"
+BUFFER_SIZES_XPATH = "*[{0} = substring(name(), string-length(name()) - string-length({0}) +1) ]"\
+    .format("'_buffer_size'")
+
+
+def get_traces_with_different_buffer_sizes(root):
+    """
+    Gets any graph xy widget and check it for buffer sizes different to the first.
+    Args:
+        root (etree): The root of the xml to search.
+    Returns:
+        error list tuple: Error line, buffer size and expected buffer size
+    """
+    graph_nodes = root.xpath(XY_GRAPH_WIDGETS_XPATH)
+    errors = []
+    for graph_node in graph_nodes:
+        node_errors = _get_buffer_difference_in_single_graph(graph_node)
+        errors.extend(node_errors)
+
+    return errors
+
+
+def _get_buffer_difference_in_single_graph(node):
+    nodes = node.xpath(BUFFER_SIZES_XPATH)
+    if len(nodes) == 0:
+        return []
+
+    buffer_size = nodes[0].text
+    return [(node.sourceline, node.text, buffer_size) for node in nodes if node.text != buffer_size]

--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
@@ -12,6 +12,8 @@ from check_OPI_format_utils.text import check_label_punctuation, check_label_cas
 from check_OPI_format_utils.container import get_items_not_in_grouping_container
 from check_OPI_format_utils.font import get_incorrect_fonts
 from xmlrunner import XMLTestRunner
+
+from check_OPI_format_utils.xy_graph import get_traces_with_different_buffer_sizes
 from check_opi_format_tests import TestCheckOpiFormatMethods
 
 # Directory to iterate through
@@ -55,6 +57,13 @@ class CheckOpiFormat(unittest.TestCase):
         if len(errors):
             self.fail("\n".join(["On line {}, text '{}', colour was not correct.".format(*error) for error in errors]))
 
+    def _assert_trace_buffers_are_the_same(self):
+        errors = get_traces_with_different_buffer_sizes(self.xml_root)
+
+        if len(errors):
+            self.fail("\n".join(["On line {}, buffer size {}, was different to the first, {}, in same graph xy widget."
+                                .format(*error) for error in errors]))
+
     def test_GIVEN_an_opi_file_with_grouping_containers_WHEN_checking_the_background_colour_THEN_it_is_the_isis_background(self):
         self._assert_colour_correct("background_color", "groupingContainer", ["ISIS_OPI_Background"])
 
@@ -72,6 +81,9 @@ class CheckOpiFormat(unittest.TestCase):
 
     def test_GIVEN_an_opi_file_with_led_WHEN_checking_off_colour_THEN_it_is_the_isis_led_off_colour(self):
         self._assert_colour_correct("off_color", "LED", ["ISIS_Green_LED_Off", "ISIS_Red_LED_Off"])
+
+    def test_GIVEN_an_opi_file_with_graph_widgets_WHEN_checking_buffer_sizes_THEN_all_buffer_sizes_are_the_same(self):
+        self._assert_trace_buffers_are_the_same()
 
     def test_GIVEN_a_label_THEN_it_ends_in_a_colon(self):
         errors = check_label_punctuation(self.xml_root)

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
@@ -1231,7 +1231,7 @@ $(trace_0_y_pv_value)</tooltip>
       <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
     </axis_2_grid_color>
     <trace_0_buffer_size>1000</trace_0_buffer_size>
-    <trace_2_buffer_size>100</trace_2_buffer_size>
+    <trace_2_buffer_size>1000</trace_2_buffer_size>
     <axis_1_maximum>50.0</axis_1_maximum>
     <axis_0_scale_font>
       <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GraphScale_NEW</opifont.name>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/TPG300.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/TPG300.opi
@@ -701,7 +701,7 @@ $(trace_0_y_pv_value)</tooltip>
     <trace_1_anti_alias>true</trace_1_anti_alias>
     <pv_value />
     <trace_0_buffer_size>1000</trace_0_buffer_size>
-    <trace_2_buffer_size>100</trace_2_buffer_size>
+    <trace_2_buffer_size>1000</trace_2_buffer_size>
     <axis_1_maximum>50.0</axis_1_maximum>
     <axis_0_scale_font>
       <opifont.name fontName="Arial" height="9" style="0">ISIS_Label_Small</opifont.name>
@@ -742,7 +742,7 @@ $(trace_0_y_pv_value)</tooltip>
       <color name="ISIS_Trace_2" red="33" green="179" blue="33" />
     </trace_2_trace_color>
     <axis_1_dash_grid_line>true</axis_1_dash_grid_line>
-    <trace_3_buffer_size>100</trace_3_buffer_size>
+    <trace_3_buffer_size>1000</trace_3_buffer_size>
     <trace_2_trace_type>0</trace_2_trace_type>
     <trace_3_line_width>1</trace_3_line_width>
     <show_toolbar>false</show_toolbar>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/neocera_ltc21.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/neocera_ltc21.opi
@@ -977,7 +977,7 @@ $(trace_0_y_pv_value)</tooltip>
       <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
     </axis_2_grid_color>
     <trace_0_buffer_size>1000</trace_0_buffer_size>
-    <trace_2_buffer_size>100</trace_2_buffer_size>
+    <trace_2_buffer_size>1000</trace_2_buffer_size>
     <axis_1_maximum>50.0</axis_1_maximum>
     <axis_0_scale_font>
       <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GraphScale_NEW</opifont.name>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/template.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/template.opi
@@ -314,7 +314,7 @@ $(trace_0_y_pv_value)</tooltip>
           <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
         </axis_2_grid_color>
         <trace_0_buffer_size>1000</trace_0_buffer_size>
-        <trace_2_buffer_size>100</trace_2_buffer_size>
+        <trace_2_buffer_size>1000</trace_2_buffer_size>
         <axis_1_maximum>50.0</axis_1_maximum>
         <axis_0_scale_font>
           <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GraphScale_NEW</opifont.name>


### PR DESCRIPTION
### Description of work

Increase buffer size in graph to make it capture all points. Also update check script to ensure this can not happen again. Fix other similar OPIs,

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2762

### Acceptance criteria

Can plot more than 100 points of heater changes on the graph (see handy script on ticket)

### Unit tests

Can not test graph plotting but have tested opi format checker

### System tests

Non no-point

### Documentation

Non - small change

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

