### PR TITLE
Ticket2527 default synoptics in edit config dialog

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/ConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/ConfigurationTest.java
@@ -19,9 +19,13 @@
 
 package uk.ac.stfc.isis.ibex.configserver.tests.editing;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
+import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
+import uk.ac.stfc.isis.ibex.configserver.internal.ConfigEditing;
 
 @SuppressWarnings("checkstyle:methodname")
 public class ConfigurationTest extends EditableConfigurationTest {
@@ -37,5 +41,18 @@ public class ConfigurationTest extends EditableConfigurationTest {
 		populateConfig();
 		EditableConfiguration edited = edit(config());		
 		assertAreEqual(config(), edited.asConfiguration());
+	}
+	
+	@Test
+	public void GIVEN_blank_default_synoptic_WHEN_creating_configuration_THEN_default_synoptic_name_is_NONE() {
+		// Arrange
+		String defaultSynoptic = "";
+		
+		// Act
+		Configuration config = new Configuration("name", "description", defaultSynoptic, iocs, blocks, groups, components, history);
+		
+		// Assert
+		assertEquals(ConfigEditing.NONE_SYNOPTIC_NAME, config.synoptic());
+		
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.configserver/META-INF/MANIFEST.MF
@@ -17,8 +17,7 @@ Require-Bundle: org.eclipse.core.runtime,
  uk.ac.stfc.isis.ibex.runcontrol,
  org.eclipse.core.databinding,
  uk.ac.stfc.isis.ibex.epics.switching,
- uk.ac.stfc.isis.ibex.alarm,
- uk.ac.stfc.isis.ibex.synoptic
+ uk.ac.stfc.isis.ibex.alarm
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.configserver;
@@ -38,7 +37,8 @@ Export-Package: uk.ac.stfc.isis.ibex.configserver;
    uk.ac.stfc.isis.ibex.model,
    uk.ac.stfc.isis.ibex.configserver,
    uk.ac.stfc.isis.ibex.configserver.configuration,
-   uk.ac.stfc.isis.ibex.epics.observing"
+   uk.ac.stfc.isis.ibex.epics.observing",
+ uk.ac.stfc.isis.ibex.configserver.internal
 Import-Package: org.eclipse.wb.swt,
  uk.ac.stfc.isis.ibex.instrument,
  uk.ac.stfc.isis.ibex.validators

--- a/base/uk.ac.stfc.isis.ibex.configserver/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.configserver/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.runtime,
  uk.ac.stfc.isis.ibex.runcontrol,
  org.eclipse.core.databinding,
  uk.ac.stfc.isis.ibex.epics.switching,
- uk.ac.stfc.isis.ibex.alarm
+ uk.ac.stfc.isis.ibex.alarm,
+ uk.ac.stfc.isis.ibex.synoptic
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.configserver;

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Configuration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Configuration.java
@@ -24,8 +24,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import uk.ac.stfc.isis.ibex.configserver.internal.ConfigEditing;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
-import uk.ac.stfc.isis.ibex.synoptic.internal.Variables;
 
 /**
  * This is the base class that holds all information relating to a BlockServer
@@ -92,7 +92,7 @@ public class Configuration extends ModelObject {
 			Collection<String> history) {
 		this.name = name;
 		this.description = description;
-		this.synoptic = defaultSynoptic.equals("") ? Variables.NONE_SYNOPTIC_NAME : defaultSynoptic;
+		this.synoptic = defaultSynoptic.equals("") ? ConfigEditing.NONE_SYNOPTIC_NAME : defaultSynoptic;
 		this.pv = "";
 		
 		for (Ioc ioc : iocs) {

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Configuration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Configuration.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 import uk.ac.stfc.isis.ibex.model.ModelObject;
+import uk.ac.stfc.isis.ibex.synoptic.internal.Variables;
 
 /**
  * This is the base class that holds all information relating to a BlockServer
@@ -91,7 +92,7 @@ public class Configuration extends ModelObject {
 			Collection<String> history) {
 		this.name = name;
 		this.description = description;
-		this.synoptic = defaultSynoptic;
+		this.synoptic = defaultSynoptic.equals("") ? Variables.NONE_SYNOPTIC_NAME : defaultSynoptic;
 		this.pv = "";
 		
 		for (Ioc ioc : iocs) {

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ConfigEditing.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ConfigEditing.java
@@ -29,6 +29,16 @@ import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.epics.pv.Closer;
 
 public class ConfigEditing extends Closer implements Editing {
+	
+    /**
+     * The name associated with the "blank" synoptic from the BlockServer.
+     */
+    public static final String NONE_SYNOPTIC_NAME = "-- NONE --";
+
+    /**
+     * The pv associated with the "blank" synoptic from the BlockServer.
+     */
+    public static final String NONE_SYNOPTIC_PV = "__BLANK__";
 
 	private final ConfigServer configServer;
 

--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/internal/Variables.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/internal/Variables.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.synoptic.internal;
 
 import java.util.Collection;
 
+import uk.ac.stfc.isis.ibex.configserver.internal.ConfigEditing;
 import uk.ac.stfc.isis.ibex.epics.conversion.Convert;
 import uk.ac.stfc.isis.ibex.epics.conversion.Converter;
 import uk.ac.stfc.isis.ibex.epics.conversion.json.JsonDeserialisingConverter;
@@ -57,12 +58,12 @@ public class Variables {
     /**
      * The name associated with the "blank" synoptic from the BlockServer.
      */
-    public static final String NONE_SYNOPTIC_NAME = "-- NONE --";
+    public static final String NONE_SYNOPTIC_NAME = ConfigEditing.NONE_SYNOPTIC_NAME;
 
     /**
      * The pv associated with the "blank" synoptic from the BlockServer.
      */
-    public static final String NONE_SYNOPTIC_PV = "__BLANK__";
+    public static final String NONE_SYNOPTIC_PV = ConfigEditing.NONE_SYNOPTIC_PV;
 
     public final Writable<String> synopticSetter;
 

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticSelection.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticSelection.java
@@ -66,6 +66,14 @@ public class SynopticSelection extends Composite {
 		loadDefaultButton.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false, 1, 1));
 		loadDefaultButton.setBackground(BACKGROUND);
 		
+		loadDefaultButton.addSelectionListener(new SelectionAdapter() {
+			
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				model.setLastDefault();
+			}
+		});
+		
         refreshButton = new Button(this, SWT.NONE);
 		refreshButton.setText("Refresh Synoptic");
 		refreshButton.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false, 1, 1));

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticSelection.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticSelection.java
@@ -56,13 +56,15 @@ public class SynopticSelection extends Composite {
 
 		setLayout(gridLayout);
 		
-		GridData gdGotoLabel = new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1);
-		gdGotoLabel.verticalAlignment = SWT.CENTER;
-		
 		GridData gdSynopticCombo = new GridData(SWT.CENTER, SWT.CENTER, false, false, 1, 1);
 		gdSynopticCombo.widthHint = 120;
 		synopticCombo = new Combo(this, SWT.READ_ONLY);
 		synopticCombo.setLayoutData(gdSynopticCombo);
+		
+		Button loadDefaultButton = new Button(this, SWT.NONE);
+		loadDefaultButton.setText("Load Default");
+		loadDefaultButton.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false, 1, 1));
+		loadDefaultButton.setBackground(BACKGROUND);
 		
         refreshButton = new Button(this, SWT.NONE);
 		refreshButton.setText("Refresh Synoptic");

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticSelectionViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticSelectionViewModel.java
@@ -115,6 +115,10 @@ public class SynopticSelectionViewModel extends ModelObject {
             lastSetDefaultSynoptic = newDefaultSynoptic;
         }
     }
+    
+    public void setLastDefault() {
+    	setSelected(lastSetDefaultSynoptic.name());
+    }
 
     public String getSelected() {
         return selected;


### PR DESCRIPTION
### Description of work

We've removed "recommended" from the default synoptic name in the config editor dialog as it didn't add any functionality. On discussion with @John-Holt-Tessella, the main use of having a default synoptic appears to be to be able to return to an appropriate synoptic in the synoptic perspective. As such, we've added a "load default" synoptic button to the perspective.

Additionally, the default synoptic in the config editor dialog will now always be the default synoptic for that configuration. Previously, if no synoptic was actively selected by the user at time of creation, the default synoptic for the current configuration would be used. This could lead to confusing behaviour on saving and loading configurations.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2527

### Acceptance criteria

Run the new manual system tests as described below. The expected default synoptic should appear in the edit configuration dialog, and in the synoptic perspective.

### Unit tests

A new unit test has been added for `Configuration.java` owing to the change in the constructor

### System tests

We've added some new checks for the default synoptic in the manual system test spreadsheet:

- 15-65 
- 16-26 
- 16-27

### Documentation

None needed

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

