### PR TITLE
Ticket2901 journal viewer connection

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
@@ -258,6 +258,7 @@
 		<module>../uk.ac.stfc.isis.ibex.ui.scripting.tests</module>
 		<module>../uk.ac.stfc.isis.ibex.ui.journalviewer</module>
 		<module>../uk.ac.stfc.isis.ibex.journal</module>
+		<module>../uk.ac.stfc.isis.ibex.ui.journalviewer.tests</module>
 	</modules>
 </project>
 

--- a/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.client.tycho.parent/pom.xml
@@ -257,6 +257,7 @@
 		<module>../uk.ac.stfc.isis.ibex.managermode.tests</module>
 		<module>../uk.ac.stfc.isis.ibex.ui.scripting.tests</module>
 		<module>../uk.ac.stfc.isis.ibex.ui.journalviewer</module>
+		<module>../uk.ac.stfc.isis.ibex.journal</module>
 	</modules>
 </project>
 

--- a/base/uk.ac.stfc.isis.ibex.databases/src/uk/ac/stfc/isis/ibex/databases/DbError.java
+++ b/base/uk.ac.stfc.isis.ibex.databases/src/uk/ac/stfc/isis/ibex/databases/DbError.java
@@ -22,7 +22,7 @@
 package uk.ac.stfc.isis.ibex.databases;
 
 /**
- *
+ * Types of error that can arise when connecting to an external database.
  */
 public enum DbError {
     /**
@@ -40,7 +40,12 @@ public enum DbError {
 
     private final String message;
 
-    private DbError(String message) {
+    /**
+     * Constructor that allows attaching a message to the error type.
+     * 
+     * @param message The message.
+     */
+    DbError(String message) {
         this.message = message;
     }
 

--- a/base/uk.ac.stfc.isis.ibex.databases/src/uk/ac/stfc/isis/ibex/databases/DbError.java
+++ b/base/uk.ac.stfc.isis.ibex.databases/src/uk/ac/stfc/isis/ibex/databases/DbError.java
@@ -19,35 +19,35 @@
 /**
  * 
  */
-package uk.ac.stfc.isis.ibex.journal;
-
-import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
-import uk.ac.stfc.isis.ibex.instrument.InstrumentInfoReceiver;
+package uk.ac.stfc.isis.ibex.databases;
 
 /**
- * This class is responsible for updating all connections when an instrument is
- * switched.
+ *
  */
-public class OnInstrumentSwitch implements InstrumentInfoReceiver {
-
+public enum DbError {
     /**
-     * Updates the journal model on switching instrument.
-     * 
-     * @param instrument
-     *            The instrument to switch to.
+     * Motors are moving.
      */
-    @Override
-    public void setInstrument(InstrumentInfo instrument) {
-        // Nothing to be done
+    CONNECTION_ERROR("Could not establish connection to database"),
+    /**
+     * Motors are stationary.
+     */
+    UNKNOWN_DB("Unknown database name"),
+    /**
+     * Motor state is unknown.
+     */
+    ACCESS_DENIED("Access to database denied");
+
+    private final String message;
+
+    private DbError(String message) {
+        this.message = message;
     }
 
     @Override
-    public void preSetInstrument(InstrumentInfo instrument) {
-        // Nothing to be done
+    public String toString() {
+        return message;
     }
 
-    @Override
-    public void postSetInstrument(InstrumentInfo instrument) {
-        Journal.getInstance().getModel().refresh();
-    }
 }
+

--- a/base/uk.ac.stfc.isis.ibex.databases/src/uk/ac/stfc/isis/ibex/databases/Rdb.java
+++ b/base/uk.ac.stfc.isis.ibex.databases/src/uk/ac/stfc/isis/ibex/databases/Rdb.java
@@ -20,6 +20,7 @@ package uk.ac.stfc.isis.ibex.databases;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.SQLRecoverableException;
 
 import org.apache.logging.log4j.Logger;
 
@@ -92,5 +93,21 @@ public class Rdb {
 		    LOG.error("Error closing connection to database (" + schema + "): "
 			    + ex.getMessage());
 		}
+    }
+
+    /**
+     * Returns an appropriate DbError with message based on a given exception.
+     * 
+     * @param ex The exception
+     * @return The relevant error message
+     */
+    public static DbError getError(Exception ex) {
+        if (ex instanceof SQLRecoverableException) {
+            return DbError.CONNECTION_ERROR;
+        }
+        if (ex.getMessage().startsWith("Unknown database")) {
+            return DbError.UNKNOWN_DB;
+        }
+        return DbError.ACCESS_DENIED;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/ExperimentDetails.java
+++ b/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/ExperimentDetails.java
@@ -38,6 +38,11 @@ public class ExperimentDetails extends AbstractUIPlugin {
 	private Model model;
 	private SearchModel searchModel;
 
+    /**
+     * Return the bundle context of this plugin.
+     * 
+     * @return The context.
+     */
 	static BundleContext getContext() {
 		return context;
 	}

--- a/base/uk.ac.stfc.isis.ibex.feature.base/feature.xml
+++ b/base/uk.ac.stfc.isis.ibex.feature.base/feature.xml
@@ -485,4 +485,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="uk.ac.stfc.isis.ibex.journal"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/base/uk.ac.stfc.isis.ibex.journal.tests/src/uk/ac/stfc/isis/ibex/journal/tests/package-info.java
+++ b/base/uk.ac.stfc.isis.ibex.journal.tests/src/uk/ac/stfc/isis/ibex/journal/tests/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2018 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * Contains tests for the journal plug-in.
+ */
+package uk.ac.stfc.isis.ibex.journal.tests;

--- a/base/uk.ac.stfc.isis.ibex.journal/.classpath
+++ b/base/uk.ac.stfc.isis.ibex.journal/.classpath
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/base/uk.ac.stfc.isis.ibex.journal/.project
+++ b/base/uk.ac.stfc.isis.ibex.journal/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>uk.ac.stfc.isis.ibex.journal</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Journal
-Bundle-SymbolicName: uk.ac.stfc.isis.ibex.journal
+Bundle-SymbolicName: uk.ac.stfc.isis.ibex.journal;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: uk.ac.stfc.isis.ibex.journal.Journal
 Require-Bundle: org.eclipse.core.runtime,

--- a/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
@@ -11,7 +11,9 @@ Require-Bundle: org.eclipse.core.runtime,
  uk.ac.stfc.isis.ibex.databases,
  org.eclipse.osgi,
  uk.ac.stfc.isis.ibex.model,
- uk.ac.stfc.isis.ibex.instrument
+ uk.ac.stfc.isis.ibex.instrument,
+ uk.ac.stfc.isis.ibex.logger
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.journal
+Import-Package: org.apache.logging.log4j

--- a/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jface,
  org.eclipse.core.resources,
  uk.ac.stfc.isis.ibex.databases,
- org.eclipse.osgi
+ org.eclipse.osgi,
+ uk.ac.stfc.isis.ibex.model
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.journal

--- a/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  uk.ac.stfc.isis.ibex.databases,
  org.eclipse.osgi,
- uk.ac.stfc.isis.ibex.model
+ uk.ac.stfc.isis.ibex.model,
+ uk.ac.stfc.isis.ibex.instrument
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.journal

--- a/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
@@ -1,0 +1,15 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Journal
+Bundle-SymbolicName: uk.ac.stfc.isis.ibex.journal
+Bundle-Version: 1.0.0.qualifier
+Bundle-Activator: uk.ac.stfc.isis.ibex.journal.Journal
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.ui.workbench,
+ org.eclipse.jface,
+ org.eclipse.core.resources,
+ uk.ac.stfc.isis.ibex.databases,
+ org.eclipse.osgi
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ActivationPolicy: lazy
+Export-Package: uk.ac.stfc.isis.ibex.journal

--- a/base/uk.ac.stfc.isis.ibex.journal/build.properties
+++ b/base/uk.ac.stfc.isis.ibex.journal/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/base/uk.ac.stfc.isis.ibex.journal/build.properties
+++ b/base/uk.ac.stfc.isis.ibex.journal/build.properties
@@ -1,4 +1,5 @@
 source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               plugin.xml

--- a/base/uk.ac.stfc.isis.ibex.journal/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.journal/plugin.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="uk.ac.stfc.isis.ibex.journal.preferences.PreferenceInitializer">
+      </initializer>
+   </extension>
+   
+   <extension
+         point="uk.ac.stfc.isis.ibex.instrument.info">
+      <InstrumentInfoReceiver
+            class="uk.ac.stfc.isis.ibex.journal.OnInstrumentSwitch">
+      </InstrumentInfoReceiver>
+   </extension>
+
+</plugin>

--- a/base/uk.ac.stfc.isis.ibex.journal/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.journal/plugin.xml
@@ -7,12 +7,10 @@
             class="uk.ac.stfc.isis.ibex.journal.preferences.PreferenceInitializer">
       </initializer>
    </extension>
-   
    <extension
          point="uk.ac.stfc.isis.ibex.instrument.info">
       <InstrumentInfoReceiver
             class="uk.ac.stfc.isis.ibex.journal.OnInstrumentSwitch">
       </InstrumentInfoReceiver>
    </extension>
-
 </plugin>

--- a/base/uk.ac.stfc.isis.ibex.journal/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.journal/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>uk.ac.stfc.isis.ibex.journal</artifactId>
+  <packaging>eclipse-plugin</packaging>
+  <parent>
+    <groupId>CSS_ISIS</groupId>
+    <version>1.0.0-SNAPSHOT</version>
+    <artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
+    <relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
+  </parent>
+  <version>1.0.0-SNAPSHOT</version>
+</project>

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
@@ -7,7 +7,6 @@ public class Journal extends AbstractUIPlugin {
 
     private static Journal instance;
     private static JournalModel model;
-//    private static BundleContext context;
 
     /**
      * @return The instance of this singleton.
@@ -23,30 +22,23 @@ public class Journal extends AbstractUIPlugin {
         return instance;
     }
 
-//    private final JournalModel model;
-
     /**
      * The constructor for the activator. Creates a new model and counter.
      */
     public Journal() {
         super();
+        instance = this;
+        model = new JournalModel(getPreferenceStore());
     }
 
     @Override
     public void start(BundleContext bundleContext) throws Exception {
         super.start(bundleContext);
-        instance = this;
     }
 
     @Override
     public void stop(BundleContext bundleContext) throws Exception {
-        instance = null;
         super.stop(bundleContext);
-//        model.stop();
-    }
-
-    public static void saySomething() {
-        System.out.println("something");
     }
 
 }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
@@ -3,6 +3,9 @@ package uk.ac.stfc.isis.ibex.journal;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
+/**
+ * The singleton class for the journal backend.
+ */
 public class Journal extends AbstractUIPlugin {
 
     private static Journal instance;
@@ -11,17 +14,13 @@ public class Journal extends AbstractUIPlugin {
     /**
      * @return The instance of this singleton.
      */
-    public static Journal getInstance() {
-        return instance;
-    }
-
-    /**
-     * @return The instance of this singleton.
-     */
     public static Journal getDefault() {
         return instance;
     }
 
+    /**
+     * @return The journal model.
+     */
     public JournalModel getModel() {
         return model;
     }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
@@ -4,7 +4,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
 /**
- * The singleton class for the journal backend.
+ * The singleton class for the journal back end.
  */
 public class Journal extends AbstractUIPlugin {
 

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
@@ -22,6 +22,10 @@ public class Journal extends AbstractUIPlugin {
         return instance;
     }
 
+    public JournalModel getModel() {
+        return model;
+    }
+
     /**
      * The constructor for the activator. Creates a new model and counter.
      */

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/Journal.java
@@ -1,0 +1,52 @@
+package uk.ac.stfc.isis.ibex.journal;
+
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+public class Journal extends AbstractUIPlugin {
+
+    private static Journal instance;
+    private static JournalModel model;
+//    private static BundleContext context;
+
+    /**
+     * @return The instance of this singleton.
+     */
+    public static Journal getInstance() {
+        return instance;
+    }
+
+    /**
+     * @return The instance of this singleton.
+     */
+    public static Journal getDefault() {
+        return instance;
+    }
+
+//    private final JournalModel model;
+
+    /**
+     * The constructor for the activator. Creates a new model and counter.
+     */
+    public Journal() {
+        super();
+    }
+
+    @Override
+    public void start(BundleContext bundleContext) throws Exception {
+        super.start(bundleContext);
+        instance = this;
+    }
+
+    @Override
+    public void stop(BundleContext bundleContext) throws Exception {
+        instance = null;
+        super.stop(bundleContext);
+//        model.stop();
+    }
+
+    public static void saySomething() {
+        System.out.println("something");
+    }
+
+}

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -29,16 +29,34 @@ import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.journal.preferences.PreferenceConstants;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
-public class JournalModel extends ModelObject {
+public class JournalModel extends ModelObject implements Runnable {
 
     IPreferenceStore preferenceStore;
 
     private String message = "";
     private boolean connectionSuccess = false;
 
+    private final static int REFRESH_INTERVAL = 60 * 1000;
+
     public JournalModel(IPreferenceStore preferenceStore) {
         this.preferenceStore = preferenceStore;
-        refresh();
+        Thread thread = new Thread(this);
+        thread.start();
+    }
+
+    /**
+     * Periodically tries to fetch new data from the database.
+     */
+    @Override
+    public void run() {
+        while (true) {
+            refresh();
+            try {
+                Thread.sleep(REFRESH_INTERVAL);
+            } catch (InterruptedException e) {
+                // e.printStackTrace();
+            }
+        }
     }
 
     public void refresh() {

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -29,6 +29,9 @@ import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.journal.preferences.PreferenceConstants;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
+/**
+ * Fetches and stores journal data from a SQL database.
+ */
 public class JournalModel extends ModelObject implements Runnable {
 
     IPreferenceStore preferenceStore;

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -21,10 +21,12 @@ package uk.ac.stfc.isis.ibex.journal;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jface.preference.IPreferenceStore;
 
 import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.journal.preferences.PreferenceConstants;
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
 /**
@@ -38,6 +40,7 @@ public class JournalModel extends ModelObject implements Runnable {
     private boolean connectionSuccess = false;
 
     private final static int REFRESH_INTERVAL = 60 * 1000;
+    private static final Logger LOG = IsisLog.getLogger(JournalModel.class);
 
 	/**
 	 * Constructor for the journal model. Takes a preferenceStore as an argument
@@ -84,6 +87,7 @@ public class JournalModel extends ModelObject implements Runnable {
         } catch (Exception ex) {
             setConnectionSuccess(false);
             setMessage(Rdb.getError(ex).toString());
+            LOG.error(ex);
         }
     }
 

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -1,0 +1,71 @@
+ /*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.journal;
+
+import java.sql.SQLRecoverableException;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import uk.ac.stfc.isis.ibex.databases.Rdb;
+import uk.ac.stfc.isis.ibex.journal.preferences.PreferenceConstants;
+
+public class JournalModel {
+
+    IPreferenceStore preferenceStore;
+    Rdb rdb;
+
+    private static final String CONNECTION_ERROR_MESSAGE = "Error connecting to MySQL database.";
+    private static final String UNKNOWN_DATABASE_MESSAGE = "Unknown database name.";
+    private static final String ACCESS_DENIED_MESSAGE = "Database access denied.";
+
+    public JournalModel(IPreferenceStore preferenceStore) {
+        this.preferenceStore = preferenceStore;
+        connect();
+    }
+
+    private void connect() {
+        try {
+            String schema = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_SCHEMA);
+            String user = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_USERNAME);
+            String password = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_PASSWORD);
+
+            rdb = Rdb.connectToDatabase(schema, user, password);
+
+        } catch (Exception ex) {
+            // TODO handle properly
+            System.out.println(errorMessage(ex));
+        }
+    }
+
+    private String errorMessage(Exception ex) {
+        if (ex instanceof SQLRecoverableException) {
+            return CONNECTION_ERROR_MESSAGE;
+        }
+
+        if (ex.getMessage().startsWith("Unknown database")) {
+            return UNKNOWN_DATABASE_MESSAGE;
+        }
+
+        return ACCESS_DENIED_MESSAGE;
+    }
+
+}

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -59,6 +59,9 @@ public class JournalModel extends ModelObject implements Runnable {
         }
     }
 
+    /**
+     * Attempts to connect to the database and updates the status accordingly.
+     */
     public void refresh() {
         try {
             String schema = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_SCHEMA);
@@ -87,18 +90,34 @@ public class JournalModel extends ModelObject implements Runnable {
         return DbError.ACCESS_DENIED;
     }
 
+    /**
+     * Sets the connection status message to display.
+     * 
+     * @param message The message
+     */
     public void setMessage(String message) {
         firePropertyChange("message", this.message, this.message = message);
     }
 
+    /**
+     * @return The connection status message
+     */
     public String getMessage() {
         return this.message;
     }
 
+    /**
+     * Sets the current connection status.
+     * 
+     * @param connectionSuccess The connection status
+     */
     public void setConnectionSuccess(boolean connectionSuccess) {
         firePropertyChange("connectionSuccess", this.connectionSuccess, this.connectionSuccess = connectionSuccess);
     }
 
+    /**
+     * @return The connection status
+     */
     public boolean getConnectionSuccess() {
         return this.connectionSuccess;
     }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -18,13 +18,11 @@
 
 package uk.ac.stfc.isis.ibex.journal;
 
-import java.sql.SQLRecoverableException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
-import uk.ac.stfc.isis.ibex.databases.DbError;
 import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.journal.preferences.PreferenceConstants;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
@@ -41,6 +39,12 @@ public class JournalModel extends ModelObject implements Runnable {
 
     private final static int REFRESH_INTERVAL = 60 * 1000;
 
+	/**
+	 * Constructor for the journal model. Takes a preferenceStore as an argument
+	 * from which to extract the journal db details.
+	 * 
+	 * @param preferenceStore The preference store
+	 */
     public JournalModel(IPreferenceStore preferenceStore) {
         this.preferenceStore = preferenceStore;
         Thread thread = new Thread(this);
@@ -79,18 +83,8 @@ public class JournalModel extends ModelObject implements Runnable {
 
         } catch (Exception ex) {
             setConnectionSuccess(false);
-            setMessage(getError(ex).toString());
+            setMessage(Rdb.getError(ex).toString());
         }
-    }
-
-    private DbError getError(Exception ex) {
-        if (ex instanceof SQLRecoverableException) {
-            return DbError.CONNECTION_ERROR;
-        }
-        if (ex.getMessage().startsWith("Unknown database")) {
-            return DbError.UNKNOWN_DB;
-        }
-        return DbError.ACCESS_DENIED;
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -16,9 +16,6 @@
  * http://opensource.org/licenses/eclipse-1.0.php
  */
 
-/**
- * 
- */
 package uk.ac.stfc.isis.ibex.journal;
 
 import java.sql.SQLRecoverableException;
@@ -27,33 +24,36 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.journal.preferences.PreferenceConstants;
+import uk.ac.stfc.isis.ibex.model.ModelObject;
 
-public class JournalModel {
+public class JournalModel extends ModelObject {
 
     IPreferenceStore preferenceStore;
-    Rdb rdb;
 
     private static final String CONNECTION_ERROR_MESSAGE = "Error connecting to MySQL database.";
     private static final String UNKNOWN_DATABASE_MESSAGE = "Unknown database name.";
     private static final String ACCESS_DENIED_MESSAGE = "Database access denied.";
 
+    private String errorMsg = "";
+
     public JournalModel(IPreferenceStore preferenceStore) {
         this.preferenceStore = preferenceStore;
-        connect();
+        query();
     }
 
-    private void connect() {
+    private void query() {
         try {
             String schema = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_SCHEMA);
             String user = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_USERNAME);
             String password = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_PASSWORD);
 
-            rdb = Rdb.connectToDatabase(schema, user, password);
+            Rdb rdb = Rdb.connectToDatabase(schema, user, password);
+            setErrorMsg("");
 
         } catch (Exception ex) {
-            // TODO handle properly
-            System.out.println(errorMessage(ex));
+            setErrorMsg(errorMessage(ex));
         }
+
     }
 
     private String errorMessage(Exception ex) {
@@ -66,6 +66,14 @@ public class JournalModel {
         }
 
         return ACCESS_DENIED_MESSAGE;
+    }
+
+    public void setErrorMsg(String errorMsg) {
+        firePropertyChange("errorMsg", this.errorMsg, this.errorMsg = errorMsg);
+    }
+
+    public String getErrorMsg() {
+        return this.errorMsg;
     }
 
 }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -34,26 +34,25 @@ public class JournalModel extends ModelObject {
     private static final String UNKNOWN_DATABASE_MESSAGE = "Unknown database name.";
     private static final String ACCESS_DENIED_MESSAGE = "Database access denied.";
 
-    private String errorMsg = "";
+    private String message = "";
 
     public JournalModel(IPreferenceStore preferenceStore) {
         this.preferenceStore = preferenceStore;
-        query();
+        refresh();
     }
 
-    private void query() {
+    public void refresh() {
         try {
             String schema = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_SCHEMA);
             String user = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_USERNAME);
             String password = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_PASSWORD);
 
             Rdb rdb = Rdb.connectToDatabase(schema, user, password);
-            setErrorMsg("");
+            setMessage("Connected");
 
         } catch (Exception ex) {
-            setErrorMsg(errorMessage(ex));
+            setMessage(errorMessage(ex));
         }
-
     }
 
     private String errorMessage(Exception ex) {
@@ -68,12 +67,12 @@ public class JournalModel extends ModelObject {
         return ACCESS_DENIED_MESSAGE;
     }
 
-    public void setErrorMsg(String errorMsg) {
-        firePropertyChange("errorMsg", this.errorMsg, this.errorMsg = errorMsg);
+    public void setMessage(String message) {
+        firePropertyChange("message", this.message, this.message = message);
     }
 
-    public String getErrorMsg() {
-        return this.errorMsg;
+    public String getMessage() {
+        return this.message;
     }
 
 }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/OnInstrumentSwitch.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/OnInstrumentSwitch.java
@@ -19,33 +19,36 @@
 /**
  * 
  */
-package uk.ac.stfc.isis.ibex.ui.journalviewer.models;
+package uk.ac.stfc.isis.ibex.journal;
 
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
+import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
+import uk.ac.stfc.isis.ibex.instrument.InstrumentInfoReceiver;
 
-import uk.ac.stfc.isis.ibex.journal.Journal;
-import uk.ac.stfc.isis.ibex.journal.JournalModel;
-import uk.ac.stfc.isis.ibex.model.ModelObject;
+/**
+ * This class is responsible for updating all connections when an instrument is
+ * switched.
+ */
+public class OnInstrumentSwitch implements InstrumentInfoReceiver {
 
-public class JournalViewModel extends ModelObject {
-
-    private JournalModel model;
-
-    PropertyChangeListener passThroughListener = new PropertyChangeListener() {
-        @Override
-        public void propertyChange(PropertyChangeEvent evt) {
-            firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
-        }
-    };
-
-    public JournalViewModel() {
-        model = Journal.getInstance().getModel();
-        model.addPropertyChangeListener(passThroughListener);
+    /**
+     * Updates the journal model on switching instrument.
+     * 
+     * @param instrument
+     *            The instrument to switch to.
+     */
+    @Override
+    public void setInstrument(InstrumentInfo instrument) {
+        //
     }
 
-    public String getMessage() {
-        return model.getMessage();
+    @Override
+    public void preSetInstrument(InstrumentInfo instrument) {
+        //
     }
 
+    @Override
+    public void postSetInstrument(InstrumentInfo instrument) {
+        System.out.println("SETINST");
+        Journal.getInstance().getModel().refresh();
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/OnInstrumentSwitch.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/OnInstrumentSwitch.java
@@ -48,6 +48,6 @@ public class OnInstrumentSwitch implements InstrumentInfoReceiver {
 
     @Override
     public void postSetInstrument(InstrumentInfo instrument) {
-        Journal.getInstance().getModel().refresh();
+        Journal.getDefault().getModel().refresh();
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceConstants.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceConstants.java
@@ -1,0 +1,46 @@
+ /*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.journal.preferences;
+
+/**
+ *
+ */
+public class PreferenceConstants {
+
+    /** The username to connect to the journal database. **/
+    public static final String P_JOURNAL_SQL_USERNAME = "sqlJournalUsername";
+    /** The password to connect to the journal database. **/
+    public static final String P_JOURNAL_SQL_PASSWORD = "sqlJournalPassword";
+    /** The schema to connect to the journal database. **/
+    public static final String P_JOURNAL_SQL_SCHEMA = "sqlJournalSchema";
+
+    /** The default for the database username. **/
+    public static final String DEFAULT_JOURNAL_SQL_USERNAME = "report";
+    /** The default for the database password. **/
+    public static final String DEFAULT_JOURNAL_SQL_PASSWORD = "$report";
+    /** The default for the database schema. **/
+    public static final String DEFAULT_JOURNAL_SQL_SCHEMA = "journal";
+
+    private PreferenceConstants() {
+    }
+
+}

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceConstants.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceConstants.java
@@ -22,7 +22,7 @@
 package uk.ac.stfc.isis.ibex.journal.preferences;
 
 /**
- *
+ * Preference constants related to the journal viewer.
  */
 public class PreferenceConstants {
 

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceInitialiser.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceInitialiser.java
@@ -1,0 +1,40 @@
+ /*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.journal.preferences;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.jface.preference.IPreferenceStore;
+
+import uk.ac.stfc.isis.ibex.journal.Journal;
+
+public class PreferenceInitialiser extends AbstractPreferenceInitializer {
+
+    @Override
+    public void initializeDefaultPreferences() {
+        IPreferenceStore store = Journal.getInstance().getPreferenceStore();
+
+        store.setDefault(PreferenceConstants.P_JOURNAL_SQL_USERNAME, PreferenceConstants.DEFAULT_JOURNAL_SQL_USERNAME);
+        store.setDefault(PreferenceConstants.P_JOURNAL_SQL_PASSWORD, PreferenceConstants.DEFAULT_JOURNAL_SQL_PASSWORD);
+        store.setDefault(PreferenceConstants.P_JOURNAL_SQL_SCHEMA, PreferenceConstants.DEFAULT_JOURNAL_SQL_SCHEMA);
+    }
+
+}

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceInitializer.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceInitializer.java
@@ -26,11 +26,15 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import uk.ac.stfc.isis.ibex.journal.Journal;
 
+/**
+ * Initialises preferences related to the journal viewer in the preference store
+ * with default values.
+ */
 public class PreferenceInitializer extends AbstractPreferenceInitializer {
 
     @Override
     public void initializeDefaultPreferences() {
-        IPreferenceStore store = Journal.getInstance().getPreferenceStore();
+        IPreferenceStore store = Journal.getDefault().getPreferenceStore();
 
         store.setDefault(PreferenceConstants.P_JOURNAL_SQL_USERNAME, PreferenceConstants.DEFAULT_JOURNAL_SQL_USERNAME);
         store.setDefault(PreferenceConstants.P_JOURNAL_SQL_PASSWORD, PreferenceConstants.DEFAULT_JOURNAL_SQL_PASSWORD);

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceInitializer.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceInitializer.java
@@ -26,7 +26,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 
 import uk.ac.stfc.isis.ibex.journal.Journal;
 
-public class PreferenceInitialiser extends AbstractPreferenceInitializer {
+public class PreferenceInitializer extends AbstractPreferenceInitializer {
 
     @Override
     public void initializeDefaultPreferences() {

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/package-info.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * 
+ */
+/**
+ * Provides the preferences for dealing with the journal database.
+ */
+package uk.ac.stfc.isis.ibex.journal.preferences;

--- a/base/uk.ac.stfc.isis.ibex.log/src/uk/ac/stfc/isis/ibex/log/Log.java
+++ b/base/uk.ac.stfc.isis.ibex.log/src/uk/ac/stfc/isis/ibex/log/Log.java
@@ -79,7 +79,7 @@ public class Log extends AbstractUIPlugin {
 
     @Override
     public void start(BundleContext bundleContext) throws Exception {
-	Log.context = bundleContext;
+        Log.context = bundleContext;
     }
 
     @Override

--- a/base/uk.ac.stfc.isis.ibex.log/src/uk/ac/stfc/isis/ibex/log/LogModel.java
+++ b/base/uk.ac.stfc.isis.ibex.log/src/uk/ac/stfc/isis/ibex/log/LogModel.java
@@ -33,6 +33,7 @@ import uk.ac.stfc.isis.ibex.activemq.ActiveMQ;
 import uk.ac.stfc.isis.ibex.activemq.ReceiveSession;
 import uk.ac.stfc.isis.ibex.activemq.message.IMessageConsumer;
 import uk.ac.stfc.isis.ibex.activemq.message.MessageParser;
+import uk.ac.stfc.isis.ibex.databases.DbError;
 import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.log.jms.XmlLogMessageParser;
 import uk.ac.stfc.isis.ibex.log.message.LogMessage;
@@ -51,12 +52,6 @@ public class LogModel extends ModelObject implements ILogMessageProducer,
      * cache. When the cache size is exceeded, older messages will be dropped
      */
     private static final int MAX_CACHE_MESSAGES = 10000;
-
-    private static final String CONNECTION_ERROR_MESSAGE = "Error connecting to MySQL database.";
-
-    private static final String UNKNOWN_DATABASE_MESSAGE = "Unknown database name.";
-
-    private static final String ACCESS_DENIED_MESSAGE = "Database access denied.";
 
     private IPreferenceStore preferenceStore = Log.getDefault().getPreferenceStore();
 
@@ -145,7 +140,7 @@ public class LogModel extends ModelObject implements ILogMessageProducer,
             LogMessageQuery query = new LogMessageQuery(rdb);
             return query.getMessages(field, value, from, to);
         } catch (SQLException ex) {
-            throw new Exception(errorMessage(ex), ex);
+            throw new Exception(getError(ex).toString(), ex);
         }
     }
 
@@ -157,15 +152,15 @@ public class LogModel extends ModelObject implements ILogMessageProducer,
         }
     }
 
-    private String errorMessage(SQLException ex) {
+    private DbError getError(SQLException ex) {
         if (ex instanceof CommunicationsException) {
-            return CONNECTION_ERROR_MESSAGE;
+            return DbError.CONNECTION_ERROR;
         }
 
         if (ex.getMessage().startsWith("Unknown database")) {
-            return UNKNOWN_DATABASE_MESSAGE;
+            return DbError.UNKNOWN_DB;
         }
 
-        return ACCESS_DENIED_MESSAGE;
+        return DbError.ACCESS_DENIED;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.log/src/uk/ac/stfc/isis/ibex/log/LogModel.java
+++ b/base/uk.ac.stfc.isis.ibex.log/src/uk/ac/stfc/isis/ibex/log/LogModel.java
@@ -27,13 +27,10 @@ import java.util.List;
 
 import org.eclipse.jface.preference.IPreferenceStore;
 
-import com.mysql.jdbc.exceptions.jdbc4.CommunicationsException;
-
 import uk.ac.stfc.isis.ibex.activemq.ActiveMQ;
 import uk.ac.stfc.isis.ibex.activemq.ReceiveSession;
 import uk.ac.stfc.isis.ibex.activemq.message.IMessageConsumer;
 import uk.ac.stfc.isis.ibex.activemq.message.MessageParser;
-import uk.ac.stfc.isis.ibex.databases.DbError;
 import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.log.jms.XmlLogMessageParser;
 import uk.ac.stfc.isis.ibex.log.message.LogMessage;
@@ -140,7 +137,7 @@ public class LogModel extends ModelObject implements ILogMessageProducer,
             LogMessageQuery query = new LogMessageQuery(rdb);
             return query.getMessages(field, value, from, to);
         } catch (SQLException ex) {
-            throw new Exception(getError(ex).toString(), ex);
+            throw new Exception(Rdb.getError(ex).toString(), ex);
         }
     }
 
@@ -150,17 +147,5 @@ public class LogModel extends ModelObject implements ILogMessageProducer,
         for (IMessageConsumer<LogMessage> receiver : messageReceivers) {
             receiver.clearMessages();
         }
-    }
-
-    private DbError getError(SQLException ex) {
-        if (ex instanceof CommunicationsException) {
-            return DbError.CONNECTION_ERROR;
-        }
-
-        if (ex.getMessage().startsWith("Unknown database")) {
-            return DbError.UNKNOWN_DB;
-        }
-
-        return DbError.ACCESS_DENIED;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.log/src/uk/ac/stfc/isis/ibex/log/preferences/package-info.java
+++ b/base/uk.ac.stfc.isis.ibex.log/src/uk/ac/stfc/isis/ibex/log/preferences/package-info.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the ISIS IBEX application. Copyright (C) 2012-2016
+ * This file is part of the ISIS IBEX application. Copyright (C) 2012-2018
  * Science & Technology Facilities Council. All rights reserved.
  *
  * This program is distributed in the hope that it will be useful. This program
@@ -17,6 +17,6 @@
  */
 
 /**
- * Provides the preferences for dealing with the lg messages.
+ * Provides the preferences for dealing with the log messages.
  */
 package uk.ac.stfc.isis.ibex.log.preferences;

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/.classpath
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/.classpath
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/.project
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>uk.ac.stfc.isis.ibex.ui.journalviewer.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,9 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Tests
+Bundle-SymbolicName: uk.ac.stfc.isis.ibex.ui.journalviewer.tests
+Bundle-Version: 1.0.0.qualifier
+Fragment-Host: uk.ac.stfc.isis.ibex.ui.journalviewer;bundle-version="1.0.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Require-Bundle: org.junit;bundle-version="4.11.0",
+ org.mockito;bundle-version="1.9.5"

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/build.properties
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/pom.xml
@@ -1,0 +1,11 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>uk.ac.stfc.isis.ibex.ui.journalviewer.tests</artifactId>
+  <packaging>eclipse-test-plugin</packaging>
+  <parent>
+  	<groupId>CSS_ISIS</groupId>
+  	<artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
+  	<version>1.0.0-SNAPSHOT</version>
+  	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
+  </parent>
+</project>

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/pom.xml
@@ -8,4 +8,5 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
+  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
@@ -1,0 +1,113 @@
+ /*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.ui.journalviewer.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.wb.swt.SWTResourceManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.journal.JournalModel;
+import uk.ac.stfc.isis.ibex.ui.journalviewer.models.JournalViewModel;
+
+/**
+ * Tests for the JournalViewModel class.
+ */
+public class JournalViewModelTest {
+
+    private JournalViewModel viewModel;
+    private JournalModel model;
+
+    @Before
+    public void setUp() {
+        if (Display.getCurrent() == null) {
+            new Display();
+        }
+        model = mock(JournalModel.class);
+    }
+
+    @Test
+    public void GIVEN_connection_success_THEN_message_shows_last_refresh() {
+        // Arrange
+        String timestamp = "11:12:13";
+        when(model.getConnectionSuccess()).thenReturn(true);
+        when(model.getMessage()).thenReturn(timestamp);
+        String expected = "Last refresh: " + timestamp;
+        
+        // Act
+        viewModel = new JournalViewModel(model);
+        String actual = viewModel.getMessage();
+        
+        // Assert
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void GIVEN_connection_success_THEN_message_colour_is_neutral() {
+        // Arrange
+        when(model.getConnectionSuccess()).thenReturn(true);
+        Color expected = SWTResourceManager.getColor(SWT.COLOR_BLACK);
+
+        // Act
+        viewModel = new JournalViewModel(model);
+        Color actual = viewModel.getColor();
+
+        // Assert
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void GIVEN_connection_failed_THEN_message_shows_error() {
+        // Arrange
+        String error = "Something went wrong";
+        when(model.getConnectionSuccess()).thenReturn(false);
+        when(model.getMessage()).thenReturn(error);
+        String expected = "Error retrieving data: " + error;
+
+        // Act
+        viewModel = new JournalViewModel(model);
+        String actual = viewModel.getMessage();
+
+        // Assert
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void GIVEN_connection_failed_THEN_message_colour_is_error() {
+        // Arrange
+        when(model.getConnectionSuccess()).thenReturn(false);
+        Color expected = SWTResourceManager.getColor(SWT.COLOR_RED);
+
+        // Act
+        viewModel = new JournalViewModel(model);
+        Color actual = viewModel.getColor();
+
+        // Assert
+        assertEquals(expected, actual);
+    }
+
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
@@ -1,6 +1,6 @@
  /*
  * This file is part of the ISIS IBEX application.
- * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * Copyright (C) 2012-2018 Science & Technology Facilities Council.
  * All rights reserved.
  *
  * This program is distributed in the hope that it will be useful.
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.*;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.wb.swt.SWTResourceManager;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,9 +43,6 @@ public class JournalViewModelTest {
 
     @Before
     public void setUp() {
-        if (Display.getCurrent() == null) {
-            new Display();
-        }
         model = mock(JournalModel.class);
     }
 
@@ -70,7 +66,7 @@ public class JournalViewModelTest {
     public void GIVEN_connection_success_THEN_message_colour_is_neutral() {
         // Arrange
         when(model.getConnectionSuccess()).thenReturn(true);
-        Color expected = SWTResourceManager.getColor(SWT.COLOR_BLACK);
+        Color expected = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
 
         // Act
         viewModel = new JournalViewModel(model);
@@ -100,7 +96,7 @@ public class JournalViewModelTest {
     public void GIVEN_connection_failed_THEN_message_colour_is_error() {
         // Arrange
         when(model.getConnectionSuccess()).thenReturn(false);
-        Color expected = SWTResourceManager.getColor(SWT.COLOR_RED);
+        Color expected = Display.getDefault().getSystemColor(SWT.COLOR_RED);
 
         // Act
         viewModel = new JournalViewModel(model);

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/package-info.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/package-info.java
@@ -17,6 +17,6 @@
  */
 
 /**
- * Contains tests for the journal plug-in.
+ * Contains tests for the journal viewer UI plug-in.
  */
-package uk.ac.stfc.isis.ibex.journal.tests;
+package uk.ac.stfc.isis.ibex.ui.journalviewer.tests;

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/META-INF/MANIFEST.MF
@@ -7,6 +7,7 @@ Bundle-Activator: uk.ac.stfc.isis.ibex.ui.journalviewer.JournalViewerUI
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  uk.ac.stfc.isis.ibex.ui;bundle-version="1.0.0",
- uk.ac.stfc.isis.ibex.ui.perspectives;bundle-version="1.0.0"
+ uk.ac.stfc.isis.ibex.ui.perspectives;bundle-version="1.0.0",
+ uk.ac.stfc.isis.ibex.journal;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  uk.ac.stfc.isis.ibex.ui;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.ui.perspectives;bundle-version="1.0.0",
- uk.ac.stfc.isis.ibex.journal;bundle-version="1.0.0"
+ uk.ac.stfc.isis.ibex.journal;bundle-version="1.0.0",
+ uk.ac.stfc.isis.ibex.model
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
@@ -22,6 +22,7 @@ package uk.ac.stfc.isis.ibex.ui.journalviewer;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
+import uk.ac.stfc.isis.ibex.journal.Journal;
 import uk.ac.stfc.isis.ibex.ui.journalviewer.models.JournalViewModel;
 
 /**
@@ -42,7 +43,7 @@ public class JournalViewerUI extends AbstractUIPlugin {
      * The constructor.
      */
 	public JournalViewerUI() {
-        model = new JournalViewModel();
+        model = new JournalViewModel(Journal.getInstance().getModel());
 	}
 	
 	/*

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
@@ -43,7 +43,7 @@ public class JournalViewerUI extends AbstractUIPlugin {
      * The constructor.
      */
 	public JournalViewerUI() {
-        model = new JournalViewModel(Journal.getInstance().getModel());
+        model = new JournalViewModel(Journal.getDefault().getModel());
 	}
 	
 	/*

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
@@ -22,6 +22,7 @@ package uk.ac.stfc.isis.ibex.ui.journalviewer;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 
+import uk.ac.stfc.isis.ibex.ui.journalviewer.models.JournalViewModel;
 
 /**
  * The activator class controls the plug-in life cycle.
@@ -35,11 +36,13 @@ public class JournalViewerUI extends AbstractUIPlugin {
 
 	// The shared instance
 	private static JournalViewerUI plugin;
+    private JournalViewModel model;
 	
 	/**
      * The constructor.
      */
 	public JournalViewerUI() {
+        model = new JournalViewModel();
 	}
 	
 	/*
@@ -70,5 +73,9 @@ public class JournalViewerUI extends AbstractUIPlugin {
 	public static JournalViewerUI getDefault() {
 		return plugin;
 	}
+
+    public JournalViewModel getModel() {
+        return model;
+    }
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
@@ -1,7 +1,7 @@
 
 /*
 * This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* Copyright (C) 2012-2018 Science & Technology Facilities Council.
 * All rights reserved.
 *
 * This program is distributed in the hope that it will be useful.

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerUI.java
@@ -74,6 +74,11 @@ public class JournalViewerUI extends AbstractUIPlugin {
 		return plugin;
 	}
 
+    /**
+     * Returns the viewmodel for the Journal Viewer UI.
+     * 
+     * @return the viewmodel
+     */
     public JournalViewModel getModel() {
         return model;
     }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -72,6 +72,8 @@ public class JournalViewerView extends ViewPart {
 
         bindingContext.bindValue(WidgetProperties.text().observe(lblError),
                 BeanProperties.value("message").observe(model));
+        bindingContext.bindValue(WidgetProperties.foreground().observe(lblError),
+                BeanProperties.value("color").observe(model));
 
     }
 

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -74,7 +74,6 @@ public class JournalViewerView extends ViewPart {
                 BeanProperties.value("message").observe(model));
         bindingContext.bindValue(WidgetProperties.foreground().observe(lblError),
                 BeanProperties.value("color").observe(model));
-
     }
 
 	@Override

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -19,14 +19,18 @@
 
 package uk.ac.stfc.isis.ibex.ui.journalviewer;
 
+import org.eclipse.core.databinding.DataBindingContext;
+import org.eclipse.core.databinding.beans.BeanProperties;
+import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.wb.swt.SWTResourceManager;
 
-import uk.ac.stfc.isis.ibex.journal.Journal;
+import uk.ac.stfc.isis.ibex.ui.journalviewer.models.JournalViewModel;
 
 /**
  * Journal viewer main view.
@@ -38,6 +42,8 @@ public class JournalViewerView extends ViewPart {
      */
 	public static final String ID = "uk.ac.stfc.isis.ibex.ui.journalviewer.JournalViewerView"; //$NON-NLS-1$
 	
+    private Label lblError;
+
 	/**
 	 * Create contents of the view part.
 	 * @param parent
@@ -54,9 +60,21 @@ public class JournalViewerView extends ViewPart {
 		lblDescription.setFont(SWTResourceManager.getFont("Segoe UI", 11, SWT.NORMAL));
 		lblDescription.setText("This is the future home of the Journal Viewer. Watch this space...");
 
-        Journal j = Journal.getInstance();
+        lblError = new Label(parent, SWT.NONE);
+        lblError.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, true));
+        lblError.setText("placeholder");
+
+        bind(JournalViewerUI.getDefault().getModel());
 	}
 	
+    private void bind(JournalViewModel model) {
+        DataBindingContext bindingContext = new DataBindingContext();
+
+        bindingContext.bindValue(WidgetProperties.text().observe(lblError),
+                BeanProperties.value("errorMsg").observe(model));
+
+    }
+
 	@Override
 	public void dispose() {
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -26,6 +26,8 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.wb.swt.SWTResourceManager;
 
+import uk.ac.stfc.isis.ibex.journal.Journal;
+
 /**
  * Journal viewer main view.
  */
@@ -43,7 +45,7 @@ public class JournalViewerView extends ViewPart {
 	@Override
 	public void createPartControl(Composite parent) {
 		parent.setLayout(new GridLayout(1, false));
-		
+
 		Label lblTitle = new Label(parent, SWT.NONE);
 		lblTitle.setFont(SWTResourceManager.getFont("Segoe UI", 16, SWT.BOLD));
 		lblTitle.setText("Journal Viewer");
@@ -51,6 +53,8 @@ public class JournalViewerView extends ViewPart {
 		Label lblDescription = new Label(parent, SWT.NONE);
 		lblDescription.setFont(SWTResourceManager.getFont("Segoe UI", 11, SWT.NORMAL));
 		lblDescription.setText("This is the future home of the Journal Viewer. Watch this space...");
+
+        Journal j = Journal.getInstance();
 	}
 	
 	@Override

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -71,7 +71,7 @@ public class JournalViewerView extends ViewPart {
         DataBindingContext bindingContext = new DataBindingContext();
 
         bindingContext.bindValue(WidgetProperties.text().observe(lblError),
-                BeanProperties.value("errorMsg").observe(model));
+                BeanProperties.value("message").observe(model));
 
     }
 

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -1,7 +1,7 @@
 
 /*
 * This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* Copyright (C) 2012-2018 Science & Technology Facilities Council.
 * All rights reserved.
 *
 * This program is distributed in the hope that it will be useful.

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/Perspective.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/Perspective.java
@@ -1,7 +1,7 @@
 
 /*
 * This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* Copyright (C) 2012-2018 Science & Technology Facilities Council.
 * All rights reserved.
 *
 * This program is distributed in the hope that it will be useful.

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -24,28 +24,60 @@ package uk.ac.stfc.isis.ibex.ui.journalviewer.models;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.wb.swt.SWTResourceManager;
+
 import uk.ac.stfc.isis.ibex.journal.Journal;
 import uk.ac.stfc.isis.ibex.journal.JournalModel;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
 public class JournalViewModel extends ModelObject {
 
-    private JournalModel model;
+    private final static Color NEUTRAL_COLOR = SWTResourceManager.getColor(SWT.COLOR_BLACK);
+    private final static Color ERROR_COLOR = SWTResourceManager.getColor(SWT.COLOR_RED);
 
-    PropertyChangeListener passThroughListener = new PropertyChangeListener() {
+    private JournalModel model;
+    private Color color;
+    private String message;
+
+    PropertyChangeListener listener = new PropertyChangeListener() {
         @Override
         public void propertyChange(PropertyChangeEvent evt) {
-            firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
+            update();
         }
     };
 
     public JournalViewModel() {
         model = Journal.getInstance().getModel();
-        model.addPropertyChangeListener(passThroughListener);
+        model.addPropertyChangeListener(listener);
+    }
+
+    private void update() {
+        if (model.getConnectionSuccess()) {
+            setMessage("Last refresh: " + model.getMessage());
+            setColor(NEUTRAL_COLOR);
+        } else {
+            setMessage("Error retrieving data: " + model.getMessage());
+            setColor(ERROR_COLOR);
+        }
     }
 
     public String getMessage() {
-        return model.getMessage();
+        return message;
+    }
+
+    private void setMessage(String message) {
+        firePropertyChange("message", this.message, this.message = message);
+    }
+
+
+    public Color getColor() {
+        return color;
+    }
+
+    private void setColor(Color color) {
+        firePropertyChange("color", this.color, this.color = color);
     }
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -1,6 +1,6 @@
  /*
  * This file is part of the ISIS IBEX application.
- * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * Copyright (C) 2012-2018 Science & Technology Facilities Council.
  * All rights reserved.
  *
  * This program is distributed in the hope that it will be useful.
@@ -26,7 +26,7 @@ import java.beans.PropertyChangeListener;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.wb.swt.SWTResourceManager;
+import org.eclipse.swt.widgets.Display;
 
 import uk.ac.stfc.isis.ibex.journal.JournalModel;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
@@ -39,12 +39,12 @@ public class JournalViewModel extends ModelObject {
     /**
      * A neutral color for the status message text.
      */
-    private static final Color NEUTRAL_COLOR = SWTResourceManager.getColor(SWT.COLOR_BLACK);
+    private static final Color NEUTRAL_COLOR = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
 
     /**
      * A color indicating an error for the status message text.
      */
-    private static final Color ERROR_COLOR = SWTResourceManager.getColor(SWT.COLOR_RED);
+    private static final Color ERROR_COLOR = Display.getDefault().getSystemColor(SWT.COLOR_RED);
 
     private JournalModel model;
     private Color color;

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -1,0 +1,51 @@
+ /*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.ui.journalviewer.models;
+
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+import uk.ac.stfc.isis.ibex.journal.Journal;
+import uk.ac.stfc.isis.ibex.journal.JournalModel;
+import uk.ac.stfc.isis.ibex.model.ModelObject;
+
+public class JournalViewModel extends ModelObject {
+
+    private JournalModel model;
+
+    PropertyChangeListener passThroughListener = new PropertyChangeListener() {
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            firePropertyChange(evt.getPropertyName(), evt.getOldValue(), evt.getNewValue());
+        }
+    };
+
+    public JournalViewModel() {
+        model = Journal.getInstance().getModel();
+        model.addPropertyChangeListener(passThroughListener);
+    }
+
+    public String getErrorMsg() {
+        return model.getErrorMsg();
+    }
+
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -66,6 +66,7 @@ public class JournalViewModel extends ModelObject {
     public JournalViewModel(JournalModel model) {
         this.model = model;
         this.model.addPropertyChangeListener(listener);
+        update();
     }
 
     private void update() {

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -28,14 +28,23 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.wb.swt.SWTResourceManager;
 
-import uk.ac.stfc.isis.ibex.journal.Journal;
 import uk.ac.stfc.isis.ibex.journal.JournalModel;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
+/**
+ * The viewmodel providing data for the journal viewer view.
+ */
 public class JournalViewModel extends ModelObject {
 
-    private final static Color NEUTRAL_COLOR = SWTResourceManager.getColor(SWT.COLOR_BLACK);
-    private final static Color ERROR_COLOR = SWTResourceManager.getColor(SWT.COLOR_RED);
+    /**
+     * A neutral color for the status message text.
+     */
+    private static final Color NEUTRAL_COLOR = SWTResourceManager.getColor(SWT.COLOR_BLACK);
+
+    /**
+     * A color indicating an error for the status message text.
+     */
+    private static final Color ERROR_COLOR = SWTResourceManager.getColor(SWT.COLOR_RED);
 
     private JournalModel model;
     private Color color;
@@ -48,9 +57,15 @@ public class JournalViewModel extends ModelObject {
         }
     };
 
-    public JournalViewModel() {
-        model = Journal.getInstance().getModel();
-        model.addPropertyChangeListener(listener);
+    /**
+     * Constructor for the viewmodel. Takes a model of the journal backend to
+     * observe.
+     * 
+     * @param model The backend model
+     */
+    public JournalViewModel(JournalModel model) {
+        this.model = model;
+        this.model.addPropertyChangeListener(listener);
     }
 
     private void update() {
@@ -63,6 +78,9 @@ public class JournalViewModel extends ModelObject {
         }
     }
 
+    /**
+     * @return The connection status message.
+     */
     public String getMessage() {
         return message;
     }
@@ -71,7 +89,9 @@ public class JournalViewModel extends ModelObject {
         firePropertyChange("message", this.message, this.message = message);
     }
 
-
+    /**
+     * @return The color indicating the current connection status.
+     */
     public Color getColor() {
         return color;
     }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/package-info.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/package-info.java
@@ -17,6 +17,6 @@
  */
 
 /**
- * The front end classes for the Journal Viewer.
+ * The viewmodels used by the journal viewer front end.
  */
-package uk.ac.stfc.isis.ibex.ui.journalviewer;
+package uk.ac.stfc.isis.ibex.ui.journalviewer.models;


### PR DESCRIPTION
### Description of work

Added model and viewmodel to the journalviewer's MVVM stack. The backend model tries to establish a connection to the journal database on startup and instrument switching, as well as in regular intervals, at which point(s) it will fetch data from the database further down the line. For now, only success/failure establishing a connection is reported and reflected in the Journal viewer perspective.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2901

### Acceptance criteria

- [x] Connection to journal database can be established
- [x] Instrument switching is being handled properly
- [x] When failing to establish connection, the GUI provides good feedback (message is understandable and clearly visible)

### Unit tests

- Added tests for the view model
- Did not add tests for the model: unable to mock out connection to db

### System tests

Added tests 32-1, 32-2 in system tests spreadsheet

### Documentation
/

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

