### PR TITLE
Ticket2902 journal viewer refresh

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -18,7 +18,6 @@
 
 package uk.ac.stfc.isis.ibex.journal;
 
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import org.apache.logging.log4j.Logger;
@@ -38,8 +37,9 @@ public class JournalModel extends ModelObject implements Runnable {
 
     private String message = "";
     private boolean connectionSuccess = false;
+    private Date lastUpdate;
 
-    private final static int REFRESH_INTERVAL = 60 * 1000;
+    private static final int REFRESH_INTERVAL = 10 * 1000;
     private static final Logger LOG = IsisLog.getLogger(JournalModel.class);
 
 	/**
@@ -52,6 +52,8 @@ public class JournalModel extends ModelObject implements Runnable {
         this.preferenceStore = preferenceStore;
         Thread thread = new Thread(this);
         thread.start();
+
+        // TODO get last update
     }
 
     /**
@@ -64,7 +66,7 @@ public class JournalModel extends ModelObject implements Runnable {
             try {
                 Thread.sleep(REFRESH_INTERVAL);
             } catch (InterruptedException e) {
-                // e.printStackTrace();
+                LOG.error("Interrupted while trying to fetch journal data: " + e.getMessage());
             }
         }
     }
@@ -80,9 +82,9 @@ public class JournalModel extends ModelObject implements Runnable {
 
             Rdb rdb = Rdb.connectToDatabase(schema, user, password);
 
-            String timeStamp = new SimpleDateFormat("HH:mm:ss").format(new Date());
             setConnectionSuccess(true);
-            setMessage(timeStamp);
+            setMessage("");
+            setLastUpdate(new Date());
 
         } catch (Exception ex) {
             setConnectionSuccess(false);
@@ -123,4 +125,20 @@ public class JournalModel extends ModelObject implements Runnable {
         return this.connectionSuccess;
     }
 
+    /**
+     * Sets the date of the last successful update.
+     * 
+     * @param lastUpdate
+     *            The date of the last update
+     */
+    public void setLastUpdate(Date lastUpdate) {
+        firePropertyChange("lastUpdate", this.lastUpdate, this.lastUpdate = lastUpdate);
+    }
+
+    /**
+     * @return The date of the last successful update.
+     */
+    public Date getLastUpdate() {
+        return this.lastUpdate;
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -36,7 +36,6 @@ public class JournalModel extends ModelObject implements Runnable {
     IPreferenceStore preferenceStore;
 
     private String message = "";
-    private boolean connectionSuccess = false;
     private Date lastUpdate;
 
     private static final int REFRESH_INTERVAL = 10 * 1000;
@@ -52,8 +51,6 @@ public class JournalModel extends ModelObject implements Runnable {
         this.preferenceStore = preferenceStore;
         Thread thread = new Thread(this);
         thread.start();
-
-        // TODO get last update
     }
 
     /**
@@ -82,12 +79,10 @@ public class JournalModel extends ModelObject implements Runnable {
 
             Rdb rdb = Rdb.connectToDatabase(schema, user, password);
 
-            setConnectionSuccess(true);
             setMessage("");
             setLastUpdate(new Date());
 
         } catch (Exception ex) {
-            setConnectionSuccess(false);
             setMessage(Rdb.getError(ex).toString());
             LOG.error(ex);
         }
@@ -107,22 +102,6 @@ public class JournalModel extends ModelObject implements Runnable {
      */
     public String getMessage() {
         return this.message;
-    }
-
-    /**
-     * Sets the current connection status.
-     * 
-     * @param connectionSuccess The connection status
-     */
-    public void setConnectionSuccess(boolean connectionSuccess) {
-        firePropertyChange("connectionSuccess", this.connectionSuccess, this.connectionSuccess = connectionSuccess);
-    }
-
-    /**
-     * @return The connection status
-     */
-    public boolean getConnectionSuccess() {
-        return this.connectionSuccess;
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/package-info.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/package-info.java
@@ -17,6 +17,6 @@
 */
 
 /**
- * Provides the preferences for dealing with the journal database.
+ * Contains classes responsible for communicating with the journal database.
  */
-package uk.ac.stfc.isis.ibex.journal.preferences;
+package uk.ac.stfc.isis.ibex.journal;

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceConstants.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/preferences/PreferenceConstants.java
@@ -24,7 +24,7 @@ package uk.ac.stfc.isis.ibex.journal.preferences;
 /**
  * Preference constants related to the journal viewer.
  */
-public class PreferenceConstants {
+public final class PreferenceConstants {
 
     /** The username to connect to the journal database. **/
     public static final String P_JOURNAL_SQL_USERNAME = "sqlJournalUsername";

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
@@ -50,41 +50,9 @@ public class JournalViewModelTest {
     }
 
     @Test
-    public void GIVEN_connection_success_THEN_last_update_time_is_correct() {
+    public void GIVEN_message_in_model_THEN_viewmodel_returns_same_message() {
         // Arrange
-        Date lastUpdate = new Date();
-        when(model.getConnectionSuccess()).thenReturn(true);
-        when(model.getLastUpdate()).thenReturn(lastUpdate);
-        String expected = LAST_UPDATE_MESSAGE + DateFormat.getTimeInstance(DateFormat.MEDIUM).format(lastUpdate);
-
-        // Act
-        viewModel = new JournalViewModel(model);
-        String actual = viewModel.getLastUpdate();
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void GIVEN_last_update_not_today_THEN_last_update_time_contains_day() {
-        // Arrange
-        Date lastUpdate = new Date(System.currentTimeMillis() - DAY_IN_MILLIS);
-        when(model.getConnectionSuccess()).thenReturn(true);
-        when(model.getLastUpdate()).thenReturn(lastUpdate);
-        String expected = LAST_UPDATE_MESSAGE + DateFormat.getDateTimeInstance().format(lastUpdate);
-        // Act
-        viewModel = new JournalViewModel(model);
-        String actual = viewModel.getLastUpdate();
-
-        // Assert
-        assertEquals(expected, actual);
-    }
-
-    @Test
-    public void GIVEN_connection_failed_THEN_message_shows_error() {
-        // Arrange
-        String error = "Something went wrong";
-        when(model.getConnectionSuccess()).thenReturn(false);
+        String error = "Some message";
         when(model.getMessage()).thenReturn(error);
         String expected = error;
 
@@ -97,9 +65,23 @@ public class JournalViewModelTest {
     }
 
     @Test
+    public void GIVEN_last_updated_is_today_THEN_last_updated_string_contains_time_only() {
+        // Arrange
+        Date lastUpdate = new Date();
+        when(model.getLastUpdate()).thenReturn(lastUpdate);
+        String expected = LAST_UPDATE_MESSAGE + DateFormat.getTimeInstance(DateFormat.MEDIUM).format(lastUpdate);
+
+        // Act
+        viewModel = new JournalViewModel(model);
+        String actual = viewModel.getLastUpdate();
+
+        // Assert
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void GIVEN_no_successful_update_THEN_last_update_time_is_NA() {
         // Arrange
-        when(model.getConnectionSuccess()).thenReturn(false);
         when(model.getLastUpdate()).thenReturn(null);
         String expected = LAST_UPDATE_MESSAGE + "N/A";
 
@@ -111,4 +93,18 @@ public class JournalViewModelTest {
         assertEquals(expected, actual);
     }
 
+
+    @Test
+    public void GIVEN_last_update_not_today_THEN_last_updated_string_contains_date_and_time() {
+        // Arrange
+        Date lastUpdate = new Date(System.currentTimeMillis() - DAY_IN_MILLIS);
+        when(model.getLastUpdate()).thenReturn(lastUpdate);
+        String expected = LAST_UPDATE_MESSAGE + DateFormat.getDateTimeInstance().format(lastUpdate);
+        // Act
+        viewModel = new JournalViewModel(model);
+        String actual = viewModel.getLastUpdate();
+
+        // Assert
+        assertEquals(expected, actual);
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
@@ -24,9 +24,9 @@ package uk.ac.stfc.isis.ibex.ui.journalviewer.tests;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Display;
+import java.text.DateFormat;
+import java.util.Date;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,36 +41,40 @@ public class JournalViewModelTest {
     private JournalViewModel viewModel;
     private JournalModel model;
 
+    private static final long DAY_IN_MILLIS = 24 * 60 * 60 * 1000;
+    private static final String LAST_UPDATE_MESSAGE = "Last successful update: ";
+
     @Before
     public void setUp() {
         model = mock(JournalModel.class);
     }
 
     @Test
-    public void GIVEN_connection_success_THEN_message_shows_last_refresh() {
+    public void GIVEN_connection_success_THEN_last_update_time_is_correct() {
         // Arrange
-        String timestamp = "11:12:13";
+        Date lastUpdate = new Date();
         when(model.getConnectionSuccess()).thenReturn(true);
-        when(model.getMessage()).thenReturn(timestamp);
-        String expected = "Last refresh: " + timestamp;
-        
+        when(model.getLastUpdate()).thenReturn(lastUpdate);
+        String expected = LAST_UPDATE_MESSAGE + DateFormat.getTimeInstance(DateFormat.MEDIUM).format(lastUpdate);
+
         // Act
         viewModel = new JournalViewModel(model);
-        String actual = viewModel.getMessage();
-        
+        String actual = viewModel.getLastUpdate();
+
         // Assert
         assertEquals(expected, actual);
     }
 
     @Test
-    public void GIVEN_connection_success_THEN_message_colour_is_neutral() {
+    public void GIVEN_last_update_not_today_THEN_last_update_time_contains_day() {
         // Arrange
+        Date lastUpdate = new Date(System.currentTimeMillis() - DAY_IN_MILLIS);
         when(model.getConnectionSuccess()).thenReturn(true);
-        Color expected = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
-
+        when(model.getLastUpdate()).thenReturn(lastUpdate);
+        String expected = LAST_UPDATE_MESSAGE + DateFormat.getDateTimeInstance().format(lastUpdate);
         // Act
         viewModel = new JournalViewModel(model);
-        Color actual = viewModel.getColor();
+        String actual = viewModel.getLastUpdate();
 
         // Assert
         assertEquals(expected, actual);
@@ -82,7 +86,7 @@ public class JournalViewModelTest {
         String error = "Something went wrong";
         when(model.getConnectionSuccess()).thenReturn(false);
         when(model.getMessage()).thenReturn(error);
-        String expected = "Error retrieving data: " + error;
+        String expected = error;
 
         // Act
         viewModel = new JournalViewModel(model);
@@ -93,14 +97,15 @@ public class JournalViewModelTest {
     }
 
     @Test
-    public void GIVEN_connection_failed_THEN_message_colour_is_error() {
+    public void GIVEN_no_successful_update_THEN_last_update_time_is_NA() {
         // Arrange
         when(model.getConnectionSuccess()).thenReturn(false);
-        Color expected = Display.getDefault().getSystemColor(SWT.COLOR_RED);
+        when(model.getLastUpdate()).thenReturn(null);
+        String expected = LAST_UPDATE_MESSAGE + "N/A";
 
         // Act
         viewModel = new JournalViewModel(model);
-        Color actual = viewModel.getColor();
+        String actual = viewModel.getLastUpdate();
 
         // Assert
         assertEquals(expected, actual);

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -23,8 +23,11 @@ import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.part.ViewPart;
@@ -46,6 +49,7 @@ public class JournalViewerView extends ViewPart {
 	private static final int HEADER_FONT_SIZE = 16;
 	
     private Label lblError;
+    private Button btnRefresh;
 
 	/**
 	 * Create contents of the view part.
@@ -60,9 +64,10 @@ public class JournalViewerView extends ViewPart {
 		lblTitle.setFont(SWTResourceManager.getFont("Segoe UI", HEADER_FONT_SIZE, SWT.BOLD));
 		lblTitle.setText("Journal Viewer");
 		
-		Label lblDescription = new Label(parent, SWT.NONE);
-		lblDescription.setFont(SWTResourceManager.getFont("Segoe UI", LABEL_FONT_SIZE, SWT.NORMAL));
-		lblDescription.setText("This is the future home of the Journal Viewer. Watch this space...");
+        new Label(parent, SWT.NONE);
+
+        btnRefresh = new Button(parent, SWT.NONE);
+        btnRefresh.setText("Refresh");
 
         lblError = new Label(parent, SWT.NONE);
         lblError.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, true));
@@ -71,13 +76,20 @@ public class JournalViewerView extends ViewPart {
         bind(JournalViewerUI.getDefault().getModel());
 	}
 	
-    private void bind(JournalViewModel model) {
+    private void bind(final JournalViewModel model) {
         DataBindingContext bindingContext = new DataBindingContext();
 
         bindingContext.bindValue(WidgetProperties.text().observe(lblError),
                 BeanProperties.value("message").observe(model));
         bindingContext.bindValue(WidgetProperties.foreground().observe(lblError),
                 BeanProperties.value("color").observe(model));
+        
+        btnRefresh.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                model.refresh();
+            }
+        });
     }
 
 	@Override

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.wb.swt.SWTResourceManager;
@@ -49,6 +50,7 @@ public class JournalViewerView extends ViewPart {
 	private static final int HEADER_FONT_SIZE = 16;
 	
     private Label lblError;
+    private Label lblLastUpdate;
     private Button btnRefresh;
 
 	/**
@@ -71,7 +73,12 @@ public class JournalViewerView extends ViewPart {
 
         lblError = new Label(parent, SWT.NONE);
         lblError.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, true, true));
+        lblError.setForeground(Display.getDefault().getSystemColor(SWT.COLOR_RED));
         lblError.setText("placeholder");
+        
+        lblLastUpdate = new Label(parent, SWT.NONE);
+        lblLastUpdate.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
+        lblLastUpdate.setText("placeholder");
 
         bind(JournalViewerUI.getDefault().getModel());
 	}
@@ -81,8 +88,8 @@ public class JournalViewerView extends ViewPart {
 
         bindingContext.bindValue(WidgetProperties.text().observe(lblError),
                 BeanProperties.value("message").observe(model));
-        bindingContext.bindValue(WidgetProperties.foreground().observe(lblError),
-                BeanProperties.value("color").observe(model));
+        bindingContext.bindValue(WidgetProperties.text().observe(lblLastUpdate),
+                BeanProperties.value("lastUpdate").observe(model));
         
         btnRefresh.addSelectionListener(new SelectionAdapter() {
             @Override

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -101,4 +101,11 @@ public class JournalViewModel extends ModelObject {
         firePropertyChange("color", this.color, this.color = color);
     }
 
+    /**
+     * Refreshes the data from the journal database.
+     */
+    public void refresh() {
+        model.refresh();
+    }
+
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -103,7 +103,6 @@ public class JournalViewModel extends ModelObject {
     }
 
     private boolean isToday(Date date) {
-        System.out.println("Date is " + date);
         Calendar calendar = Calendar.getInstance();
         calendar.set(Calendar.HOUR_OF_DAY, 0);
         calendar.set(Calendar.MINUTE, 0);

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -23,10 +23,9 @@ package uk.ac.stfc.isis.ibex.ui.journalviewer.models;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.widgets.Display;
+import java.text.DateFormat;
+import java.util.Calendar;
+import java.util.Date;
 
 import uk.ac.stfc.isis.ibex.journal.JournalModel;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
@@ -36,19 +35,9 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
  */
 public class JournalViewModel extends ModelObject {
 
-    /**
-     * A neutral color for the status message text.
-     */
-    private static final Color NEUTRAL_COLOR = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
-
-    /**
-     * A color indicating an error for the status message text.
-     */
-    private static final Color ERROR_COLOR = Display.getDefault().getSystemColor(SWT.COLOR_RED);
-
     private JournalModel model;
-    private Color color;
     private String message;
+    private String lastUpdate;
 
     PropertyChangeListener listener = new PropertyChangeListener() {
         @Override
@@ -70,13 +59,8 @@ public class JournalViewModel extends ModelObject {
     }
 
     private void update() {
-        if (model.getConnectionSuccess()) {
-            setMessage("Last refresh: " + model.getMessage());
-            setColor(NEUTRAL_COLOR);
-        } else {
-            setMessage("Error retrieving data: " + model.getMessage());
-            setColor(ERROR_COLOR);
-        }
+        setLastUpdate("Last successful update: " + dateToString(model.getLastUpdate()));
+        setMessage(model.getMessage());
     }
 
     /**
@@ -91,16 +75,15 @@ public class JournalViewModel extends ModelObject {
     }
 
     /**
-     * @return The color indicating the current connection status.
+     * @return The connection status message.
      */
-    public Color getColor() {
-        return color;
+    public String getLastUpdate() {
+        return lastUpdate;
     }
 
-    private void setColor(Color color) {
-        firePropertyChange("color", this.color, this.color = color);
+    private void setLastUpdate(String lastUpdate) {
+        firePropertyChange("lastUpdate", this.lastUpdate, this.lastUpdate = lastUpdate);
     }
-
     /**
      * Refreshes the data from the journal database.
      */
@@ -108,4 +91,24 @@ public class JournalViewModel extends ModelObject {
         model.refresh();
     }
 
+    private String dateToString(Date lastUpdate) {
+        if (lastUpdate == null) {
+            return "N/A";
+        }
+        if (isToday(lastUpdate)) {
+            return DateFormat.getTimeInstance(DateFormat.MEDIUM).format(lastUpdate);
+        } else {
+            return DateFormat.getDateTimeInstance().format(lastUpdate);
+        }
+    }
+
+    private boolean isToday(Date date) {
+        System.out.println("Date is " + date);
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        Date today = calendar.getTime();
+        return date.after(today);
+    }
 }


### PR DESCRIPTION
### Description of work

Added a manual refresh button in the Journal Viewer perspective. Slightly updated connection status labels (to make last successful update visible even when last attempt to connect was unsuccessful) and adapted connection information communicated by the `JournalModel` accordingly.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2902

### Acceptance criteria

- [x]  Manual refresh button works
- [x] View displays sensible messages for connection error/last update at all times.

### Unit tests

- Updated `JournalViewModelTests` to work with changes in models.

### System tests

Added test 32-3 to manual system tests spreadsheet.

### Documentation

/

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

