### PR TITLE
Ticket2904 jv pagination

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.osgi,
  uk.ac.stfc.isis.ibex.model,
  uk.ac.stfc.isis.ibex.instrument,
- uk.ac.stfc.isis.ibex.logger
+ uk.ac.stfc.isis.ibex.logger,
+ org.csstudio.platform.libs.jdbc
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.journal

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -54,11 +54,11 @@ public class JournalModel extends ModelObject implements Runnable {
 
     private static final int REFRESH_INTERVAL = 10 * 1000;
     private static final Logger LOG = IsisLog.getLogger(JournalModel.class);
-    private static final int PAGE_SIZE = 2;
+    private static final int PAGE_SIZE = 30;
     
     // In ms. If a query takes longer than this, issue a warning.
     // Exact choice of number is arbitrary.
-    private static final int QUERY_DURATION_WARNING_LEVEL = 250; 
+    private static final int QUERY_DURATION_WARNING_LEVEL = 500; 
     
     private int pageNumber = 1;
     private int pageMax = 1;

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -26,13 +26,13 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jface.preference.IPreferenceStore;
+
+import java.sql.PreparedStatement;
+
 import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.journal.preferences.PreferenceConstants;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -54,11 +54,14 @@ public class JournalModel extends ModelObject implements Runnable {
 
     private static final int REFRESH_INTERVAL = 10 * 1000;
     private static final Logger LOG = IsisLog.getLogger(JournalModel.class);
-    
     private static final int PAGE_SIZE = 2;
     
+    // In ms. If a query takes longer than this, issue a warning.
+    // Exact choice of number is arbitrary.
+    private static final int QUERY_DURATION_WARNING_LEVEL = 250; 
+    
     private int pageNumber = 1;
-    private int pageMax = 0;
+    private int pageMax = 1;
 
 	/**
 	 * Constructor for the journal model. Takes a preferenceStore as an argument
@@ -129,16 +132,11 @@ public class JournalModel extends ModelObject implements Runnable {
      * @throws SQLException - If there was an error while querying the database
      */
     private void updateRuns(Connection connection) throws SQLException {
-    	
-    	if (getSelectedFields().size() <= 0) {
-    		setRuns(Collections.<Map<JournalField, String>>emptyList());
-    		return;
-    	}
-    	
-    	ResultSet rs = connection.createStatement().executeQuery(constructSQLQuery());
+    	long startTime = System.currentTimeMillis();
+
+    	ResultSet rs = constructSQLQuery(connection).executeQuery();
     	
     	List<Map<JournalField, String>> runs = new ArrayList<>();
-    	
     	while (rs.next()) {
     		Map<JournalField, String> run = new HashMap<>();
     		for (JournalField property : selectedFields) {
@@ -150,42 +148,56 @@ public class JournalModel extends ModelObject implements Runnable {
     		}  
     		runs.add(Collections.unmodifiableMap(run));
     	}
+    	rs.close();
     	
     	setRuns(Collections.unmodifiableList(runs));
-    	
-    	rs = connection.createStatement().executeQuery(constructCountFieldsSQLQuery());
-    	rs.next();
-	    setPageMax((int) Math.ceil(rs.getInt(1)/(double) PAGE_SIZE));
+    	updateRunsCount(connection);
+	    
+	    long totalTime = System.currentTimeMillis() - startTime;
+	    if (totalTime > QUERY_DURATION_WARNING_LEVEL) {
+	    	LOG.warn(String.format(
+	    			"Journal parser SQL queries took %s ms. Should have taken less than %s ms.",
+	    			totalTime, QUERY_DURATION_WARNING_LEVEL));
+	    }
+    }
+    
+    private void updateRunsCount(Connection connection) throws SQLException {
+    	ResultSet rs = constructCountFieldsSQLQuery(connection).executeQuery();
+    	if (!rs.next()) {
+    		throw new RuntimeException("No results returned from SQL query to count rows.");
+    	}
+	    setTotalResults(rs.getInt(1));
+	    rs.close();
+    }
+
+	/**
+     * Constructs the SQL query which extracts all relevant information from the database.
+     * 
+     * NOTE: Ensure that arbitrary strings cannot be inserted into this query, maliciously or 
+     * accidentally as that could lead to a SQL injection vulnerability.
+     * 
+     * @return a SQL prepared statement ready to be executed.
+     * @throws SQLException if a SQL exception occurred while preparing the statement
+     */
+    private PreparedStatement constructSQLQuery(Connection connection) throws SQLException {
+    	String query = "SELECT * FROM journal_entries ORDER BY run_number DESC LIMIT ?, ?";
+        PreparedStatement st = connection.prepareStatement(query);
+    	st.setInt(1, (pageNumber-1) * PAGE_SIZE);
+    	st.setInt(2, PAGE_SIZE);
+    	return st;
     }
     
     /**
-     * Constructs the SQL query which extracts all relevant information from the database.
-     * @see getSelectedFields for the fields which will be selected.
-     * @return the SQL query to be executed.
+     * Constructs a SQL query which gets the number of runs available.
+     * 
+     * NOTE: Ensure that arbitrary strings cannot be inserted into this query, maliciously or 
+     * accidentally as that could lead to a SQL injection vulnerability.
+     * 
+     * @return a SQL prepared statement ready to be executed.
+     * @throws SQLException if a SQL exception occurred while preparing the statement
      */
-    private String constructSQLQuery() {
-    	
-    	Set<JournalField> selectedFields = getSelectedFields();
-    	
-    	Set<String> selectedFieldNames = new HashSet<String>();
-    	for (JournalField field : selectedFields) {
-    		selectedFieldNames.add(field.getSqlFieldName());
-    	}
-    	
-    	String fields;
-    	if (selectedFieldNames.size() > 0) {
-    		fields = String.join(", ", selectedFieldNames.toArray(new String[selectedFieldNames.size()]));
-    	} else {
-    		fields = "null";
-    	}
-    	
-    	String query = String.format(
-    			"SELECT %s FROM journal_entries ORDER BY run_number DESC LIMIT %s, %s", fields, (pageNumber-1) * PAGE_SIZE, PAGE_SIZE);
-    	return query;
-    }
-    
-    private String constructCountFieldsSQLQuery() {
-    	return "SELECT COUNT(*) FROM journal_entries";
+    private PreparedStatement constructCountFieldsSQLQuery(Connection connection) throws SQLException {
+    	return connection.prepareStatement("SELECT COUNT(*) FROM journal_entries");
     }
     
     private void setRuns(List<Map<JournalField, String>> runs) {
@@ -273,6 +285,10 @@ public class JournalModel extends ModelObject implements Runnable {
     public int getPage() {
         return pageNumber;
     }
+    
+    private void setTotalResults(int totalResults) {
+    	setPageMax((int) Math.ceil(totalResults/(double) PAGE_SIZE));
+	}
     
     /**
      * The maximum page number that can be selected.

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -274,10 +274,18 @@ public class JournalModel extends ModelObject implements Runnable {
         return pageNumber;
     }
     
+    /**
+     * The maximum page number that can be selected.
+     * @param max the new maximum selectable page number
+     */
     public void setPageMax(int max) {
     	firePropertyChange("pageNumberMax", this.pageMax, this.pageMax = max);
     }
 
+    /**
+     * Gets the maximum page number with data in it.
+     * @return the maximum page number
+     */
 	public int getPageMax() {
 		return pageMax;
 	}

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -55,6 +55,10 @@ public class JournalModel extends ModelObject implements Runnable {
 
     private static final int REFRESH_INTERVAL = 10 * 1000;
     private static final Logger LOG = IsisLog.getLogger(JournalModel.class);
+    
+    private static final int PAGE_SIZE = 2;
+    
+    private int pageNumber = 0;
 
 	/**
 	 * Constructor for the journal model. Takes a preferenceStore as an argument
@@ -171,7 +175,8 @@ public class JournalModel extends ModelObject implements Runnable {
     		fields = "null";
     	}
     	
-    	String query = String.format("SELECT %s FROM journal_entries ORDER BY run_number DESC LIMIT 1000", fields);
+    	String query = String.format(
+    			"SELECT %s FROM journal_entries ORDER BY run_number DESC LIMIT %s, %s", fields, pageNumber * PAGE_SIZE, PAGE_SIZE);
     	return query;
     }
     
@@ -241,5 +246,23 @@ public class JournalModel extends ModelObject implements Runnable {
      */
     public Date getLastUpdate() {
         return this.lastUpdate;
+    }
+    
+    /**
+     * Sets the page number that is being looked at.
+     * 
+     * @param page The new page number
+     */
+    public void setPage(int pageNumber) {
+        firePropertyChange("pageNumber", this.pageNumber, this.pageNumber = pageNumber);
+        refresh();
+    }
+
+    /**
+     * Returns the current page number.
+     * @return The page number.
+     */
+    public int getPage() {
+        return pageNumber;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -74,11 +74,17 @@ public class JournalViewerView extends ViewPart {
 		lblTitle.setFont(SWTResourceManager.getFont("Segoe UI", HEADER_FONT_SIZE, SWT.BOLD));
 		lblTitle.setText("Journal Viewer");
 		
-        btnRefresh = new Button(parent, SWT.NONE);
-        btnRefresh.setText("Refresh");
+		Composite controls = new Composite(parent, SWT.FILL);
+		controls.setLayout(new GridLayout(3, false));
+		
+		Label lblPage = new Label(controls, SWT.NONE);
+		lblPage.setText("Page number: ");
         
-        spinnerPageNumber = new Spinner(parent, SWT.NONE);
-        spinnerPageNumber.setMinimum(0);
+        spinnerPageNumber = new Spinner(controls, SWT.BORDER);
+        spinnerPageNumber.setMinimum(1);
+		
+        btnRefresh = new Button(controls, SWT.NONE);
+        btnRefresh.setText("Refresh data");
 		
 		Composite selectedContainer = new Composite(parent, SWT.FILL);
 		GridLayout gl = new GridLayout(JournalField.values().length, false);
@@ -123,6 +129,8 @@ public class JournalViewerView extends ViewPart {
                 BeanProperties.value("runs").observe(model));
         bindingContext.bindValue(WidgetProperties.selection().observe(spinnerPageNumber),
                 BeanProperties.value("pageNumber").observe(model));
+        bindingContext.bindValue(WidgetProperties.maximum().observe(spinnerPageNumber),
+                BeanProperties.value("pageNumberMax").observe(model));
 
         
         btnRefresh.addSelectionListener(new SelectionAdapter() {

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -31,6 +31,7 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.wb.swt.SWTResourceManager;
 
@@ -58,6 +59,7 @@ public class JournalViewerView extends ViewPart {
     private final JournalViewModel model = JournalViewerUI.getDefault().getModel();
     
     private Button btnRefresh;
+    private Spinner spinnerPageNumber;
 
 	/**
 	 * Create contents of the view part.
@@ -74,6 +76,9 @@ public class JournalViewerView extends ViewPart {
 		
         btnRefresh = new Button(parent, SWT.NONE);
         btnRefresh.setText("Refresh");
+        
+        spinnerPageNumber = new Spinner(parent, SWT.NONE);
+        spinnerPageNumber.setMinimum(0);
 		
 		Composite selectedContainer = new Composite(parent, SWT.FILL);
 		GridLayout gl = new GridLayout(JournalField.values().length, false);
@@ -116,6 +121,9 @@ public class JournalViewerView extends ViewPart {
                 BeanProperties.value("lastUpdate").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(lblDescription),
                 BeanProperties.value("runs").observe(model));
+        bindingContext.bindValue(WidgetProperties.selection().observe(spinnerPageNumber),
+                BeanProperties.value("pageNumber").observe(model));
+
         
         btnRefresh.addSelectionListener(new SelectionAdapter() {
             @Override

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -45,6 +45,7 @@ public class JournalViewModel extends ModelObject {
     private String message;
     private List<Map<JournalField, String>> runs;
     private String lastUpdate;
+    private int pageNumber;
 
     PropertyChangeListener listener = new PropertyChangeListener() {
         @Override
@@ -69,6 +70,7 @@ public class JournalViewModel extends ModelObject {
         setLastUpdate("Last successful update: " + dateToString(model.getLastUpdate()));
         setMessage(model.getMessage());
         setRuns(model.getRuns());
+        setPageNumber(model.getPage());
     }
 
     /**
@@ -148,6 +150,7 @@ public class JournalViewModel extends ModelObject {
     public boolean getFieldSelected(JournalField field) {
     	return model.getSelectedFields().contains(field);
     }
+    
     private String dateToString(Date lastUpdate) {
         if (lastUpdate == null) {
             return "N/A";
@@ -166,5 +169,17 @@ public class JournalViewModel extends ModelObject {
         calendar.set(Calendar.SECOND, 0);
         Date today = calendar.getTime();
         return date.after(today);
+    }
+    
+    public void setPageNumber(int pageNumber) {
+    	if (pageNumber != model.getPage()) {
+    		int previousPage = model.getPage();
+	    	model.setPage(pageNumber);
+	    	firePropertyChange("pageNumber", previousPage, model.getPage());
+    	}
+    }
+    
+    public int getPageNumber() {
+    	return model.getPage();
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -45,7 +45,6 @@ public class JournalViewModel extends ModelObject {
     private String message;
     private List<Map<JournalField, String>> runs;
     private String lastUpdate;
-    private int pageNumber;
 
     PropertyChangeListener listener = new PropertyChangeListener() {
         @Override
@@ -71,6 +70,7 @@ public class JournalViewModel extends ModelObject {
         setMessage(model.getMessage());
         setRuns(model.getRuns());
         setPageNumber(model.getPage());
+        setPageNumberMax(model.getPageMax());
     }
 
     /**
@@ -182,4 +182,15 @@ public class JournalViewModel extends ModelObject {
     public int getPageNumber() {
     	return model.getPage();
     }
+    
+
+    
+    public void setPageNumberMax(int max) {
+	    firePropertyChange("pageNumberMax", 0, model.getPageMax());
+    }
+    
+    public int getPageNumberMax() {
+    	return model.getPageMax();
+    }
+
 }


### PR DESCRIPTION
### Description of work

Allow the journal viewer to display paginated results

To check the performance, I loaded all of ENGIN-X's journal files from the last 5 years into my local database. I wrote a quick script to do this, it's not perfect but it can serve as the basis for a data ingestion upgrade script in the future.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2904

### Acceptance criteria

- [x] Journal viewer has a configurable page size (currently 2 for testing)
- [x] Can navigate up and down the page range adequately.

I have made the user interface quite dumb at the moment because it's likely to change in the next ticket (table view)

### Unit tests

None added in model because SQL layer is hard to mock. None added in viewmodel as there is no logic so nothing to test.

### System tests

RCPTT dead, squish not yet alive

### Documentation

None

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

