### PR TITLE
Ticket2869 sim mode more obvious

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/BannerModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/BannerModel.java
@@ -42,7 +42,7 @@ public class BannerModel extends Closer {
 	
 	/**
 	 * Constructor for the banner model.
-	 * @param observables
+	 * @param observables The observables for values displayed on the dashboard banner
 	 */
 	public BannerModel(DashboardObservables observables) {
 		instrumentName = Instrument.getInstance().name();
@@ -103,7 +103,7 @@ public class BannerModel extends Closer {
 	}
 	
 	/**
-	 * Whether the DAE is in simulation mode or not
+	 * Whether the DAE is in simulation mode or not.
 	 * @return Updated value where true means the DAE is in simulation mode and false means it is not in simulation mode.
 	 */
 	public UpdatedValue<Boolean> daeSimMode() {

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/BannerModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/BannerModel.java
@@ -21,15 +21,16 @@ package uk.ac.stfc.isis.ibex.ui.dashboard.models;
 
 import org.eclipse.swt.graphics.Color;
 
-import uk.ac.stfc.isis.ibex.dae.Dae;
 import uk.ac.stfc.isis.ibex.dashboard.DashboardObservables;
 import uk.ac.stfc.isis.ibex.epics.adapters.TextUpdatedObservableAdapter;
 import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
 import uk.ac.stfc.isis.ibex.epics.pv.Closer;
 import uk.ac.stfc.isis.ibex.instrument.Instrument;
-import uk.ac.stfc.isis.ibex.model.SettableUpdatedValue;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 
+/**
+ * Model for the banner within the dashboard view.
+ */
 public class BannerModel extends Closer {
 		
 	private final UpdatedValue<String> instrumentName;
@@ -39,6 +40,10 @@ public class BannerModel extends Closer {
 	private final UpdatedValue<Boolean> simulationMode;
 	private final ShutterState shutterState;
 	
+	/**
+	 * Constructor for the banner model.
+	 * @param observables
+	 */
 	public BannerModel(DashboardObservables observables) {
 		instrumentName = Instrument.getInstance().name();
 		instrumentState = registerForClose(new InstrumentState(observables.dae.runState));
@@ -49,30 +54,58 @@ public class BannerModel extends Closer {
 		shutterState = registerForClose(new ShutterState(observables.shutter));
 	}
 	
+	/**
+	 * The text of the banner (e.g. IRIS is RUNNING).
+	 * @return an updated value wrapping the text.
+	 */
 	public UpdatedValue<String> bannerText() {
 		return bannerText;
 	}
 	
+	/**
+	 * The instrument name as a string (e.g. IRIS, LARMOR).
+	 * @return an updated value wrapping the instrument name string.
+	 */
 	public UpdatedValue<String> instrumentName() {
 		return instrumentName;
 	}
 	
+	/**
+	 * The run state as a string (e.g. RUNNING, SETUP).
+	 * @return an updated value wrapping the run state string.
+	 */
 	public UpdatedValue<String> runState() {
 		return instrumentState.text();
 	}
 	
+	/**
+	 * The colour of the dashboard.
+	 * @return an updated value wrapping the dashboard colour.
+	 */
 	public UpdatedValue<Color> background() {
 		return instrumentState.color();
 	}
 	
+	/**
+	 * Gets the run number as a string.
+	 * @return an updated value wrapping the run number string
+	 */
 	public UpdatedValue<String> runNumber() {
 		return runNumber;
 	}
 	
+	/**
+	 * Gets the shutter status of the current instrument as a string.
+	 * @return an updated value wrapping the shutter status string
+	 */
 	public UpdatedValue<String> shutter() {
 		return shutterState.text();
 	}
 	
+	/**
+	 * Whether the DAE is in simulation mode or not
+	 * @return Updated value where true means the DAE is in simulation mode and false means it is not in simulation mode.
+	 */
 	public UpdatedValue<Boolean> daeSimMode() {
 		return simulationMode;
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/BannerModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/BannerModel.java
@@ -21,10 +21,13 @@ package uk.ac.stfc.isis.ibex.ui.dashboard.models;
 
 import org.eclipse.swt.graphics.Color;
 
+import uk.ac.stfc.isis.ibex.dae.Dae;
 import uk.ac.stfc.isis.ibex.dashboard.DashboardObservables;
 import uk.ac.stfc.isis.ibex.epics.adapters.TextUpdatedObservableAdapter;
+import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
 import uk.ac.stfc.isis.ibex.epics.pv.Closer;
 import uk.ac.stfc.isis.ibex.instrument.Instrument;
+import uk.ac.stfc.isis.ibex.model.SettableUpdatedValue;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 
 public class BannerModel extends Closer {
@@ -33,6 +36,7 @@ public class BannerModel extends Closer {
 	private final InstrumentState instrumentState;
 	private final BannerText bannerText;
 	private final UpdatedValue<String> runNumber;
+	private final UpdatedValue<Boolean> simulationMode;
 	private final ShutterState shutterState;
 	
 	public BannerModel(DashboardObservables observables) {
@@ -41,6 +45,7 @@ public class BannerModel extends Closer {
 		bannerText = new BannerText(instrumentName, instrumentState.text());
 		
 		runNumber = registerForClose(new TextUpdatedObservableAdapter(observables.dae.runNumber));
+		simulationMode = registerForClose(new UpdatedObservableAdapter<Boolean>(observables.dae.simulationMode));
 		shutterState = registerForClose(new ShutterState(observables.shutter));
 	}
 	
@@ -66,5 +71,9 @@ public class BannerModel extends Closer {
 	
 	public UpdatedValue<String> shutter() {
 		return shutterState.text();
+	}
+	
+	public UpdatedValue<Boolean> daeSimMode() {
+		return simulationMode;
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
@@ -52,6 +52,7 @@ public class DashboardView extends ViewPart implements ISizeProvider {
 	private final Font bannerTitleFont = SWTResourceManager.getFont("Arial", 24, SWT.BOLD);
 	private final Font bannerFont = SWTResourceManager.getFont("Arial", 14, SWT.NORMAL);
 	private final Font textFont = SWTResourceManager.getFont("Arial", 12, SWT.NORMAL);
+	private final Font simulationModeFont = SWTResourceManager.getFont("Arial", 20, SWT.BOLD);
 	
 	private final Dashboard dashboard = Dashboard.getInstance();
 	
@@ -71,7 +72,7 @@ public class DashboardView extends ViewPart implements ISizeProvider {
 		glParent.horizontalSpacing = 1;
 		glParent.verticalSpacing = 0;
 		parent.setLayout(glParent);
-		Banner banner = new Banner(parent, SWT.NONE, bannerModel, bannerTitleFont, bannerFont);
+		Banner banner = new Banner(parent, SWT.NONE, bannerModel, bannerTitleFont, bannerFont, simulationModeFont);
         banner.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 3, 1));
 		
 		Label separator1 = new Label(parent, SWT.SEPARATOR | SWT.HORIZONTAL);

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/widgets/Banner.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/widgets/Banner.java
@@ -40,8 +40,9 @@ public class Banner extends Composite {
 	private final Label runNumber;
 	private final Label lblShutter;
 	private final Label shutter;
+	private final Label simMode;
 	
-	public Banner(Composite parent, int style, BannerModel model, Font titleFont, Font textFont) {
+	public Banner(Composite parent, int style, BannerModel model, Font titleFont, Font textFont, Font simulationModeFont) {
 		super(parent, style);
 		GridLayout gridLayout = new GridLayout(1, false);
 		gridLayout.marginWidth = 0;
@@ -57,7 +58,7 @@ public class Banner extends Composite {
 		
 		details = new Composite(this, SWT.NONE);
 		details.setLayoutData(new GridData(SWT.FILL, SWT.BOTTOM, false, false, 1, 1));
-		details.setLayout(new GridLayout(4, false));
+		details.setLayout(new GridLayout(5, false));
 		details.setBackgroundMode(SWT.INHERIT_DEFAULT);
 		
 		lblRun = new Label(details, SWT.NONE);
@@ -68,6 +69,11 @@ public class Banner extends Composite {
 		runNumber.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 		runNumber.setFont(textFont);
 		runNumber.setText("0000001");
+		
+		simMode = new Label(details, SWT.NONE);
+		simMode.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, true, false, 1, 1));
+		simMode.setFont(simulationModeFont);
+		simMode.setText("SIMULATION MODE");
 		
 		lblShutter = new Label(details, SWT.NONE);
 		lblShutter.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, true, false, 1, 1));
@@ -93,5 +99,6 @@ public class Banner extends Composite {
 		bindingContext.bindValue(WidgetProperties.background().observe(this), BeanProperties.value("value").observe(model.background()));
 		bindingContext.bindValue(WidgetProperties.text().observe(runNumber), BeanProperties.value("value").observe(model.runNumber()));
 		bindingContext.bindValue(WidgetProperties.text().observe(shutter), BeanProperties.value("value").observe(model.shutter()));
+		bindingContext.bindValue(WidgetProperties.visible().observe(simMode), BeanProperties.value("value").observe(model.daeSimMode()));
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/widgets/Banner.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/widgets/Banner.java
@@ -31,6 +31,9 @@ import org.eclipse.swt.layout.GridData;
 
 import uk.ac.stfc.isis.ibex.ui.dashboard.models.BannerModel;
 
+/**
+ * The view for the instrument dashboard banner showing the instrument state.
+ */
 @SuppressWarnings("checkstyle:magicnumber")
 public class Banner extends Composite {
 
@@ -42,6 +45,16 @@ public class Banner extends Composite {
 	private final Label shutter;
 	private final Label simMode;
 	
+	/**
+	 * The constructor. 
+	 * 
+	 * @param parent The parent composite
+	 * @param style The SWT style
+	 * @param model The model holding data to display in the view
+	 * @param titleFont The font for the banner title
+	 * @param textFont The font for the banner text
+	 * @param simulationModeFont The font for the simulation mode indicator
+	 */
 	public Banner(Composite parent, int style, BannerModel model, Font titleFont, Font textFont, Font simulationModeFont) {
 		super(parent, style);
 		GridLayout gridLayout = new GridLayout(1, false);
@@ -93,7 +106,7 @@ public class Banner extends Composite {
 		}
 	}
 	
-	public void bind(BannerModel model) {		
+    private void bind(BannerModel model) {
 		DataBindingContext bindingContext = new DataBindingContext();
 		bindingContext.bindValue(WidgetProperties.text().observe(bannerText), BeanProperties.value("value").observe(model.bannerText()));
 		bindingContext.bindValue(WidgetProperties.background().observe(this), BeanProperties.value("value").observe(model.background()));


### PR DESCRIPTION
### Description of work

Makes it more obvious when an instrument is in simulation mode. Should look similar to the mockup on the ticket, bearing in mind the colour-blindness considerations in the comments.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2869

### Acceptance criteria

- [ ] It is sufficiently obvious that an instrument is in simulation mode
- [ ] The colour is clear to all users (including colour-blind users) in all run states
- [ ] Behaviour on instrument switching is appropriate.

### Unit tests

No unit tests added as this was only GUI code

### System tests

None added, RCPTT not being developed any more, squish not yet ready.

### Documentation

None required for this minimal change.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

