### PR TITLE
Ticket2222 ioc settings persist after cancelling

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
@@ -38,7 +38,6 @@ import uk.ac.stfc.isis.ibex.configserver.configuration.ComponentInfo;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Group;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
-import uk.ac.stfc.isis.ibex.configserver.configuration.Macro;
 import uk.ac.stfc.isis.ibex.configserver.configuration.PV;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
@@ -38,6 +38,7 @@ import uk.ac.stfc.isis.ibex.configserver.configuration.ComponentInfo;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Group;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
+import uk.ac.stfc.isis.ibex.configserver.configuration.Macro;
 import uk.ac.stfc.isis.ibex.configserver.configuration.PV;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
@@ -188,5 +189,15 @@ public class EditableConfigurationTest {
 
         // Assert
         assertNull(config.getBlockByName(GAPX.getName()));
+    }
+    
+    @Test
+    public void GIVEN_two_editable_configurations_created_from_same_list_of_iocs_with_macros_THEN_editable_configurations_do_not_share_state() {
+    	EditableConfiguration config1 = edit(config());    	
+    	allIocs.add(new EditableIoc(GALIL01));	
+    	EditableConfiguration config2 = edit(config());
+    	
+    	assertFalse(config1.getAvailableIocs().equals(allIocs));
+    	assertTrue(config2.getAvailableIocs().equals(allIocs));
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -148,7 +148,14 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
 		this.name = config.name();
 		this.description = config.description();
 		this.synoptic = config.synoptic();
-        this.allIocs = iocs;
+		
+		this.allIocs = new ArrayList<>();
+		
+		for (EditableIoc ioc : iocs) {
+			EditableIoc newIoc = new EditableIoc(ioc, ioc.getDescription());
+			newIoc.setAvailableMacros(new ArrayList<>(ioc.getAvailableMacros()));
+			this.allIocs.add(newIoc);
+		}
 
         this.history = new ArrayList<>();
 

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableIoc.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableIoc.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.configserver.editing;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.AvailablePV;
 import uk.ac.stfc.isis.ibex.configserver.configuration.AvailablePVSet;
@@ -103,7 +104,7 @@ public class EditableIoc extends Ioc {
      *            The new macros to apply to the IOC
      */
 	public void setAvailableMacros(Collection<Macro> macros) {
-		firePropertyChange("availableMacros", this.availableMacros, this.availableMacros = macros);
+		firePropertyChange("availableMacros", this.availableMacros, this.availableMacros = new ArrayList<>(macros));
 	}
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableIoc.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableIoc.java
@@ -21,8 +21,6 @@ package uk.ac.stfc.isis.ibex.configserver.editing;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-
 import uk.ac.stfc.isis.ibex.configserver.configuration.AvailablePV;
 import uk.ac.stfc.isis.ibex.configserver.configuration.AvailablePVSet;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
@@ -104,7 +102,7 @@ public class EditableIoc extends Ioc {
      *            The new macros to apply to the IOC
      */
 	public void setAvailableMacros(Collection<Macro> macros) {
-		firePropertyChange("availableMacros", this.availableMacros, this.availableMacros = new ArrayList<>(macros));
+		firePropertyChange("availableMacros", this.availableMacros, this.availableMacros = macros);
 	}
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
@@ -19,6 +19,7 @@
 
 package uk.ac.stfc.isis.ibex.configserver.editing;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.logging.Level;

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
@@ -19,7 +19,6 @@
 
 package uk.ac.stfc.isis.ibex.configserver.editing;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.logging.Level;


### PR DESCRIPTION
### Description of work

Fixes the crash described in https://github.com/ISISComputingGroup/IBEX/issues/2222

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2222

### Acceptance criteria

- Follow the steps listed in the ticket. Ensure you cannot reproduce the bug.

### Unit tests

I've added a unit test to ensure state is not shared when it shouldn't be. This test should fail on the old code and pass on the new code.

### System tests

None added.

### Documentation

None.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

