### PR TITLE
Ticket 3001

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerWritable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerWritable.java
@@ -26,10 +26,11 @@ import org.epics.pvmanager.PVWriter;
 import org.epics.pvmanager.PVWriterEvent;
 import org.epics.pvmanager.PVWriterListener;
 import org.epics.pvmanager.expression.WriteExpressionImpl;
-
 import uk.ac.stfc.isis.ibex.epics.pv.PVInfo;
 import uk.ac.stfc.isis.ibex.epics.pv.WritablePV;
 import uk.ac.stfc.isis.ibex.epics.writing.WriteException;
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
 
 /**
  * A class for writing to a PV via PVManager.
@@ -49,6 +50,8 @@ public class PVManagerWritable<T> extends WritablePV<T> {
 			}
 			
 			if (evt.isConnectionChanged()) {
+				LoggerUtils.logIfExtraDebug(IsisLog.getLogger(getClass()),
+						"(Ticket 3001) PV canWrite changed to " + pv.isWriteConnected() + ". This PV is " + details().address());
 				canWriteChanged(pv.isWriteConnected());
 			}
 			

--- a/base/uk.ac.stfc.isis.ibex.logger/src/uk/ac/stfc/isis/ibex/logger/LoggerUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.logger/src/uk/ac/stfc/isis/ibex/logger/LoggerUtils.java
@@ -33,6 +33,9 @@ public final class LoggerUtils {
 
     private LoggerUtils() {
     }
+    
+    private static final String EXTRA_DEBUG_ENV_VAR = "IBEX_GUI_EXTRA_DEBUG";
+    private static final boolean EXTRA_DEBUG = "1".equals(System.getenv(EXTRA_DEBUG_ENV_VAR));
 
     /**
      * Sends an error to the log along with the stack trace of an exception
@@ -48,5 +51,16 @@ public final class LoggerUtils {
     public static void logErrorWithStackTrace(Logger log, String message, Exception e) {
         log.error(message + "\n    " + e.getMessage() + "\n    Stack Trace:\n    "
                 + Joiner.on("\n    ").join(e.getStackTrace()));
+    }
+    
+    /**
+     * Logs a message if the IBEX_GUI_EXTRA_DEBUG environment variable is set to 1. Otherwise does nothing.
+     * @param log the logger to log the message to
+     * @param message the message to log
+     */
+    public static void logIfExtraDebug(Logger logger, String message) {
+    	if (EXTRA_DEBUG) {
+			logger.info(message);
+		}
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.ui,
  uk.ac.stfc.isis.ibex.epics,
  uk.ac.stfc.isis.ibex.synoptic;bundle-version="1.0.0",
  org.eclipse.swt,
- uk.ac.stfc.isis.ibex.validators
+ uk.ac.stfc.isis.ibex.validators,
+ uk.ac.stfc.isis.ibex.logger
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: uk.ac.stfc.isis.ibex.ui.configserver.commands,

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DisablingConfigHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DisablingConfigHandler.java
@@ -1,6 +1,10 @@
 package uk.ac.stfc.isis.ibex.ui.configserver.commands;
 
+import org.apache.logging.log4j.Logger;
+
 import uk.ac.stfc.isis.ibex.epics.writing.Writable;
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
 
 /**
  * This class is a specific type of ConfigHandler that will disable the command
@@ -9,6 +13,8 @@ import uk.ac.stfc.isis.ibex.epics.writing.Writable;
  * @param <T> The type of data expected from the underlying PV
  */
 public abstract class DisablingConfigHandler<T> extends ConfigHandler<T> {
+	
+	private final Logger LOG = IsisLog.getLogger(getClass());
 
 	/**
 	 * The default constructor.
@@ -21,7 +27,7 @@ public abstract class DisablingConfigHandler<T> extends ConfigHandler<T> {
 
 	@Override
 	public void canWriteChanged(boolean canWrite) {
+		LoggerUtils.logIfExtraDebug(LOG, "(Ticket 3001) canWrite set to " + canWrite);
 		setBaseEnabled(canWrite);		
 	}
-
 }


### PR DESCRIPTION
### Description of work

Adds some extra debug logging

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3001

### Acceptance criteria

- If no extra environment variables are set, no additional logging.
- If an envoronment variable called `IBEX_GUI_EXTRA_DEBUG` is set to `1`, you get additional debug messages.
- If an envoronment variable called `IBEX_GUI_EXTRA_DEBUG` is set to any other value, you do not get additional debug messages.

### Unit tests

No unit-testable logic

### System tests

None

### Documentation

Added to https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Eclipse-logging

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

