### PR TITLE
Ticket2922 Remove logic for not showing beam in synoptic when only one component exists.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticPanel.java
@@ -100,7 +100,7 @@ public class SynopticPanel extends Composite {
 			ComponentView.create(instrumentComposite, component);
 		}
 		
-		if (components.size() > 1 && showBeam) {
+		if (showBeam) {
 			addBeamline();				
 		}
 	}


### PR DESCRIPTION


### Description of work

Removed logic for not showing beam in synoptic when only one component exists.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2922

### Acceptance criteria

Create a synoptic with only one component and check "show beam" option. Make sure beam is displayed after saving.

### Unit tests

This is a GUI change and is hard to do unit tests for because it spans multiple sections.

### System tests

We aren't currently doing system tests.

### Documentation
Checked documentation and can't see anywhere it says that a single component won't show the beam.
Current documentation is shows this behaviour properly.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

