### PR TITLE
Ticket1306 Pydev interactive console now retains history across sessions.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/ConsoleSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/ConsoleSettings.java
@@ -22,6 +22,8 @@
  */
 package uk.ac.stfc.isis.ibex.ui.scripting;
 
+import org.python.pydev.shared_interactive_console.console.ui.ScriptConsoleManager;
+
 import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 import uk.ac.stfc.isis.ibex.instrument.InstrumentInfoReceiverAdapter;
 import uk.ac.stfc.isis.ibex.ui.PerspectiveReopener;
@@ -38,7 +40,8 @@ public class ConsoleSettings extends InstrumentInfoReceiverAdapter {
     }
 
     @Override
-    public void preSetInstrument(InstrumentInfo instrument) {       
+    public void preSetInstrument(InstrumentInfo instrument) {
+        ScriptConsoleManager.getInstance().closeAll();
         scriptingPerspectiveReopener.closePerspective();
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Consoles.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Consoles.java
@@ -24,6 +24,7 @@ import org.eclipse.ui.console.IConsole;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.python.pydev.shared_interactive_console.console.ui.ScriptConsole;
+import org.python.pydev.shared_interactive_console.console.ui.ScriptConsoleManager;
 
 /**
  * The activator class controls the plug-in life cycle.
@@ -73,6 +74,7 @@ public class Consoles extends AbstractUIPlugin {
 	 */
 	@Override
     public void stop(BundleContext context) throws Exception {
+		ScriptConsoleManager.getInstance().closeAll();
 		plugin = null;
 		super.stop(context);
 	}


### PR DESCRIPTION
### Description of work

When changing instrument or closing IBEX, Pydev interactive console is
closed properly which causes it to write the history to
C:\Users\USER\Documents\IBEX\runtime-ibex.product\.metadata\.plugins\org.python.pydev.shared_interactive_console\history.py
this file will be read when the console is opened again to give the user
their global history.
The number of lines stored in the global history is set in preferences
under PyDev interactive console.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/1306

### Acceptance criteria

Open Scripting perspective, run some commands in the PyDev Console, switch instruments or close and reopen IBEX, see if the old history is available.

### Unit tests

This is a GUI change and is hard to do unit tests for because it spans multiple sections.

### System tests

We aren't currently doing system tests.

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

