### PR TITLE
Ticket 2306: Incorrect initialisation order in SynopticPresenter causes null pointer exception

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticPresenter.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticPresenter.java
@@ -74,38 +74,40 @@ public class SynopticPresenter extends ModelObject {
 		}
 	};
 
-    private final Observer<SynopticDescription> descriptionObserver = new BaseObserver<SynopticDescription>() {
-        @Override
-        public void onValue(SynopticDescription value) {
-            updateModel();
-        }
-
-        @Override
-        public void onError(Exception e) {
-            e.printStackTrace();
-            clearComponents();
-        }
-
-        @Override
-        public void onConnectionStatus(boolean isConnected) {
-            if (!isConnected) {
-                clearComponents();
-            }
-        }
-    };
+    private final Observer<SynopticDescription> descriptionObserver;
 
     /**
      * Presents synoptics.
      */
 	public SynopticPresenter() {
 		model = Synoptic.getInstance().currentViewerModel();
-        ObservingSynopticModel observingSynopticModel = Synoptic.getInstance().currentObservingViewerModel();
-        observingSynopticModel.getSynopticObservable().addObserver(descriptionObserver);
 
 		navigator = new NavigationPresenter(model.instrumentGraph().head());
 		navigator.addPropertyChangeListener("currentTarget", navigationListener);
 
 		updateModel();
+
+		descriptionObserver = new BaseObserver<SynopticDescription>() {
+	        @Override
+	        public void onValue(SynopticDescription value) {
+	            updateModel();
+	        }
+
+	        @Override
+	        public void onError(Exception e) {
+	            e.printStackTrace();
+	            clearComponents();
+	        }
+
+	        @Override
+	        public void onConnectionStatus(boolean isConnected) {
+	            if (!isConnected) {
+	                clearComponents();
+	            }
+	        }
+	    };
+        ObservingSynopticModel observingSynopticModel = Synoptic.getInstance().currentObservingViewerModel();
+        observingSynopticModel.getSynopticObservable().addObserver(descriptionObserver);
 	}
 
     private void updateModel() {


### PR DESCRIPTION
### Description of work

I've changed the order of initialisation in Synoptic Presenter to avoid the case of a null pointer exception if `updateModel()` is called by `descriptionObserver` before the `navigator` is initialised.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2306

### Acceptance criteria

Synoptic no longer fails at startup.

### Unit tests

No change

### System tests

No change

### Documentation

No change

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

