### PR TITLE
Ticket2875 fix opi scripting

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.feature.css/feature.xml
+++ b/base/uk.ac.stfc.isis.ibex.feature.css/feature.xml
@@ -1092,13 +1092,6 @@
          version="0.0.0"
          unpack="false"/>
 
-   <!-- 
-   These two plugins have their versions pinned because the current P2
-   repository can't resolve the dependency on the Maven build when left
-   to its own devices. I think that is because version 3.106.* is available
-   for the win32 plugin, but not the base version. It's possible this will
-   be resolved in the future but is out of our control.
-   -->
    <plugin
          id="org.eclipse.swt"
          download-size="0"
@@ -1115,6 +1108,13 @@
          install-size="0"
          version="3.105.3.v20170228-0512"
          fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.diirt.datasource-loc"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/base/uk.ac.stfc.isis.ibex.feature.css/feature.xml
+++ b/base/uk.ac.stfc.isis.ibex.feature.css/feature.xml
@@ -1117,4 +1117,11 @@
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.csstudio.trends.databrowser2.opiwidget"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/base/uk.ac.stfc.isis.ibex.feature.css/feature.xml
+++ b/base/uk.ac.stfc.isis.ibex.feature.css/feature.xml
@@ -1092,6 +1092,14 @@
          version="0.0.0"
          unpack="false"/>
 
+	<!-- 
+	These two plugins have their versions pinned because the current P2
+	repository can't resolve the dependency on the Maven build when left
+	to its own devices. I think that is because version 3.106.* is available
+	for the win32 plugin, but not the base version. It's possible this will
+	be resolved in the future but is out of our control.
+	-->
+
    <plugin
          id="org.eclipse.swt"
          download-size="0"

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/EurothermFileCheck.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/EurothermFileCheck.py
@@ -1,5 +1,5 @@
 from org.csstudio.opibuilder.scriptUtil import ConsoleUtil
-from org.epics.vtype import AlarmSeverity
+from org.diirt.vtype import AlarmSeverity
 from org.csstudio.opibuilder.util import OPIColor
 
 def check(file_type, pv):

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/HV/Scripts/DisplayChannels.js
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/HV/Scripts/DisplayChannels.js
@@ -60,10 +60,10 @@ for (z=0; z < maxcrate; z++){
 				var avail = crate + ':' + x + ':' + y;
 				var target = WidgetUtil.createWidgetModel("org.csstudio.opibuilder.widgets.linkingContainer");
 				target.setPropertyValue('opi_file', "HVChannelSummaryMaintenance.opi");
-				target.setPropertyValue('auto_size','true');
-				target.setPropertyValue('zoom_to_fit','false');
+				target.setPropertyValue('auto_size', true);
+				target.setPropertyValue('zoom_to_fit', false);
 				target.setPropertyValue('border_style',0);
-				target.setPropertyValue('name',avail);
+				target.setPropertyValue('name', avail);
 				target.addMacro('SEL',avail);
 				group.addChildToBottom(target);
 				container = display.getWidget(avail);

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/HV/Scripts/DisplaySummary.js
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/HV/Scripts/DisplaySummary.js
@@ -25,8 +25,8 @@ for (i = 0; i < chanlist.length; i++){
 	if ((chan != '')&&(chan != ',')){
 		target = WidgetUtil.createWidgetModel("org.csstudio.opibuilder.widgets.linkingContainer")
 		target.setPropertyValue('opi_file', "HVChannelMonitorSummary.opi")
-		target.setPropertyValue('auto_size','true')
-		target.setPropertyValue('zoom_to_fit','false')
+		target.setPropertyValue('auto_size', true)
+		target.setPropertyValue('zoom_to_fit', false)
 		target.setPropertyValue('border_style',0)
 		target.addMacro('SEL',chan)
 		group.addChildToBottom(target)

--- a/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
+++ b/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="uk.ac.stfc.isis.ibex.targetplatform" sequenceNumber="241">
+<?pde version="3.8"?><target name="uk.ac.stfc.isis.ibex.targetplatform" sequenceNumber="242">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.mockito.feature.feature.group" version="1.0.0.20150724-1352"/>
@@ -18,17 +18,6 @@
 <repository location="http://download.eclipse.org/eclipse/updates/4.6"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.csstudio.archive.reader.rdb.feature.feature.group" version="1.0.0.201804041854"/>
-<unit id="org.csstudio.core.diirt.feature.feature.group" version="0.0.1.201804041845"/>
-<unit id="org.csstudio.core.platform.feature.source.feature.group" version="0.0.1.201804041845"/>
-<unit id="org.csstudio.core.platform.feature.feature.group" version="0.0.1.201804041845"/>
-<unit id="org.csstudio.applications.opibuilder.feature.feature.group" version="5.0.0.201804041854"/>
-<unit id="org.csstudio.core.utility.feature.feature.group" version="4.1.0.201804041845"/>
-<unit id="org.csstudio.alarm.beast.ui.feature.feature.group" version="4.1.0.201804041854"/>
-<unit id="org.csstudio.trends.databrowser2.feature.feature.group" version="4.1.0.201804041854"/>
-<repository location="http://download.controlsystemstudio.org/updates/4.5"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.emf.sdk.feature.group" version="2.13.0.v20170609-0928"/>
 <repository location="http://download.eclipse.org/releases/oxygen"/>
 </location>
@@ -41,6 +30,18 @@
 <unit id="javax.activation" version="1.1.0.v201211130549"/>
 <unit id="com.google.gson" version="2.2.4.v201311231704"/>
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20180330011457/repository"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.csstudio.archive.reader.rdb.feature.feature.group" version="1.0.0.201804041854"/>
+<unit id="org.csstudio.core.diirt.feature.feature.group" version="0.0.1.201804041845"/>
+<unit id="org.csstudio.core.platform.feature.source.feature.group" version="0.0.1.201804041845"/>
+<unit id="org.csstudio.applications.opibuilder.feature.feature.group" version="5.0.0.201804041854"/>
+<unit id="org.csstudio.core.platform.feature.feature.group" version="0.0.1.201804041845"/>
+<unit id="org.csstudio.core.utility.feature.feature.group" version="4.1.0.201804041845"/>
+<unit id="org.csstudio.trends.databrowser2.opiwidget.feature.feature.group" version="3.2.0.201804041854"/>
+<unit id="org.csstudio.alarm.beast.ui.feature.feature.group" version="4.1.0.201804041854"/>
+<unit id="org.csstudio.trends.databrowser2.feature.feature.group" version="4.1.0.201804041854"/>
+<repository location="http://download.controlsystemstudio.org/updates/4.5"/>
 </location>
 </locations>
 <environment>


### PR DESCRIPTION
### Description of work

- Stopped errors regarding local PV data source not being configured. This involved adding the missing dependency `org.diirt.datasource-loc`
- I've been through a selection of OPIs that covers all external scripts and several internal The following issues were found:
    - JS API now expects `boolean` rather than boolean `String` equivalents
    - One instance of the import module in a Python script has been changed
- I've added the dependency for the `databrowser` OPI widget for the stress rig OPI
- I've added a ticket to improve the appearance of the new `databrowser` in the stress rig OPI

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2875

### Acceptance criteria

- All existing scripts within OPI work as in E3

### Unit tests

No change

### System tests

No change

### Documentation

No change

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

