### PR TITLE
Remove reference to flow on CCD100

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/CCD100/CCD100.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/CCD100/CCD100.opi
@@ -386,7 +386,7 @@ $(trace_0_y_pv_value)</tooltip>
     </axis_1_axis_color>
     <axis_0_scale_format></axis_0_scale_format>
     <axis_1_log_scale>false</axis_1_log_scale>
-    <title>Flow vs Time</title>
+    <title>Reading vs Time</title>
     <trace_0_visible>true</trace_0_visible>
     <trace_1_name>$(trace_1_y_pv)</trace_1_name>
     <trace_3_anti_alias>true</trace_3_anti_alias>
@@ -463,7 +463,7 @@ $(trace_0_y_pv_value)</tooltip>
     <axis_0_minimum>0.0</axis_0_minimum>
     <trace_2_y_axis_index>1</trace_2_y_axis_index>
     <trace_1_update_delay>100</trace_1_update_delay>
-    <axis_1_axis_title>Flow</axis_1_axis_title>
+    <axis_1_axis_title>Reading</axis_1_axis_title>
     <trace_2_x_pv_value />
     <axis_1_auto_scale>true</axis_1_auto_scale>
     <trace_1_line_width>1</trace_1_line_width>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/CCD100/single_channel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/CCD100/single_channel.opi
@@ -148,7 +148,7 @@ $(pv_value)</tooltip>
     <wuid>-1be97a08:160734ec8eb:-7f18</wuid>
     <transparent>false</transparent>
     <auto_size>false</auto_size>
-    <text>Flow set point $(N):</text>
+    <text>Set point $(N):</text>
     <scripts />
     <height>20</height>
     <border_width>1</border_width>
@@ -240,7 +240,7 @@ $(pv_value)</tooltip>
     <wuid>-1be97a08:160734ec8eb:-7f16</wuid>
     <transparent>false</transparent>
     <auto_size>false</auto_size>
-    <text>Flow reading $(N):</text>
+    <text>Reading $(N):</text>
     <scripts />
     <height>20</height>
     <border_width>1</border_width>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -56,6 +56,10 @@
 				<type>CCD100</type>
 				<path>CCD100/CCD100.opi</path>
 				<description>The OPI for a Chell CCD100</description>
+				<categories>
+					<category>Pressure sensors</category>
+					<category>Flow meters</category>
+				</categories>
 				<macros>
 					<macro>		
 						<name>CCD_1</name>		


### PR DESCRIPTION
### Description of work

Removes references to flow on CCD100 OPI (it is not only used to measure flow it can measure many different things)

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3142

### Acceptance criteria

- [x] OPI does not reference flow

### Unit tests

n/a

### System tests

n/a

### Documentation

n/a

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

