### PR TITLE
Sort DAE table numerically

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/detectordiagnostics/DetectorDiagnosticsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/detectordiagnostics/DetectorDiagnosticsTable.java
@@ -88,6 +88,16 @@ public class DetectorDiagnosticsTable extends DataboundTable<SpectrumInformation
                     return DISPLAY_STRING_FOR_NULL_VALUE;
                 }
             }
+            
+            @Override
+            public Comparable<SpectrumInformation> comparableForRow(final SpectrumInformation row) {
+        		return new Comparable<SpectrumInformation>() {
+        			@Override
+        			public int compareTo(SpectrumInformation arg0) {
+        				return row.getSpectrumNumber().compareTo(arg0.getSpectrumNumber());
+        			}
+        		};
+        	}
         });
     }
     
@@ -101,6 +111,16 @@ public class DetectorDiagnosticsTable extends DataboundTable<SpectrumInformation
                     return DISPLAY_STRING_FOR_NULL_VALUE;
                 }
             }
+            
+            @Override
+            public Comparable<SpectrumInformation> comparableForRow(final SpectrumInformation row) {
+        		return new Comparable<SpectrumInformation>() {
+        			@Override
+        			public int compareTo(SpectrumInformation arg0) {
+        				return row.getCountRate().compareTo(arg0.getCountRate());
+        			}
+        		};
+        	}
         });
     }
     
@@ -114,6 +134,16 @@ public class DetectorDiagnosticsTable extends DataboundTable<SpectrumInformation
                     return DISPLAY_STRING_FOR_NULL_VALUE;
                 }
             }
+            
+            @Override
+            public Comparable<SpectrumInformation> comparableForRow(final SpectrumInformation row) {
+        		return new Comparable<SpectrumInformation>() {
+        			@Override
+        			public int compareTo(SpectrumInformation arg0) {
+        				return row.getMaxSpecBinCount().compareTo(arg0.getMaxSpecBinCount());
+        			}
+        		};
+        	}
         });
     }
     
@@ -127,6 +157,16 @@ public class DetectorDiagnosticsTable extends DataboundTable<SpectrumInformation
                     return DISPLAY_STRING_FOR_NULL_VALUE;
                 }
             }
+            
+            @Override
+            public Comparable<SpectrumInformation> comparableForRow(final SpectrumInformation row) {
+        		return new Comparable<SpectrumInformation>() {
+        			@Override
+        			public int compareTo(SpectrumInformation arg0) {
+        				return row.getIntegral().compareTo(arg0.getIntegral());
+        			}
+        		};
+        	}
         });
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/detectordiagnostics/DetectorDiagnosticsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/detectordiagnostics/DetectorDiagnosticsTable.java
@@ -94,7 +94,11 @@ public class DetectorDiagnosticsTable extends DataboundTable<SpectrumInformation
         		return new Comparable<SpectrumInformation>() {
         			@Override
         			public int compareTo(SpectrumInformation arg0) {
-        				return row.getSpectrumNumber().compareTo(arg0.getSpectrumNumber());
+        				try {
+        					return row.getSpectrumNumber().compareTo(arg0.getSpectrumNumber());
+        				} catch (NullPointerException e) {
+        					return 0;
+        				}
         			}
         		};
         	}
@@ -117,7 +121,11 @@ public class DetectorDiagnosticsTable extends DataboundTable<SpectrumInformation
         		return new Comparable<SpectrumInformation>() {
         			@Override
         			public int compareTo(SpectrumInformation arg0) {
-        				return row.getCountRate().compareTo(arg0.getCountRate());
+        				try {
+        				    return row.getCountRate().compareTo(arg0.getCountRate());
+        				} catch (NullPointerException e) {
+        					return 0;
+        				}
         			}
         		};
         	}
@@ -140,7 +148,11 @@ public class DetectorDiagnosticsTable extends DataboundTable<SpectrumInformation
         		return new Comparable<SpectrumInformation>() {
         			@Override
         			public int compareTo(SpectrumInformation arg0) {
-        				return row.getMaxSpecBinCount().compareTo(arg0.getMaxSpecBinCount());
+        				try {
+	        				return row.getMaxSpecBinCount().compareTo(arg0.getMaxSpecBinCount());
+	        			} catch (NullPointerException e) {
+	    					return 0;
+	    				}
         			}
         		};
         	}
@@ -163,7 +175,11 @@ public class DetectorDiagnosticsTable extends DataboundTable<SpectrumInformation
         		return new Comparable<SpectrumInformation>() {
         			@Override
         			public int compareTo(SpectrumInformation arg0) {
-        				return row.getIntegral().compareTo(arg0.getIntegral());
+        				try {
+        				    return row.getIntegral().compareTo(arg0.getIntegral());
+        				} catch (NullPointerException e) {
+        					return 0;
+        				}
         			}
         		};
         	}


### PR DESCRIPTION
### Description of work

Sorts DAE detector diagnostics tables purely numerically rather than string based

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3186

### Acceptance criteria

Table sorts correctly

### Unit tests

This is quite hard to test, the sorting logic is quite deep down in SWT layers, this change just passes it the correct comparator to use.

### System tests

None added, minimal change

### Documentation

None

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

