### PR TITLE
Ticket3132: Fixed bug: periodDuration showed periodSequence value

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/runinformation/RunInformationPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/runinformation/RunInformationPanel.java
@@ -533,7 +533,7 @@ public class RunInformationPanel extends Composite {
 		bindLabel(periodGoodFrames, viewModel.periodGoodFrames);
 		bindLabel(periodRawFrames, viewModel.periodRawFrames);
 		bindLabel(periodSequence, viewModel.periodSequence);
-		bindLabel(periodDuration, viewModel.periodSequence);
+		bindLabel(periodDuration, viewModel.periodDuration);
 		bindLabel(monitorSpectrum, viewModel.monitorSpectrum);
 		bindLabel(monitorCounts, viewModel.monitorCounts);
 		bindLabel(npRatio, viewModel.npRatio);


### PR DESCRIPTION
### Description of work

DAE view -> Run information tab - > Period Duration value incorrectly showed Period Sequence value.
Changed it to show Period Duration.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3132

### Acceptance criteria

On the IBEX client, go to: DAE view -> Run information tab
And check that the Period Duration in the Periods group shows the correct value.
You can see the correct value in an EPICS terminal with "caget IN:LARMOR:DAE:RUNDURATION_PD" (using LARMOR as an example).

### Unit tests

N/A

### System tests

N/A

### Documentation

No change to docs made.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

