### PR TITLE
updated MCR display URL

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/McrNewsPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/McrNewsPanel.java
@@ -47,7 +47,7 @@ public class McrNewsPanel extends Composite {
     private static final int FONT_SIZE = 10;
     private static final int NEWS_FIELD_HEIGHT = 155;
 
-    private static final String MCR_NEWS_PAGE_URL = "https://www.isis.stfc.ac.uk/gallery/mcrnews.txt";
+    private static final String MCR_NEWS_PAGE_URL = "https://www.isis.stfc.ac.uk/gallery/beam-status/mcrnews.txt";
     private static final String GET_NEWS_FAILED_MESSAGE =
             "Unable to load MCR news. \nTarget URL: " + MCR_NEWS_PAGE_URL + "\nError: ";
 


### PR DESCRIPTION
### Description of work

We changed the URL for the MCR display as per the recommendation in the ticket.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3244

### Acceptance criteria

The url has been changed.

### Unit tests

Not applicable.

### System tests

Not applicable.

### Documentation

We looked in the user's manual and the developpre's manula but there wasn't any documentation on the URL.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

