### PR TITLE
Removed the checkbox next to the synoptics writable PV components

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
@@ -53,14 +53,14 @@ public class WritableComponentView extends Composite {
 	private Label propertyName;
 	private Text text;
 	private Composite composite;
-	private Button setButton;
+	
 	
 	private final WritableComponentProperty property;
 	
 	private final ModifyListener textModifyListener = new ModifyListener() {
 		@Override
 		public void modifyText(ModifyEvent e) {
-			setButton.setEnabled(true);
+			
 		}
 	};
 	
@@ -106,9 +106,6 @@ public class WritableComponentView extends Composite {
 		
 		bindText(property);
 		
-		setButton = new Button(composite, SWT.CENTER);
-		setButton.setEnabled(false);
-		setButton.setImage(ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui.synoptic", "icons/tick.png"));
 		
 		text.addFocusListener(new FocusListener() {
 			
@@ -128,18 +125,12 @@ public class WritableComponentView extends Composite {
 			public void handleEvent(Event event) {
 				if (event.detail == SWT.TRAVERSE_RETURN) {
 					sendValue();
-					setButton.setFocus();
+					
 				}
 			}
 		});
 		
-		setButton.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				sendValue();
-			}
-		});
-		
+				
 	}
 
 	private void bindText(final WritableComponentProperty property) {
@@ -153,6 +144,6 @@ public class WritableComponentView extends Composite {
 	private void sendValue() {
 	    property.writer().uncheckedWrite(text.getText());
 		parent.setFocus();
-		setButton.setEnabled(false);
+		
 	}
 }


### PR DESCRIPTION
### Description of work

I removed the checkbox next to the synoptics writable PV components in the GUI.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3205

### Acceptance criteria

After launching the IBEX GUI, the checkbox next to the synoptics writable PV components should have disappeared..

### Unit tests

None available.

### System tests

None available.

### Documentation

As far as I can tell there is no documentation relating to the checkbox.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

