### PR TITLE
Reduce warnings shown in eclipse.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
+++ b/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
@@ -105,7 +105,7 @@ public abstract class MessageParser<T extends IMessage> implements Runnable {
                     Thread.sleep(TIMEOUT_50_MS);
                 }
             } catch (JMSException | InterruptedException e) {
-                // Do nothing; exception will be caught be exception
+                // Do nothing; exception will be caught by exception
                 // listener (see connect())
             }
         }

--- a/base/uk.ac.stfc.isis.ibex.alarm.tests/src/uk/ac/stfc/isis/ibex/alarm/tests/AlarmTest.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm.tests/src/uk/ac/stfc/isis/ibex/alarm/tests/AlarmTest.java
@@ -34,6 +34,10 @@ import org.mockito.stubbing.Answer;
 import uk.ac.stfc.isis.ibex.alarm.AlarmSettings;
 import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 
+/**
+ * Test the alarm settings for CSS Beast Alarm.
+ *
+ */
 @SuppressWarnings("checkstyle:methodname")
 public class AlarmTest {
 
@@ -258,18 +262,6 @@ public class AlarmTest {
         InstrumentInfo returnedInstrument = mock(InstrumentInfo.class);
         when(returnedInstrument.hostName()).thenReturn(hostName);
         return returnedInstrument;
-    }
-
-    @Test
-    public void default_rdb_url_is_set_correctly() {
-        // Assert
-        assertEquals(DEFAULT_RDB_URL, preferenceStore.getString(Preferences.RDB_URL));
-    }
-
-    @Test
-    public void default_jms_url_is_set_correctly() {
-        // Assert
-        assertEquals(DEFAULT_JMS_URL, preferenceStore.getString(Preferences.JMS_URL));
     }
 
     @Test

--- a/base/uk.ac.stfc.isis.ibex.banner/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.banner/plugin.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.4"?>
-<plugin>
-
-</plugin>

--- a/base/uk.ac.stfc.isis.ibex.banner/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.banner/pom.xml
@@ -8,5 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/pom.xml
@@ -8,5 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/json/JsonConvertersTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/json/JsonConvertersTest.java
@@ -289,6 +289,6 @@ public class JsonConvertersTest {
         Converter<String, Collection<BannerItem>> conv = new JsonConverters().toBannerDescription();
 
         // Act
-        List<BannerItem> bannerList = new ArrayList<BannerItem>(conv.convert(bannerJsonBroken));
+        new ArrayList<BannerItem>(conv.convert(bannerJsonBroken));
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/AlarmState.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/AlarmState.java
@@ -26,9 +26,24 @@ package uk.ac.stfc.isis.ibex.configserver;
  * An enumeration containing possible block alarm states.
  */
 public enum AlarmState {
+    /**
+     * NO_ALARM: as expected.
+     */
     NO_ALARM,
+    /**
+     * MINOR: minor alarm.
+     */
     MINOR,
+    /**
+     * MAJOR: major alarm.
+     */
     MAJOR,
+    /**
+     * INVALID: alarm state is invalid.
+     */
     INVALID,
+    /**
+     * UNDEFINED: alarm state is undefined.
+     */
     UNDEFINED
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/AvailablePV.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/AvailablePV.java
@@ -19,32 +19,65 @@
 
 package uk.ac.stfc.isis.ibex.configserver.configuration;
 
+/**
+ * Holds the details of an available PV.
+ *
+ */
 public class AvailablePV {
 	private String name;
 	private String description;
 	
+	/**
+	 * Create a new AvailablePV.
+	 * 
+	 * @param name PV name
+	 * @param description PV description
+	 */
 	public AvailablePV(String name, String description) {
 		this.name = name;
 		this.description = description;
 	}
 	
+	/**
+	 * Clone an existing AvailablePV.
+	 * 
+	 * @param other existing AvailablePV to clone
+	 */
 	public AvailablePV(AvailablePV other) {
 		this.name = other.name;
 		this.description = other.description;
 	}
 	
+	/**
+	 * 
+	 * @return PV name
+	 */
 	public String getName() {
 		return name;
 	}
 	
+	/**
+	 * Set this PV's name.
+	 * 
+	 * @param name new PV name
+	 */
 	public void setName(String name) {
 		this.name = name;
 	}
 	
+	/**
+	 * 
+	 * @return PV description
+	 */
 	public String getDescription() {
 		return description;
 	}
 	
+	/**
+	 * Set this PV's description.
+	 * 
+	 * @param description new PV description
+	 */
 	public void setDescription(String description) {
 		this.description = description;
 	}

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/AvailablePVSet.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/AvailablePVSet.java
@@ -19,14 +19,26 @@
 
 package uk.ac.stfc.isis.ibex.configserver.configuration;
 
+/**
+ * Holds details of a set of PVs.
+ *
+ */
 public class AvailablePVSet {
 	String name;
 	String description;
 	
+	/**
+	 * 
+	 * @return PV set's name
+	 */
 	public String getName() {
 		return name;
 	}
 	
+	/**
+	 * 
+	 * @return PV set's description
+	 */
 	public String getDescription() {
 		return description;
 	}

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/BannerItem.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/BannerItem.java
@@ -17,7 +17,6 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
  * 
  * CREATED FROM JSON therefore uses snake case
  */
-@SuppressWarnings("checkstyle:MemberName")
 public class BannerItem extends ModelObject {
 
     private String name;
@@ -124,10 +123,10 @@ public class BannerItem extends ModelObject {
 	}
     
     /**
-     * Sets the current state of the property based on the PV value and fires a
+     * Sets the current state of the alarm based on the PV value and fires a
      * property change for listeners.
      * 
-     * @param value the state value of the property.
+     * @param alarm the alarm state to be set
      */
     public synchronized void setCurrentAlarm(AlarmState alarm) {
         firePropertyChange("alarm", this.currentAlarmState, this.currentAlarmState = alarm);

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Macro.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Macro.java
@@ -40,14 +40,28 @@ public class Macro extends ModelObject {
 	 * create the object. This mean the parent class's constructor is NOT called.
 	 * GSON does not care if this is private.
 	 */
+	@SuppressWarnings("unused")
 	private Macro() {
 	}
 
+	/**
+	 * Create this Macro based on an existing Macro.
+	 * 
+	 * @param other exiting Macro to clone
+	 */
 	public Macro(Macro other) {
 		this(other.getName(), other.getValue(), other.getDescription(), other
 				.getPattern());
 	}
 
+	/**
+	 * Create a new Macro.
+	 * 
+	 * @param name macro name
+	 * @param value macro value
+	 * @param description macro description
+	 * @param pattern Regex pattern macro value should follow
+	 */
 	public Macro(String name, String value, String description, String pattern) {
 		this.name = name;
 		this.value = value;
@@ -55,34 +69,70 @@ public class Macro extends ModelObject {
 		this.pattern = pattern;
 	}
 
+	/**
+	 * Set Macro name and fire a property change.
+	 * 
+	 * @param name new Macro name
+	 */
 	public void setName(String name) {
 		firePropertyChange("name", this.name, this.name = name);
 	}
 
+	/**
+	 * 
+	 * @return macro name
+	 */
 	public String getName() {
 		return name;
 	}
 
+	/**
+	 * Set Macro value and fire a property change.
+	 * 
+	 * @param value new Macro value
+	 */
 	public void setValue(String value) {
 		firePropertyChange("value", this.value, this.value = value);
 	}
 
+	 /**
+     * 
+     * @return macro value
+     */
 	public String getValue() {
 		return value;
 	}
 
+	/**
+	 * Set macro description.
+	 * 
+	 * @param description new macro description
+	 */
 	public void setDescription(String description) {
 		this.description = description;
 	}
 
+	 /**
+     * 
+     * @return macro description
+     */
 	public String getDescription() {
 		return description;
 	}
 
+	/**
+	 * Set macro regex pattern.
+	 * 
+	 * @param pattern new regex pattern
+	 */
 	public void setPattern(String pattern) {
 		this.pattern = pattern;
 	}
 
+	/**
+     * 
+     * @return macro regex pattern
+     */
 	public String getPattern() {
 		return pattern;
 	}

--- a/base/uk.ac.stfc.isis.ibex.dae.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.dae.tests/pom.xml
@@ -8,5 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/spectra/SpectrumYAxisTypes.java
@@ -13,7 +13,11 @@ public enum SpectrumYAxisTypes {
 	
 	private String name;
 	
-	private SpectrumYAxisTypes(String name) {
+	/**
+	 * Constructor for enum representing the possible Y axes on a spectrum plot.
+	 * @param name text displayed to the user.
+	 */
+	SpectrumYAxisTypes(String name) {
 		this.name = name;
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/updatesettings/AutosaveUnit.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/updatesettings/AutosaveUnit.java
@@ -23,11 +23,28 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import uk.ac.stfc.isis.ibex.ui.Utils;
+
+/**
+ * Enum containing the possible auto save units for the DAE.
+ */
 public enum AutosaveUnit {
+    /**
+     * Save on every so many frames.
+     */
     FRAMES("Frames"),
+    /**
+     * Save on every so many events.
+     */
     EVENTS("Events"),
+    /**
+     * Save on every so many dashboard polls.
+     */
     DASHBOARD_POLLS("Dashboard polls"),
-    MICROAMPS("μA");
+    /**
+     * Save on every so many micro-amps.
+     */
+    MICROAMPS(Utils.MU + "A");
 	
 	private String text;
 
@@ -39,10 +56,20 @@ public enum AutosaveUnit {
 		}
 	}
 	
+	/**
+	 * Assigns the enum value to the text variable.
+	 *  
+	 * @param text enum value
+	 */
 	AutosaveUnit(String text) {
 		this.text = text;
 	}
-	 
+	
+	/**
+	 * Create a list containing all the auto save units.
+	 * 
+	 * @return a list of each auto save unit.
+	 */
 	public static List<String> allToString() {
 		return Collections.unmodifiableList(ALLTOSTRING);
 	}

--- a/base/uk.ac.stfc.isis.ibex.dashboard/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.dashboard/plugin.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.4"?>
-<plugin>
-
-</plugin>

--- a/base/uk.ac.stfc.isis.ibex.devicescreens.tests/src/uk/ac/stfc/isis/ibex/devicescreens/desc/tests/DeviceScreensDescriptionToXmlConverterTest.java
+++ b/base/uk.ac.stfc.isis.ibex.devicescreens.tests/src/uk/ac/stfc/isis/ibex/devicescreens/desc/tests/DeviceScreensDescriptionToXmlConverterTest.java
@@ -35,7 +35,7 @@ import uk.ac.stfc.isis.ibex.devicescreens.tests.xmldata.DeviceScreensXmlProvider
 import uk.ac.stfc.isis.ibex.epics.conversion.ConversionException;
 import uk.ac.stfc.isis.ibex.epics.observing.Observable;
 
-@SuppressWarnings("checkstyle:methodname")
+@SuppressWarnings( {"checkstyle:methodname", "unchecked"} )
 public class DeviceScreensDescriptionToXmlConverterTest {
 
     @Test

--- a/base/uk.ac.stfc.isis.ibex.devicescreens.tests/src/uk/ac/stfc/isis/ibex/devicescreens/xml/tests/XmlUtilTest.java
+++ b/base/uk.ac.stfc.isis.ibex.devicescreens.tests/src/uk/ac/stfc/isis/ibex/devicescreens/xml/tests/XmlUtilTest.java
@@ -50,7 +50,7 @@ import uk.ac.stfc.isis.ibex.epics.observing.Observable;
 /**
  * This class tests the loading and parsing of an xml by the XMLUtil class.
  */
-@SuppressWarnings("checkstyle:methodname")
+@SuppressWarnings( {"checkstyle:methodname", "unchecked"} )
 public class XmlUtilTest {
 
     private static String deviceName = "Eurotherm 2";

--- a/base/uk.ac.stfc.isis.ibex.epics.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.epics.tests/pom.xml
@@ -8,5 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/conversion/ExponentialOnThresholdFormat.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/conversion/ExponentialOnThresholdFormat.java
@@ -40,7 +40,6 @@ public class ExponentialOnThresholdFormat extends NumberFormat {
     private static final String EXPONENTIAL_PATTERN = "0.####E0";
     private static final double SMALL_NUMBER_THRESHOLD = 0.001;
     private static final double BIG_NUMBER_THRESHOLD = 1000000;
-    private static final int INTEGER_EXPO_FRACTIONAL_DIGITS = 4;
 
     private final NumberFormat defaultFormat;
 

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerObservable.java
@@ -22,7 +22,6 @@ package uk.ac.stfc.isis.ibex.epics.pvmanager;
 import static org.epics.pvmanager.ExpressionLanguage.channel;
 import static org.epics.util.time.TimeDuration.ofHertz;
 
-import org.epics.pvmanager.DataSource;
 import org.epics.pvmanager.PVManager;
 import org.epics.pvmanager.PVReader;
 import org.epics.pvmanager.PVReaderEvent;
@@ -66,8 +65,6 @@ public class PVManagerObservable<R extends VType> extends ObservablePV<R> {
 	
 	public PVManagerObservable(PVInfo<R> info) {
 		super(info);
-		
-		DataSource a = PVManager.getDefaultDataSource();
 		
 		pv = PVManager
 				.read(channel(info.address(), info.type(), Object.class))

--- a/base/uk.ac.stfc.isis.ibex.example/src/uk/ac/stfc/isis/ibex/example/ApplicationActionBarAdvisor.java
+++ b/base/uk.ac.stfc.isis.ibex.example/src/uk/ac/stfc/isis/ibex/example/ApplicationActionBarAdvisor.java
@@ -34,6 +34,12 @@ public class ApplicationActionBarAdvisor extends ActionBarAdvisor {
 	// in the fill methods. This ensures that the actions aren't recreated
 	// when fillActionBars is called with FILL_PROXY.
 
+    /**
+     * Creates a new action bar advisor to configure a workbench
+     * window's action bars via the given action bar configurer.
+     * 
+     * @param configurer the action bar configurer
+     */
 	public ApplicationActionBarAdvisor(IActionBarConfigurer configurer) {
 		super(configurer);
 	}

--- a/base/uk.ac.stfc.isis.ibex.experimentdetails.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.experimentdetails.tests/pom.xml
@@ -8,5 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.experimentdetails.tests/src/uk/ac/stfc/isis/ibex/experimentdetails/tests/database/ExperimentDataFieldsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.experimentdetails.tests/src/uk/ac/stfc/isis/ibex/experimentdetails/tests/database/ExperimentDataFieldsTest.java
@@ -51,6 +51,6 @@ public class ExperimentDataFieldsTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void experiment_table_does_not_contain_name() {
         // Act
-		ExpDataField result = ExpDataFieldsCreator.getField(ExpDataTablesEnum.EXPERIMENT_TABLE, ExpDataFieldsEnum.NAME);	
+		ExpDataFieldsCreator.getField(ExpDataTablesEnum.EXPERIMENT_TABLE, ExpDataFieldsEnum.NAME);	
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.feature.pydev/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.feature.pydev/pom.xml
@@ -1,7 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>uk.ac.stfc.isis.ibex.feature.pydev</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
   <parent>
   	<groupId>CSS_ISIS</groupId>

--- a/base/uk.ac.stfc.isis.ibex.instrument.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.instrument.tests/pom.xml
@@ -8,5 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.journal/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.journal/pom.xml
@@ -8,5 +8,4 @@
     <artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
     <relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.log.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.log.tests/pom.xml
@@ -8,5 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.logger/src/uk/ac/stfc/isis/ibex/logger/LoggerUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.logger/src/uk/ac/stfc/isis/ibex/logger/LoggerUtils.java
@@ -55,7 +55,7 @@ public final class LoggerUtils {
     
     /**
      * Logs a message if the IBEX_GUI_EXTRA_DEBUG environment variable is set to 1. Otherwise does nothing.
-     * @param log the logger to log the message to
+     * @param logger the logger to log the message to
      * @param message the message to log
      */
     public static void logIfExtraDebug(Logger logger, String message) {

--- a/base/uk.ac.stfc.isis.ibex.managermode/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.managermode/pom.xml
@@ -8,5 +8,4 @@
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   	<artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
-  </project>
+</project>

--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/scriptstatus/QueuedScript.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/scriptstatus/QueuedScript.java
@@ -7,7 +7,7 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
  * 
  * THIS IS DESERIALISED FROM JSON AND SO THE CONSTRUCTOR MAY NOT BE CALLED
  */
-@SuppressWarnings({ "checkstyle:membername", "unused" })
+@SuppressWarnings("checkstyle:membername")
 public class QueuedScript extends ModelObject {
 	
 	private static final String INITIAL_NAME = "My Script";

--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/scriptstatus/ReceiveScriptStatus.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/scriptstatus/ReceiveScriptStatus.java
@@ -27,7 +27,7 @@ import uk.ac.stfc.isis.ibex.nicos.messages.ReceiveMessage;
  * 
  * THIS IS DESERIALISED FROM JSON AND SO THE CONSTRUCTOR MAY NOT BE CALLED
  */
-@SuppressWarnings({ "checkstyle:membername", "unused" })
+@SuppressWarnings("checkstyle:membername")
 public class ReceiveScriptStatus implements ReceiveMessage {
 	/**
 	 * Tuple of two items (status code, line number).

--- a/base/uk.ac.stfc.isis.ibex.opis.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis.tests/pom.xml
@@ -1,7 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>uk.ac.stfc.isis.ibex.opis.tests</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <parent>
   	<groupId>CSS_ISIS</groupId>

--- a/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/DescriptionsProviderTest.java
+++ b/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/DescriptionsProviderTest.java
@@ -28,8 +28,7 @@ public class DescriptionsProviderTest {
 	private String opiPath1 = "TestOpi1\\TestOpi1.opi";
 	private String opiDescription1 = "This is test OPI 1";
 	private List<String> opiCategories1 = Collections.<String>emptyList();
-	
-    private String opiType2 = "Type2";
+
     private String opiName2 = "Test Opi 2";
     private String opiPath2 = "TestOpi2\\TestOpi2.opi";
     private String opiDescription2 = "This is test OPI 2";

--- a/base/uk.ac.stfc.isis.ibex.runcontrol.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.runcontrol.tests/pom.xml
@@ -8,6 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.runcontrol.tests/src/uk/ac/stfc/isis/ibex/runcontrol/tests/RunControlAddressesTest.java
+++ b/base/uk.ac.stfc.isis.ibex.runcontrol.tests/src/uk/ac/stfc/isis/ibex/runcontrol/tests/RunControlAddressesTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import uk.ac.stfc.isis.ibex.runcontrol.internal.RunControlAddresses;
 
 // A lot of unchecked type conversions for mocking purposes
-@SuppressWarnings({ "unchecked", "checkstyle:methodname" })
+@SuppressWarnings("checkstyle:methodname")
 public class RunControlAddressesTest {
 	@Test
 	public void get_low_limit_pv() {

--- a/base/uk.ac.stfc.isis.ibex.runcontrol/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.runcontrol/pom.xml
@@ -8,6 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
-  
 </project>

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/plugin.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.4"?>
-<plugin>
-
-</plugin>

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/pom.xml
@@ -8,6 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/BaseComponentTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/BaseComponentTest.java
@@ -38,7 +38,7 @@ import uk.ac.stfc.isis.ibex.targets.Target;
  * This class is responsible for testing the Base Component.
  *
  */
-@SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:methodname", "unchecked" })
+@SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:methodname" })
 public class BaseComponentTest {
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/InstrumentDescriptionParserTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/InstrumentDescriptionParserTest.java
@@ -31,7 +31,7 @@ import uk.ac.stfc.isis.ibex.synoptic.model.desc.SynopticDescription;
  * This class is responsible for testing the Instrument Description Parser.
  */
 
-@SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:methodname", "unchecked" })
+@SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:methodname" })
 public class InstrumentDescriptionParserTest {
 
 	/**
@@ -63,7 +63,7 @@ public class InstrumentDescriptionParserTest {
 		String value = expected;
 		// Act
 		try {
-			SynopticDescription testDesc = parser.convert(value);
+			parser.convert(value);
 			fail("ConversionException not thrown");
 		} catch (ConversionException e) {
 			assertNotNull(e.getMessage());

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/ObservableComponentTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/ObservableComponentTest.java
@@ -61,7 +61,6 @@ public class ObservableComponentTest {
 	public void set_up_observable_component() {
 		// Arrange - used as before for use in each test
 		String addressSuffix = "Address Suffix";
-		String channelValue = "Channel";
 		String synopticDescription = "Synoptic Description";
 		String pvDisplayName = "PV Display Name";
 		String targetValue = "Target Value";

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/ObservableSynopticTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/ObservableSynopticTest.java
@@ -37,7 +37,7 @@ import uk.ac.stfc.isis.ibex.synoptic.model.desc.SynopticDescription;
 /**
  * This class is responsible for testing the observable synoptic.
  */
-@SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:methodname", "unchecked" })
+@SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:methodname" })
 public class ObservableSynopticTest {
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/ObservingSynopticModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/ObservingSynopticModelTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 /**
  * This class is responsible for testing the Observing Synoptic Model.
  */
-@SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:methodname", "unchecked" })
+@SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:methodname" })
 public class ObservingSynopticModelTest {
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/VariablesTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/VariablesTest.java
@@ -54,7 +54,6 @@ public class VariablesTest {
      * Items used throughout
      */
     private final String pvPrefix = "PVPrefix";
-    private final String synopticPV = "Synoptic PV";
     private static final String SYNOPTIC_ADDRESS = "CS:SYNOPTICS:";
     private static final String SET_DETAILS = "SET_DETAILS";
     private static final String DELETE = "DELETE";

--- a/base/uk.ac.stfc.isis.ibex.ui.blocks.presentation/src/uk/ac/stfc/isis/ibex/ui/blocks/presentation/PVHistoryPresenter.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.blocks.presentation/src/uk/ac/stfc/isis/ibex/ui/blocks/presentation/PVHistoryPresenter.java
@@ -42,7 +42,7 @@ public interface PVHistoryPresenter {
 	 * Adds a PV to a pre-existing display.
 	 * @param pvAddress The PV to plot the history of.
 	 * @param display The user-friendly name for the plot and the axis
-	 * @param presenterName The name of the presenter to add the PV to.
+	 * @param displayName The name of the display to add the PV to.
 	 */
 	void addToDisplay(String pvAddress, String display, String displayName);
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/BlocksMenu.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/BlocksMenu.java
@@ -88,7 +88,7 @@ public class BlocksMenu extends MenuManager {
         add(new GroupMarker(BLOCK_MENU_GROUP));
 
         final MenuManager logSubMenu = new MenuManager("Display block history...");
-        logSubMenu.add(new Action("never shown entry"){
+        logSubMenu.add(new Action("never shown entry") {
         	//needed if it's a submenu
         });
         // Allows the menu to be dynamic
@@ -106,7 +106,7 @@ public class BlocksMenu extends MenuManager {
 			public void menuAboutToShow(IMenuManager manager) {
 				logSubMenu.add(newPresenter);
 				for (final String plot : pvHistoryPresenter.getCurrentDisplays()) {
-					logSubMenu.add(new Action("Add to " + plot + " plot"){
+					logSubMenu.add(new Action("Add to " + plot + " plot") {
 						@Override
 						public void run() {
 							pvHistoryPresenter.addToDisplay(block.blockServerAlias(), block.getName(), plot);

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/AvailableIocsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/AvailableIocsTable.java
@@ -23,11 +23,9 @@ package uk.ac.stfc.isis.ibex.ui.configserver.editing;
 
 import java.util.Collection;
 
-import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
-import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundTable;

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/EditableIocsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/EditableIocsTable.java
@@ -119,7 +119,7 @@ public class EditableIocsTable extends DataboundTable<EditableIoc> {
      * Creates the Name column.
      */
 	private void name() {
-        TableViewerColumn name = createColumn("Name", 1, false, new DecoratedCellLabelProvider<EditableIoc>(
+        createColumn("Name", 1, false, new DecoratedCellLabelProvider<EditableIoc>(
 				observeProperty("name"), 
 				Arrays.asList(rowDecorator, simulationDecorator)) {
 			@Override
@@ -133,7 +133,7 @@ public class EditableIocsTable extends DataboundTable<EditableIoc> {
      * Creates the Description column.
      */
 	private void description() {
-        TableViewerColumn desc = createColumn("Description", 2, false, new DecoratedCellLabelProvider<EditableIoc>(
+        createColumn("Description", 2, false, new DecoratedCellLabelProvider<EditableIoc>(
                 observeProperty("name"), 
 				Arrays.asList(rowDecorator)) {
 			@Override

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DataAcquisitionViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DataAcquisitionViewModel.java
@@ -67,7 +67,7 @@ public class DataAcquisitionViewModel extends ModelObject {
 	}
 	
     /**
-     * Sets the updateable DAE settings.
+     * Sets the updatable DAE settings.
      * 
      * @param settings the settings.
      */
@@ -226,6 +226,8 @@ public class DataAcquisitionViewModel extends ModelObject {
 	
 	/**
 	 * Gets the index of the new wiring table.
+	 * 
+	 * @return index of the new wiring table
 	 */
 	public int getNewWiringTable() {
 		return Arrays.asList(getWiringTableList()).indexOf(settings.getNewWiringTable());
@@ -261,6 +263,8 @@ public class DataAcquisitionViewModel extends ModelObject {
 	
 	/**
 	 * Gets the index of the new detector table.
+	 * 
+	 * @return index of the new detector table
 	 */
 	public int getNewDetectorTable() {
 		return Arrays.asList(getDetectorTableList()).indexOf(settings.getNewDetectorTable());
@@ -296,6 +300,8 @@ public class DataAcquisitionViewModel extends ModelObject {
 	
 	/**
 	 * Gets the index of the new spectra table.
+	 * 
+	 * @return index of the new spectra table
 	 */
 	public int getNewSpectraTable() {
 		return Arrays.asList(getSpectraTableList()).indexOf(settings.getNewSpectraTable());
@@ -440,34 +446,72 @@ public class DataAcquisitionViewModel extends ModelObject {
 		settings.setFermiChopperVeto(vetoIsActive(selected));	
 	}
 
+	/**
+	 * 
+	 * @return the current Fermi chopper delay
+	 */
 	public double getFcDelay() {
 		return settings.fcDelay();
 	}
 	
-	public void setFcDelay(double value) {
-		settings.setFcDelay(value);
+	/**
+	 * Set the Fermi chopper delay.
+	 * 
+	 * @param newFcDelay the new Fermi chopper delay
+	 */
+	public void setFcDelay(double newFcDelay) {
+		settings.setFcDelay(newFcDelay);
 	}
 
+	/**
+	 * 
+	 * @return the current Fermi chopper width
+	 */
 	public double getFcWidth() {
 		return settings.fcWidth();
 	}
 	
-	public void setFcWidth(double value) {
-		settings.setFcWidth(value);
+	/**
+	 * Set the Fermi chopper width.
+	 * 
+	 * @param newFcWidth the new Fermi chopper width
+	 */
+	public void setFcWidth(double newFcWidth) {
+		settings.setFcWidth(newFcWidth);
 	}
 	
+	/**
+	 * Checks if the current state of the muon millisecond mode is enabled.
+	 * 
+	 * @return boolean: true if enabled, false otherwise
+	 */
 	public boolean getMuonMsMode() {
 		return settings.muonMsMode() == BinaryState.ENABLED;
 	}
 	
-	public void setMuonMsMode(boolean selected) {
-		settings.setMuonMsMode(selected ? BinaryState.ENABLED : BinaryState.DISABLED);
+	/**
+	 * Set the state of the muon millisecond mode.
+	 * 
+	 * @param newMode true for enabled, false otherwise
+	 */
+	public void setMuonMsMode(boolean newMode) {
+		settings.setMuonMsMode(newMode ? BinaryState.ENABLED : BinaryState.DISABLED);
 	}
 	
+	/**
+	 * The current state of the muon Cerenkov pulse (First/Second).
+	 * 
+	 * @return boolean: true if First, false otherwise
+	 */
 	public boolean getMuonCerenkovPulse() {
 		return settings.muonCerenkovPulse() == MuonCerenkovPulse.FIRST;
 	}
 	
+	/**
+	 * Set the state of the muon Cerenkov Pulse (First/Second).
+	 * 
+	 * @param firstEnabled boolean: true for First, false for Second
+	 */
 	public void setMuonCerenkovPulse(boolean firstEnabled) {
 		settings.setMuonCerenkovPulse(firstEnabled ? MuonCerenkovPulse.FIRST : MuonCerenkovPulse.SECOND);
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/run/ActionButton.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/run/ActionButton.java
@@ -29,8 +29,19 @@ import org.eclipse.swt.widgets.Composite;
 
 import uk.ac.stfc.isis.ibex.model.Action;
 
+/**
+ * ActionButtons: on press: will perform the action assigned to them.
+ *
+ */
 public class ActionButton extends Button {
 
+    /**
+     * Create a new action button.
+     * 
+     * @param parent a composite control which will be the parent of the new instance (cannot be null)
+     * @param style the style of control to construct
+     * @param action the action the button should perform
+     */
 	public ActionButton(Composite parent, int style, Action action) {
 		super(parent, style);
 		

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/run/DaeActionButtonPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/run/DaeActionButtonPanel.java
@@ -30,9 +30,21 @@ import org.eclipse.wb.swt.ResourceManager;
 import uk.ac.stfc.isis.ibex.dae.actions.DaeActions;
 import uk.ac.stfc.isis.ibex.model.Action;
 
+/**
+ * Pane which contains the action buttons in the DAE perspective in the "Run Summary" tab.
+ * For example "BEGIN RUN" or "END RUN".
+ *
+ */
 @SuppressWarnings("checkstyle:magicnumber")
 public class DaeActionButtonPanel extends Composite {
 
+    /**
+     * Create the panel with all the buttons inside.
+     * 
+     * @param parent a composite control which will be the parent of the new instance (cannot be null)
+     * @param style the style of control to construct
+     * @param actions all state transitioning actions on the DAE
+     */
 	public DaeActionButtonPanel(Composite parent, int style, DaeActions actions) {
 		super(parent, style);
 		

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/run/RunSummaryViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/run/RunSummaryViewModel.java
@@ -29,6 +29,10 @@ import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 import uk.ac.stfc.isis.ibex.ui.widgets.observable.BooleanWritableObservableAdapter;
 import uk.ac.stfc.isis.ibex.ui.widgets.observable.StringWritableObservableAdapter;
 
+/**
+ * View Model for the DAE perspective's "Run Summary" tab.
+ *
+ */
 public class RunSummaryViewModel extends Closer {
 	
 	private IDae model;
@@ -110,10 +114,18 @@ public class RunSummaryViewModel extends Closer {
 		return title;
 	}
 	
+	/**
+	 * 
+	 * @return all state transitioning actions on the DAE
+	 */
 	public DaeActions actions() {
 		return model.actions();
 	}
 	
+	/**
+	 * 
+	 * @return producer that creates new LogMessages as they arrive
+	 */
 	public ILogMessageProducer logMessageSource() {
 		return logModel;
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/BannerText.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/BannerText.java
@@ -24,6 +24,11 @@ import java.beans.PropertyChangeListener;
 
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 
+/**
+ * Banner shows instrument name and state, that text is held here.
+ * Updates when those values change.
+ *
+ */
 public class BannerText extends UpdatedValue<String> {
 		
 	private final PropertyChangeListener update = new PropertyChangeListener() {
@@ -36,6 +41,13 @@ public class BannerText extends UpdatedValue<String> {
 	private final UpdatedValue<String> name;
 	private final UpdatedValue<String> state;
 	
+	/**
+	 * Store name and state of instrument,
+	 * create a listener for an updates to those.
+	 * 
+	 * @param name instrument name
+	 * @param state instrument state
+	 */
 	public BannerText(UpdatedValue<String> name, UpdatedValue<String> state) {
 		this.name = name;
 		this.state = state;

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/VersionPanel.java
@@ -80,8 +80,8 @@ public class VersionPanel extends Composite {
         clientPvPrefix = new Label(this, SWT.NONE);
         clientPvPrefix.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
         // Not bound as fixed
-        final String PvPrefix = Help.getInstance().getPvPrefix();
-        clientPvPrefix.setText(PvPrefix);
+        final String pvPrefix = Help.getInstance().getPvPrefix();
+        clientPvPrefix.setText(pvPrefix);
 
 		Label lblServerVersion = new Label(this, SWT.NONE);
 		lblServerVersion.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));

--- a/base/uk.ac.stfc.isis.ibex.ui.ioccontrol/src/uk/ac/stfc/isis/ibex/ui/ioccontrol/StateLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.ioccontrol/src/uk/ac/stfc/isis/ibex/ui/ioccontrol/StateLabelProvider.java
@@ -20,7 +20,6 @@
 package uk.ac.stfc.isis.ibex.ui.ioccontrol;
 
 import org.eclipse.core.databinding.observable.map.IObservableMap;
-import org.eclipse.jface.databinding.viewers.ObservableMapCellLabelProvider;
 import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.wb.swt.SWTResourceManager;
@@ -28,14 +27,29 @@ import org.eclipse.wb.swt.SWTResourceManager;
 import uk.ac.stfc.isis.ibex.configserver.IocState;
 import uk.ac.stfc.isis.ibex.ui.tables.SortableObservableMapCellLabelProvider;
 
+/**
+ * Controls how the state labels in the IOC Table appear.
+ *
+ */
 public class StateLabelProvider extends SortableObservableMapCellLabelProvider<IocState> {
 
 	public static final String TEXT_RUNNING = "Running";
 	public static final String TEXT_NOT_RUNNING = "Stopped";
 	
-	public static final Color COLOR_RUNNING = SWTResourceManager.getColor(19, 145, 44); // Green
+	/**
+	 * Text is green while running.
+	 */
+	public static final Color COLOR_RUNNING = SWTResourceManager.getColor(19, 145, 44);
+	/**
+	 * Text is red while stopped.
+	 */
 	public static final Color COLOR_STOPPED = SWTResourceManager.getColor(173, 66, 66); // RED
 
+	/**
+	 * Constructor for the state label provider.
+	 * 
+	 * @param attributeMaps A map of the attributes that this cell will observe.
+	 */
 	public StateLabelProvider(IObservableMap attributeMaps) {
 		super(attributeMaps);
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/pom.xml
@@ -8,5 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter.tests/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter.tests/pom.xml
@@ -2,7 +2,6 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>uk.ac.stfc.isis.ibex.ui.logplotter.tests</artifactId>
   <packaging>eclipse-test-plugin</packaging>
-  <version>1.0.0-SNAPSHOT</version>
   <parent>
   	<groupId>CSS_ISIS</groupId>
   	<artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>

--- a/base/uk.ac.stfc.isis.ibex.ui.motor/src/uk/ac/stfc/isis/ibex/ui/motor/views/MotorOPIView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.motor/src/uk/ac/stfc/isis/ibex/ui/motor/views/MotorOPIView.java
@@ -37,7 +37,6 @@ import uk.ac.stfc.isis.ibex.ui.targets.OpiTargetView;
 public class MotorOPIView extends OpiTargetView {
 		
 	private static final String MOTOR_OPI = "Motor/mymotor.opi";
-	private String partName = "Motor view";
     private static final Logger LOG = IsisLog.getLogger(MotorOPIView.class);
 	
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/pom.xml
@@ -8,6 +8,4 @@
   	<version>1.0.0-SNAPSHOT</version>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
-  
 </project>

--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlEditorPanel.java
@@ -60,7 +60,6 @@ public class RunControlEditorPanel extends Composite {
     private final Label spacerLabel;
     private final Label spacerLabel2;
     private Group grpGlobalSettings;
-	private DisplayBlock block;
     private boolean canSend;
 
     private final RunControlViewModel viewModel;
@@ -220,7 +219,6 @@ public class RunControlEditorPanel extends Composite {
      *            The new block to examine.
      */
 	public void setBlock(DisplayBlock block) {
-		this.block = block;
 
         viewModel.setBlock(block);
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/pom.xml
@@ -8,5 +8,4 @@
     <artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
     <relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.ui.statusbar/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.statusbar/plugin.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<?eclipse version="3.4"?>
-<plugin>
-
-</plugin>

--- a/base/uk.ac.stfc.isis.ibex.ui.statusbar/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.statusbar/pom.xml
@@ -8,5 +8,4 @@
   	<artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.ui.statusbar/src/uk/ac/stfc/isis/ibex/ui/statusbar/StatusBar.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.statusbar/src/uk/ac/stfc/isis/ibex/ui/statusbar/StatusBar.java
@@ -21,7 +21,6 @@ package uk.ac.stfc.isis.ibex.ui.statusbar;
 
 import org.eclipse.jface.action.IStatusLineManager;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.internal.PartSite;
@@ -34,75 +33,91 @@ import uk.ac.stfc.isis.ibex.epics.observing.BaseObserver;
 import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.Subscription;
 
-
+/**
+ * For displaying information in a status bar.
+ *
+ */
 public class StatusBar extends AbstractUIPlugin {
-	
-	private static StatusBar instance;
-	
-	private final Display display = Display.getCurrent();
 
-	private Subscription configSubscription;
+    private static StatusBar instance;
 
-	public StatusBar() {
-		instance = this;
-	}
-	
-	private final BaseObserver<DisplayConfiguration> configObserver = new BaseObserver<DisplayConfiguration>() {
-		@Override
-		public void onValue(DisplayConfiguration value) {
-			setTitle(value.name(), value.description());
-		}
+    private final Display display = Display.getCurrent();
 
-		@Override
-		public void onError(Exception e) {
-			setUnknownConfiguration();
-		}
+    private Subscription configSubscription;
 
-		@Override
-		public void onConnectionStatus(boolean isConnected) {
-			if (!isConnected) {
-				setUnknownConfiguration();
-			}
-		}
-		
-		private void setUnknownConfiguration() {
-			setTitle("Unknown", "Unable to display the configuration");
-		}		
-	};	
-	
-	public static StatusBar getInstance() {
-		return instance;
-	}
-	
-	public void subscribeToConfig() {
-		ForwardingObservable<DisplayConfiguration> config = 
-				Configurations.getInstance().display().displayCurrentConfig();
-		
-		configSubscription = config.addObserver(configObserver);
-	}
-	
-	@Override
-	public void stop(BundleContext context) throws Exception {
-		if (configSubscription != null) {
-			configSubscription.removeObserver();
-		}
-		super.stop(context);
-	}
-	
-	private void setTitle(final String title, final String description) {
-		display.asyncExec(new Runnable() {
-			@SuppressWarnings("restriction")
-			@Override
-			public void run() {
-				IWorkbenchPartSite site = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActivePart().getSite();
-				PartSite vSite = (PartSite) site;
-				IStatusLineManager statusLineManager = vSite.getActionBars().getStatusLineManager();
-				
-		    	StatusLineConfigLabel statusItem = (StatusLineConfigLabel) statusLineManager.find("CurrentConfigTitle");
-		    	statusItem.setConfig(title);
-		    	statusItem.setToolTip(description);
-		    	statusLineManager.update(true);
-			}
-		});
-	}
+    /**
+     * Constructor, instantiated by the framework. You probably don't want a new
+     * one. getInstance() will return the existing StatusBar.
+     */
+    public StatusBar() {
+        instance = this;
+    }
+
+    private final BaseObserver<DisplayConfiguration> configObserver = new BaseObserver<DisplayConfiguration>() {
+        @Override
+        public void onValue(DisplayConfiguration value) {
+            setTitle(value.name(), value.description());
+        }
+
+        @Override
+        public void onError(Exception e) {
+            setUnknownConfiguration();
+        }
+
+        @Override
+        public void onConnectionStatus(boolean isConnected) {
+            if (!isConnected) {
+                setUnknownConfiguration();
+            }
+        }
+
+        private void setUnknownConfiguration() {
+            setTitle("Unknown", "Unable to display the configuration");
+        }
+    };
+
+    /**
+     * Get the existing instance of StatusBar.
+     * 
+     * @return StatusBar
+     */
+    public static StatusBar getInstance() {
+        return instance;
+    }
+
+    /**
+     * When the config changes, update the config title on the status bar.
+     */
+    public void subscribeToConfig() {
+        ForwardingObservable<DisplayConfiguration> config = Configurations.getInstance().display()
+                .displayCurrentConfig();
+
+        configSubscription = config.addObserver(configObserver);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+        if (configSubscription != null) {
+            configSubscription.removeObserver();
+        }
+        super.stop(context);
+    }
+
+    private void setTitle(final String title, final String description) {
+        display.asyncExec(new Runnable() {
+            @SuppressWarnings("restriction")
+            @Override
+            public void run() {
+                IWorkbenchPartSite site = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
+                        .getActivePart().getSite();
+                PartSite vSite = (PartSite) site;
+                IStatusLineManager statusLineManager = vSite.getActionBars().getStatusLineManager();
+
+                StatusLineConfigLabel statusItem = (StatusLineConfigLabel) statusLineManager.find("CurrentConfigTitle");
+                statusItem.setConfig(title);
+                statusItem.setToolTip(description);
+                statusLineManager.update(true);
+            }
+        });
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
@@ -27,22 +27,22 @@ import org.eclipse.swt.events.FocusEvent;
 import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.wb.swt.ResourceManager;
 import org.eclipse.wb.swt.SWTResourceManager;
 
 import uk.ac.stfc.isis.ibex.synoptic.model.WritableComponentProperty;
 
+/**
+ * A component which allows the user to change a device property in the synoptic perspective.
+ *
+ */
 @SuppressWarnings("checkstyle:magicnumber")
 public class WritableComponentView extends Composite {
 	
@@ -74,6 +74,13 @@ public class WritableComponentView extends Composite {
 		this(parent, property, true);
 	}
 	
+	/**
+	 * Constructs a new instance of this class given its parent and a writable property.
+	 * 
+	 * @param parent A widget which will be the parent of the new instance (cannot be null)
+	 * @param property The property of the component that is writable
+	 * @param displayName True if the property name should be displayed
+	 */
 	public WritableComponentView(Composite parent, final WritableComponentProperty property, boolean displayName) {
 		super(parent, SWT.NONE);
 		setLayout(new FillLayout(SWT.VERTICAL));

--- a/base/uk.ac.stfc.isis.ibex.ui.weblinks/pom.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.weblinks/pom.xml
@@ -8,5 +8,4 @@
   	<artifactId>uk.ac.stfc.isis.ibex.client.tycho.parent</artifactId>
   	<relativePath>../uk.ac.stfc.isis.ibex.client.tycho.parent</relativePath>
   </parent>
-  <version>1.0.0-SNAPSHOT</version>
 </project>

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/ButtonCellLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/ButtonCellLabelProvider.java
@@ -27,9 +27,15 @@ import org.eclipse.swt.widgets.Button;
 
 /**
  * A cell provider that puts a button within a table cell.
+ * 
+ * @param <T> the type of the data in the row
  */
 public abstract class ButtonCellLabelProvider<T> extends ControlCellLabelProvider<Button, T> {
 	
+    /**
+     * 
+     * @param attributeMaps A map of the attributes that this cell will observe.
+     */
 	protected ButtonCellLabelProvider(IObservableMap attributeMaps) {
 		super(attributeMaps);
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/ControlCellLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/ControlCellLabelProvider.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.databinding.observable.map.IObservableMap;
-import org.eclipse.jface.databinding.viewers.ObservableMapCellLabelProvider;
 import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.TableEditor;
@@ -44,6 +43,11 @@ public abstract class ControlCellLabelProvider<T extends Control, TRow> extends 
 	private final Map<ViewerCell, T> cellControls = new HashMap<>();
 	private final Map<ViewerCell, TableEditor> cellEditors = new HashMap<>();
 	
+	/**
+	 * Constructor for the control cell label provider.
+	 * 
+	 * @param attributeMaps A map of the attributes that this cell will observe.
+	 */
 	protected ControlCellLabelProvider(IObservableMap attributeMaps) {
 		super(attributeMaps);
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundCellLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundCellLabelProvider.java
@@ -20,7 +20,6 @@
 package uk.ac.stfc.isis.ibex.ui.tables;
 
 import org.eclipse.core.databinding.observable.map.IObservableMap;
-import org.eclipse.jface.databinding.viewers.ObservableMapCellLabelProvider;
 import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.graphics.Image;
 


### PR DESCRIPTION
### Description of work

Changed the way the micro symbol is displayed in the DAE Experiment
Setup Data Acquisition page -> Timing Autosave units.
Added some javadocs for things I think I understand.
Removed a couple of tests which did nothing.
Fixed all the Maven warnings.
Deleted all the unused imports, variables and suppression warnings.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3280

### Acceptance criteria

- [x] GUI still builds and runs.
- [x] Reduces warnings in Eclipse.


### Unit tests

N/A

### System tests

N/A

### Documentation

N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

