### PR TITLE
Added half second wait for manager mode PV.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.managermode/src/uk/ac/stfc/isis/ibex/managermode/ManagerModeModel.java
+++ b/base/uk.ac.stfc.isis.ibex.managermode/src/uk/ac/stfc/isis/ibex/managermode/ManagerModeModel.java
@@ -205,7 +205,16 @@ public final class ManagerModeModel extends ModelObject {
      */
     public boolean isInManagerMode() throws ManagerModePvNotConnectedException {
         if (inManagerMode == null) {
-            throw new ManagerModePvNotConnectedException("Manager mode PV not connected. Please try again in a few moments.");
+            try {
+                // PV doesn't have time to connect before this is called the
+                // first time, so wait for half a second.
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                //Do nothing.
+            }
+            if (inManagerMode == null) {
+                throw new ManagerModePvNotConnectedException("Manager mode PV not connected. Please try again in a few moments.");
+            }
         }
         return inManagerMode.booleanValue();
     }


### PR DESCRIPTION
### Description of work

We needed to wait for a short time for the manager mode pv to connect before checking if we were in manager mode. This was returning null, and so throwing the exception.
Added a half second wait before trying to open the dialog when the manager mode status is unknown.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3213

### Acceptance criteria

Manager mode dialog opens first time.

### Unit tests

N/A

### System tests

Added a manual system test to the spreadsheet.

### Documentation

N/A

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

