### PR TITLE
Added warning when trying to delete synoptic in current configuration.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -36,6 +36,7 @@ public class ConfigInfo {
 	private final String name;
 	private final String description;
 	private final String pv;
+	private String synoptic;
 	
 	/**
 	 * Constructor.
@@ -43,11 +44,13 @@ public class ConfigInfo {
 	 * @param name The config name
 	 * @param description The config description
 	 * @param pv The dynamic PV for the config
+	 * @param synoptic The default synoptic view for the config
 	 */
-	public ConfigInfo(String name, String description, String pv) {
+	public ConfigInfo(String name, String description, String pv, String synoptic) {
 		this.name = name;
 		this.description = description;
 		this.pv = pv;
+		this.synoptic = synoptic;
 	}
 	
     /**
@@ -70,6 +73,13 @@ public class ConfigInfo {
 	public String pv() {
 		return pv;
 	}
+		
+	/**
+     * @return The default synoptic view for the config
+     */
+    public String synoptic() {
+        return synoptic;
+    }
 	
 	/**
      * Returns just the names of all config info objects passed in excluding

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -33,83 +33,89 @@ import uk.ac.stfc.isis.ibex.configserver.Configurations;
  */
 public class ConfigInfo {
 
-	private final String name;
-	private final String description;
-	private final String pv;
-	private String synoptic;
-	
-	/**
-	 * Constructor.
-	 * 
-	 * @param name The config name
-	 * @param description The config description
-	 * @param pv The dynamic PV for the config
-	 * @param synoptic The default synoptic view for the config
-	 */
-	public ConfigInfo(String name, String description, String pv, String synoptic) {
-		this.name = name;
-		this.description = description;
-		this.pv = pv;
-		this.synoptic = synoptic;
-	}
-	
+    private final String name;
+    private final String description;
+    private final String pv;
+    private String synoptic;
+
+    /**
+     * Constructor.
+     * 
+     * @param name
+     *            The config name
+     * @param description
+     *            The config description
+     * @param pv
+     *            The dynamic PV for the config
+     * @param synoptic
+     *            The default synoptic view for the config
+     */
+    public ConfigInfo(String name, String description, String pv, String synoptic) {
+        this.name = name;
+        this.description = description;
+        this.pv = pv;
+        this.synoptic = synoptic;
+    }
+
     /**
      * @return The name of the config
      */
-	public String name() {
-		return name;
-	}
-	
+    public String name() {
+        return name;
+    }
+
     /**
      * @return The description of the config
      */
-	public String description() {
-		return description;
-	}
-	
+    public String description() {
+        return description;
+    }
+
     /**
      * @return The dynamic PV of the config
      */
-	public String pv() {
-		return pv;
-	}
-		
-	/**
+    public String pv() {
+        return pv;
+    }
+
+    /**
      * @return The default synoptic view for the config
      */
     public String synoptic() {
         return synoptic;
     }
-	
-	/**
+
+    /**
      * Returns just the names of all config info objects passed in excluding
      * that of the current config.
      * 
-     * @param infos The list of ConfigInfos
+     * @param infos
+     *            The list of ConfigInfos
      * @return The list of config names without that of the current config
      */
-	public static Collection<String> namesWithoutCurrent(Collection<ConfigInfo> infos) {
-		Collection<String> filteredNames = names(infos);
-		filteredNames.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().name());
-		return filteredNames;
-	}
-	
-	/**
-	 * Reduces a list of ConfigInfo objects to a list of their names only.
-	 * 
-	 * @param infos The list of ConfigInfos
-	 * @return The list of config names
-	 */
-	public static Collection<String> names(Collection<ConfigInfo> infos) {
-		if (infos == null) {
-			return Collections.emptyList();
-		}
-		
-		return Lists.newArrayList(Iterables.transform(infos, new Function<ConfigInfo, String>() {
-			@Override
-			public String apply(ConfigInfo info) {
-				return info.name();
-			}	
-		}));		
-	}
+    public static Collection<String> namesWithoutCurrent(Collection<ConfigInfo> infos) {
+        Collection<String> filteredNames = names(infos);
+        filteredNames.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().name());
+        return filteredNames;
+    }
+
+    /**
+     * Reduces a list of ConfigInfo objects to a list of their names only.
+     * 
+     * @param infos
+     *            The list of ConfigInfos
+     * @return The list of config names
+     */
+    public static Collection<String> names(Collection<ConfigInfo> infos) {
+        if (infos == null) {
+            return Collections.emptyList();
+        }
+
+        return Lists.newArrayList(Iterables.transform(infos, new Function<ConfigInfo, String>() {
+            @Override
+            public String apply(ConfigInfo info) {
+                return info.name();
+            }
+        }));
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/DeleteSynopticHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/DeleteSynopticHandler.java
@@ -63,51 +63,53 @@ public class DeleteSynopticHandler extends AbstractHandler {
      * Constructor that adds a listener to disable the handler if the
      * destination is disabled.
      */
-	public DeleteSynopticHandler() {
+    public DeleteSynopticHandler() {
         synopticService.writeTo(SYNOPTIC.delete());
         SYNOPTIC.delete().subscribe(synopticService);
-	}	
-	
-	private boolean deleteConfigSynopticConfirmDialog(Collection<String> inUseSynoptics, Collection<String> configsUsingSynoptics) {
-        return MessageDialog.openQuestion(SHELL, "Confirm Delete Synoptics", "The following synoptics, " + inUseSynoptics 
-                + ", are respectively used in the configurations: " + configsUsingSynoptics + ". Are you sure you want to delete them?");
     }
-		
-	@Override
-	public Object execute(ExecutionEvent event) throws ExecutionException {		
-        MultipleSynopticsSelectionDialog dialog =
-                new MultipleSynopticsSelectionDialog(SHELL, TITLE, SYNOPTIC.availableEditableSynoptics());
-		if (dialog.open() == Window.OK) {
-		    ConfigServer server = Configurations.getInstance().server();
-		    Collection<ConfigInfo> existingConfigs = server.configsInfo().getValue();
-		    Collection<String> configsUsingSynoptic = new ArrayList<String>();
-		    Collection<String> inUseSynoptics = new ArrayList<String>();
-		    for (String selectedSynoptic : dialog.selectedSynoptics()) {
-		        for (ConfigInfo existingConfig : existingConfigs) {
-		            String existingConfigSynoptic = existingConfig.synoptic();
-    		        if (existingConfigSynoptic.equals(selectedSynoptic)) {
-    		            configsUsingSynoptic.add(existingConfig.name());
-    		            inUseSynoptics.add(selectedSynoptic);
-    		        }
-		        }    			
-		    }
-    		if (!configsUsingSynoptic.isEmpty()) {
-    		    if (deleteConfigSynopticConfirmDialog(inUseSynoptics, configsUsingSynoptic)) {
+
+    private boolean deleteConfigSynopticConfirmDialog(Collection<String> inUseSynoptics,
+            Collection<String> configsUsingSynoptics) {
+        return MessageDialog.openQuestion(SHELL, "Confirm Delete Synoptics",
+                "The following synoptics, " + inUseSynoptics + ", are respectively used in the configurations: "
+                        + configsUsingSynoptics + ". Are you sure you want to delete them?");
+    }
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        MultipleSynopticsSelectionDialog dialog = new MultipleSynopticsSelectionDialog(SHELL, TITLE,
+                SYNOPTIC.availableEditableSynoptics());
+        if (dialog.open() == Window.OK) {
+            ConfigServer server = Configurations.getInstance().server();
+            Collection<ConfigInfo> existingConfigs = server.configsInfo().getValue();
+            Collection<String> configsUsingSynoptic = new ArrayList<String>();
+            Collection<String> inUseSynoptics = new ArrayList<String>();
+            for (String selectedSynoptic : dialog.selectedSynoptics()) {
+                for (ConfigInfo existingConfig : existingConfigs) {
+                    String existingConfigSynoptic = existingConfig.synoptic();
+                    if (existingConfigSynoptic.equals(selectedSynoptic)) {
+                        configsUsingSynoptic.add(existingConfig.name());
+                        inUseSynoptics.add(selectedSynoptic);
+                    }
+                }
+            }
+            if (!configsUsingSynoptic.isEmpty()) {
+                if (deleteConfigSynopticConfirmDialog(inUseSynoptics, configsUsingSynoptic)) {
                     try {
                         synopticService.write(dialog.selectedSynoptics());
                     } catch (IOException e) {
                         throw new ExecutionException("Failed to write to PV", e);
-                    } 
+                    }
                 }
-    		} else {
+            } else {
                 try {
-                    synopticService.write(dialog.selectedSynoptics());    
+                    synopticService.write(dialog.selectedSynoptics());
                 } catch (IOException e) {
                     throw new ExecutionException("Failed to write to PV", e);
                 }
             }
-    		
-		}
-		return null;
-	}
+
+        }
+        return null;
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/DeleteSynopticHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/DeleteSynopticHandler.java
@@ -33,11 +33,7 @@ import org.eclipse.ui.PlatformUI;
 
 import uk.ac.stfc.isis.ibex.configserver.ConfigServer;
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
-import uk.ac.stfc.isis.ibex.configserver.Editing;
 import uk.ac.stfc.isis.ibex.configserver.configuration.ConfigInfo;
-import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
-import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
-import uk.ac.stfc.isis.ibex.configserver.internal.ConfigEditing;
 import uk.ac.stfc.isis.ibex.epics.writing.SameTypeWriter;
 import uk.ac.stfc.isis.ibex.synoptic.Synoptic;
 import uk.ac.stfc.isis.ibex.ui.synoptic.editor.dialogs.MultipleSynopticsSelectionDialog;


### PR DESCRIPTION
### Description of work

I added a warning that pops up when a user tries to delete a synoptic that is being used in the current configuration. I also ensured that upon deletion of said synoptic, the current configuration's synoptic is switched to "-- NONE --". As it's only after deletion of a synoptic used in a configuration that a configuration whose synoptic doesn't exist can be loaded or edited, the defaulting of the synoptic to "-- NONE --" is done after deletion of the synoptic.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3211

### Acceptance criteria

-On edit or load of configuration whose synoptic does not exist the NONE is selected. (Moved to: https://github.com/ISISComputingGroup/IBEX/issues/3288)
-On deletion of a synoptic used in a configuration the user should be warned.

### Unit tests

None applicable.

### System tests

None applicable.

### Documentation
None related.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

