### PR TITLE
Ticket 3241: Added keyboard shortcut to interrupt scripts

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/plugin.xml
@@ -67,4 +67,30 @@
          </parameter>
       </key>
    </extension>
+	<extension point="org.eclipse.ui.bindings">
+		<key
+        commandId="uk.ac.stfc.isis.ibex.ui.scripting.KillScript"
+        schemeId="IBEX_key_scheme"
+        sequence="Ctrl+C"/>
+	</extension>
+	
+	<extension point="org.eclipse.ui.handlers">
+	   <handler class="uk.ac.stfc.isis.ibex.ui.scripting.InterruptScript"
+	   commandId="uk.ac.stfc.isis.ibex.ui.scripting.KillScript">
+	      <activeWhen>
+	       <with variable="activeWorkbenchWindow.activePerspective">
+	          <equals value="uk.ac.stfc.isis.ibex.ui.scripting.perspective">
+	         </equals>
+	      </with>
+	   </activeWhen>
+	</handler>
+	</extension>
+	
+	   <extension
+         point="org.eclipse.ui.commands">
+      <command
+            id="uk.ac.stfc.isis.ibex.ui.scripting.KillScript"
+            name="Kill the script">
+      </command>
+      </extension>
 </plugin>

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/InterruptScript.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/InterruptScript.java
@@ -1,0 +1,19 @@
+package uk.ac.stfc.isis.ibex.ui.scripting;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.python.pydev.shared_interactive_console.console.ui.ScriptConsole;
+
+/**
+ * Interrupt the currently active script. 
+ */
+public class InterruptScript extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		ScriptConsole.getActiveScriptConsole().interrupt();
+		return null;
+	}
+
+}


### PR DESCRIPTION
### Description of work

Adds the Ctrl+C shortcut to the scripting window.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3241

### To Test

* Start a script
* Change perspective and press Ctrl+C
* Go back to scripting, confirm script is not interrupted
* Press Ctrl+C and confirm script is interrupted

### Unit tests

Too closely tied to framework.

### System tests

Not currently doing.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

