### PR TITLE
Ticket 3018: Added button to copy GEM jaw params to beamscraper jaws

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Common Scripts/CopyPVs.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Common Scripts/CopyPVs.py
@@ -1,0 +1,34 @@
+from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+
+def copy_pvs(this_display, this_pvs):
+    """
+    Copies PVs
+
+    Args:
+        this_display: The display that has called this script. Used to control modification of global CSS variables
+        this_pvs: PVs passed to the script by CSS. Used to control modification of global CSS variables
+                    List of PVs, first one is the trigger, then in pairs which copy to their partner.
+                    E.g: ["trigger", "PVA-source", "PVA-target", "PVB-source", "PVB-target", "PVC-source", "PVC-target", ]
+
+    Returns:
+        None
+    """
+    # Make sure this has been triggered, then reset the trigger
+    actioned = PVUtil.getDouble(this_pvs[0]) == 1
+    this_pvs[0].setValue(0)
+    if actioned:
+        these_pvs = iter(this_pvs)
+        # Skip the trigger PV
+        these_pvs.next()
+
+        # Iterate through PVs, copying every other PV to the next one
+        for value in these_pvs:
+            these_pvs.next().setValue(PVUtil.getDouble(value))
+    
+
+if __name__ == "__main__":
+    # PVs
+    # pv[0] = loc://GEM:JAWS:FWD:TO:BEAMSCRAPER, triggered
+    # pv[1-16] = $(P)GEMJAWSET:SAMPLE:HGAP:SP,$(P)MOT:JAWS6:HGAP:SP
+    copy_pvs(display, pvs)

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/jaws/gem_jaws/Jaws_gem.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/jaws/gem_jaws/Jaws_gem.opi
@@ -1415,9 +1415,9 @@ $(pv_value)</tooltip>
       <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </background_color>
     <width>169</width>
-    <x>624</x>
+    <x>331</x>
     <name>Jaws Manager</name>
-    <y>78</y>
+    <y>481</y>
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
@@ -1469,6 +1469,104 @@ $(pv_value)</tooltip>
           </macros>
           <replace>1</replace>
           <description></description>
+        </action>
+      </actions>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_Button_NEW</opifont.name>
+      </font>
+    </widget>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0">
+    <border_style>13</border_style>
+    <tooltip></tooltip>
+    <rules />
+    <enabled>true</enabled>
+    <wuid>642a7e96:16387638b40:-5c10</wuid>
+    <transparent>false</transparent>
+    <lock_children>false</lock_children>
+    <scripts />
+    <height>91</height>
+    <border_width>1</border_width>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <visible>true</visible>
+    <border_color>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+    </border_color>
+    <widget_type>Grouping Container</widget_type>
+    <background_color>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <width>169</width>
+    <x>624</x>
+    <name>Forwarding</name>
+    <y>78</y>
+    <foreground_color>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    </foreground_color>
+    <actions hook="false" hook_all="false" />
+    <show_scrollbar>true</show_scrollbar>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
+    </font>
+    <widget typeId="org.csstudio.opibuilder.widgets.NativeButton" version="1.0">
+      <toggle_button>false</toggle_button>
+      <border_style>0</border_style>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <tooltip></tooltip>
+      <push_action_index>0</push_action_index>
+      <rules />
+      <enabled>true</enabled>
+      <wuid>4cf9b5a4:15ad74ff055:-668f</wuid>
+      <pv_value />
+      <text>Send to Beamscraper Jaws</text>
+      <scripts>
+        <path pathString="../../Common Scripts/CopyPVs.py" checkConnect="true" sfe="false" seoe="false">
+          <pv trig="true">loc://GEM:JAWS:FWD:TO:BEAMSCRAPER(0)</pv>
+          <pv trig="false">$(P)GEMJAWSET:SAMPLE:HGAP:SP</pv>
+          <pv trig="false">$(P)MOT:JAWS6:HGAP:SP</pv>
+          <pv trig="false">$(P)GEMJAWSET:SAMPLE:VGAP:SP</pv>
+          <pv trig="false">$(P)MOT:JAWS6:VGAP:SP</pv>
+          <pv trig="false">$(P)GEMJAWSET:HCENT:SP</pv>
+          <pv trig="false">$(P)MOT:JAWS6:HCENT:SP</pv>
+          <pv trig="false">$(P)GEMJAWSET:VCENT:SP</pv>
+          <pv trig="false">$(P)MOT:JAWS6:VCENT:SP</pv>
+        </path>
+      </scripts>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <height>43</height>
+      <border_width>1</border_width>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <image></image>
+      <visible>true</visible>
+      <pv_name></pv_name>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <widget_type>Button</widget_type>
+      <width>116</width>
+      <x>12</x>
+      <name>Forward to Beamscraper Jaws</name>
+      <y>12</y>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <actions hook="false" hook_all="false">
+        <action type="WRITE_PV">
+          <pv_name>loc://GEM:JAWS:FWD:TO:BEAMSCRAPER</pv_name>
+          <value>1</value>
+          <timeout>10</timeout>
+          <description>Trigger Copy Script</description>
         </action>
       </actions>
       <font>


### PR DESCRIPTION
### Description of work

Created script to copy PVs from OPIs (only works for PVs with values of type double).
Added button to run that script for GEM Jaws to copy beam height & width and beam centre coords to the beamscraper jaws.

**Note:** Only works when beamscraper jaws are on MOT:JAWS6.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3018

### Acceptance criteria

Check that the button "Send to Beamscraper Jaws" in the GEM Jaws OPI copies the setpoint values for Size of Beam at Sample (Horizontal and Vertical) and Beam Centre (Horizontal and Vertical) to the beamscraper jaws.

### Unit tests

N/A

### System tests

N/A

### Documentation

N/A

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

