### PR TITLE
Added option to switch config on save as, or not.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
@@ -65,7 +65,7 @@ public class EditConfigHelper extends ConfigHelper {
             if (dialog.doAsComponent()) {
                 server.saveAsComponent().uncheckedWrite(dialog.getComponent());
             } else {
-                if (isCurrent) {
+                if (isCurrent && dialog.switchConfigOnSaveAs()) {
                     server.setCurrentConfig().uncheckedWrite(dialog.getConfig());
                 } else {
                     server.saveAs().uncheckedWrite(dialog.getConfig());

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
@@ -41,9 +41,10 @@ import uk.ac.stfc.isis.ibex.ui.configserver.ConfigurationViewModels;
  */
 public class EditConfigDialog extends ConfigDetailsDialog {
 
-	private Button saveAsBtn;
+    private Button saveAsBtn;
     private boolean editBlockFirst;
-	
+    private boolean switchConfigOnSaveAs;
+
     private ConfigServer server = Configurations.getInstance().server();
 
     /**
@@ -68,7 +69,7 @@ public class EditConfigDialog extends ConfigDetailsDialog {
             boolean isBlank, ConfigurationViewModels configurationViewModels, boolean editBlockFirst) {
         super(parentShell, title, subTitle, config, isBlank, configurationViewModels);
         this.editBlockFirst = editBlockFirst;
-	}
+    }
 
     @Override
     protected Control createDialogArea(Composite parent) {
@@ -80,63 +81,70 @@ public class EditConfigDialog extends ConfigDetailsDialog {
         return control;
     }
 
-	@Override
-	protected void createButtonsForButtonBar(Composite parent) {
-		if (!isBlank && !this.config.getName().isEmpty()) { 
+    @Override
+    protected void createButtonsForButtonBar(Composite parent) {
+        if (!isBlank && !this.config.getName().isEmpty()) {
             createButton(parent, IDialogConstants.OK_ID, "Save", true);
-		}
+        }
 
-		saveAsBtn = createButton(parent, IDialogConstants.CLIENT_ID + 1, "Save as ...", false);
-		saveAsBtn.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
+        saveAsBtn = createButton(parent, IDialogConstants.CLIENT_ID + 1, "Save as ...", false);
+        saveAsBtn.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
                 Collection<String> configNames = server.configNames();
                 Collection<String> componentNames = server.componentNames();
-				boolean hasComponents = !config.getEditableComponents()
-						.getSelected().isEmpty();
+                boolean hasComponents = !config.getEditableComponents().getSelected().isEmpty();
                 String currentConfigName = server.currentConfig().getValue().name();
-				SaveConfigDialog dlg = new SaveConfigDialog(null, config
-						.getName(), config.getDescription(), configNames,
-                        componentNames, !config.getIsComponent(), hasComponents, currentConfigName);
-				if (dlg.open() == Window.OK) {
-					if (dlg.getNewName() != config.getName()) {
-						config.setName(dlg.getNewName());
-					}
+                SaveConfigDialog dlg = new SaveConfigDialog(null, config.getName(), config.getDescription(),
+                        configNames, componentNames, !config.getIsComponent(), hasComponents, currentConfigName);
+                if (dlg.open() == Window.OK) {
+                    switchConfigOnSaveAs = dlg.shouldSwitchConfig();
+                    if (dlg.getNewName() != config.getName()) {
+                        config.setName(dlg.getNewName());
+                    }
 
-					config.setDescription(dlg.getNewDescription());
-					doAsComponent = dlg.willBeComponent();
+                    config.setDescription(dlg.getNewDescription());
+                    doAsComponent = dlg.willBeComponent();
 
-					okPressed();
-				}
-			}
-		});
+                    okPressed();
+                }
+            }
+        });
 
-		createButton(parent, IDialogConstants.CANCEL_ID, "Cancel", false);
+        createButton(parent, IDialogConstants.CANCEL_ID, "Cancel", false);
 
         // Show any error message and set buttons after creating those buttons
         super.showErrorMessage();
-	}
+    }
 
-	@Override
-	public void setErrorMessage(String newErrorMessage) {
-		if (newErrorMessage == null) {
-			setOKEnabled(true);
-			saveAsBtn.setEnabled(true);
-		} else {
-			setOKEnabled(false);
-			saveAsBtn.setEnabled(false);
-		}
-		super.setErrorMessage(newErrorMessage);
-	}
+    @Override
+    public void setErrorMessage(String newErrorMessage) {
+        if (newErrorMessage == null) {
+            setOKEnabled(true);
+            saveAsBtn.setEnabled(true);
+        } else {
+            setOKEnabled(false);
+            saveAsBtn.setEnabled(false);
+        }
+        super.setErrorMessage(newErrorMessage);
+    }
 
     private void selectBlocksTab() {
         editor.selectBlocksTab();
     }
 
-	private void setOKEnabled(boolean value) {
-		Button okButton = getButton(IDialogConstants.OK_ID);
-		if (okButton != null) {
-			okButton.setEnabled(value);
-		}
-	}
+    private void setOKEnabled(boolean value) {
+        Button okButton = getButton(IDialogConstants.OK_ID);
+        if (okButton != null) {
+            okButton.setEnabled(value);
+        }
+    }
+    
+    /**
+     * 
+     * @return true if we should switch to the new config
+     */
+    public boolean switchConfigOnSaveAs() {
+        return switchConfigOnSaveAs;
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/SaveConfigDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/SaveConfigDialog.java
@@ -57,57 +57,57 @@ public class SaveConfigDialog extends TitleAreaDialog {
     /**
      * The text to use when referring to a component.
      */
-	private static final String COMPONENT = "Component";
+    private static final String COMPONENT = "Component";
 
     /**
      * The test to use when referring to a configuration.
      */
-	private static final String CONFIGURATION = "Configuration";
-	
+    private static final String CONFIGURATION = "Configuration";
+
     /**
      * Container for the name label.
      */
-	private Text txtName;	
+    private Text txtName;
 
     /**
      * Container for the description label.
      */
-	private Text txtDesc;		
+    private Text txtDesc;
 
     /**
      * Button to save the new object. as a component.
      */
-	private Button btnAsComponent;
-	
+    private Button btnAsComponent;
+
     /**
      * Name of the new object.
      */
-	private String newName = "";
+    private String newName = "";
 
     /**
      * Name of the new object as it currently exists in the text box.
      */
-	private String currentName = "";
+    private String currentName = "";
 
     /**
      * Description of the new object.
      */
-	private String newDesc = "";
+    private String newDesc = "";
 
     /**
      * Description of the new object as it currently exists in the text box.
      */
-	private String currentDesc = "";
+    private String currentDesc = "";
 
     /**
      * Collection of existing configurations.
      */
-	private List<String> existingConfigs;
+    private List<String> existingConfigs;
 
     /**
      * Collection of existing components.
      */
-	private List<String> existingComponents;
+    private List<String> existingComponents;
 
     /**
      * Is the new object a configuration (or component).
@@ -117,17 +117,19 @@ public class SaveConfigDialog extends TitleAreaDialog {
     /**
      * Does the new object have components.
      */
-	private boolean hasComponents;
+    private boolean hasComponents;
 
     /**
      * Should the new object be saved as a component.
      */
-	private boolean asComponent = false;
-	
+    private boolean asComponent = false;
+
     /**
      * The name of the current configuration.
      */
     private final String currentConfigName;
+
+    private boolean switchToNewConfig;
 
     /**
      * Instantiates a new save configuration dialog.
@@ -151,304 +153,328 @@ public class SaveConfigDialog extends TitleAreaDialog {
      * @param currentConfigName
      *            The name of the current configuration
      */
-	public SaveConfigDialog(
-			Shell parent, 
-			String currentName, 
-			String currentDesc,
-			Collection<String> existingConfigs, 
-			Collection<String> existingComponents, 
-            boolean isConfig,
-            boolean hasComponents, String currentConfigName) {
-		super(parent);
-		setShellStyle(SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
-		this.currentName = currentName;
-		this.currentDesc = currentDesc;
-		this.existingConfigs = new ArrayList<>(existingConfigs);
-		this.existingComponents = new ArrayList<>(existingComponents);
+    public SaveConfigDialog(Shell parent, String currentName, String currentDesc, Collection<String> existingConfigs,
+            Collection<String> existingComponents, boolean isConfig, boolean hasComponents, String currentConfigName) {
+        super(parent);
+        setShellStyle(SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
+        this.currentName = currentName;
+        this.currentDesc = currentDesc;
+        this.existingConfigs = new ArrayList<>(existingConfigs);
+        this.existingComponents = new ArrayList<>(existingComponents);
         this.isConfig = isConfig;
-		this.hasComponents = hasComponents;
+        this.hasComponents = hasComponents;
         this.currentConfigName = currentConfigName;
-	}
-	
+    }
+
     /**
      * @return the new name set in this dialogue
      */
-	public String getNewName() {
-		return newName;
-	}
-	
+    public String getNewName() {
+        return newName;
+    }
+
     /**
      * @return the new description set
      */
-	public String getNewDescription() {
-		return newDesc;
-	}
-	
+    public String getNewDescription() {
+        return newDesc;
+    }
+
     /**
      * @return true, if when saved this will be a component; false otherwise
      */
-	public boolean willBeComponent() {
-		return !isConfig || asComponent;
-	}
-	
-	@Override
-	protected void configureShell(Shell shell) {
-	      super.configureShell(shell);
-	      shell.setText(String.format("Save %s As", getTypeName()));
-	}
-	
-	@Override
-	protected Control createDialogArea(Composite parent) {		
-		setTitle(String.format("Save %s", getTypeName()));
-		Composite container = (Composite) super.createDialogArea(parent);
-		GridLayout glContainer = new GridLayout(1, false);
-		container.setLayout(glContainer);
-		
-		Composite composite = new Composite(container, SWT.NONE);
-		composite.setLayout(new GridLayout(2, false));
-		GridData gdComposite = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
-		gdComposite.widthHint = 95;
-		composite.setLayoutData(gdComposite);
-		
-		Label lblConfigurationName = new Label(composite, SWT.NONE);
-		lblConfigurationName.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-		lblConfigurationName.setText("Name:");
-		
-		txtName = new Text(composite, SWT.BORDER);
-		GridData gdTxtName = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
-		gdTxtName.widthHint = 383;
-		txtName.setLayoutData(gdTxtName);
-		txtName.setBounds(0, 0, 76, 21);
-		
-		Label lblConfigurationDesc = new Label(composite, SWT.NONE);
-		lblConfigurationDesc.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-		lblConfigurationDesc.setText("Description:");
-		
-		txtDesc = new Text(composite, SWT.BORDER);
-		GridData gdTxtDesc = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
-		gdTxtDesc.widthHint = 383;
-		txtDesc.setLayoutData(gdTxtDesc);
-		txtDesc.setBounds(0, 0, 76, 21);
-		new Label(composite, SWT.NONE);		
-		new Label(composite, SWT.NONE);
-		
-		if (isConfig) { 
-			btnAsComponent = new Button(composite, SWT.CHECK);
-			btnAsComponent.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
-			btnAsComponent.setText("Save the configuration as a component");
-			btnAsComponent.setVisible(true);
-		
-			new Label(composite, SWT.NONE);
-			btnAsComponent.addSelectionListener(new SelectionAdapter() {
-				@Override
-				public void widgetSelected(SelectionEvent e) {
-					updateConfigType();
-					update();
-				}
-			});
-		}
-	
-		txtName.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent arg0) {
-				update();
-			}
-		});
-		
-		txtDesc.addModifyListener(new ModifyListener() {
-			@Override
-			public void modifyText(ModifyEvent arg0) {
-				update();
-			}
-		});
-		
-        txtName.setText(currentName);
-		txtDesc.setText(currentDesc);
-		
-		update();
-		
-		return container;
-	}
+    public boolean willBeComponent() {
+        return !isConfig || asComponent;
+    }
 
-	/**
-	 * Create contents of the button bar.
-	 * @param parent
-	 */
-	@Override
-	protected void createButtonsForButtonBar(Composite parent) {
-		Button button = createButton(parent, IDialogConstants.OK_ID, 
-				IDialogConstants.OK_LABEL, true);
-		button.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-			}
-		});
-		createButton(parent, IDialogConstants.CANCEL_ID,
-				IDialogConstants.CANCEL_LABEL, false);
+    /**
+     * @return true: switch to new config, false: keep using current config
+     */
+    public boolean shouldSwitchConfig() {
+        return switchToNewConfig;
+    }
+
+    @Override
+    protected void configureShell(Shell shell) {
+        super.configureShell(shell);
+        shell.setText(String.format("Save %s As", getTypeName()));
+    }
+
+    @Override
+    protected Control createDialogArea(Composite parent) {
+        setTitle(String.format("Save %s", getTypeName()));
+        Composite container = (Composite) super.createDialogArea(parent);
+        GridLayout glContainer = new GridLayout(1, false);
+        container.setLayout(glContainer);
+
+        Composite composite = new Composite(container, SWT.NONE);
+        composite.setLayout(new GridLayout(2, false));
+        GridData gdComposite = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
+        gdComposite.widthHint = 95;
+        composite.setLayoutData(gdComposite);
+
+        Label lblConfigurationName = new Label(composite, SWT.NONE);
+        lblConfigurationName.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblConfigurationName.setText("Name:");
+
+        txtName = new Text(composite, SWT.BORDER);
+        GridData gdTxtName = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
+        gdTxtName.widthHint = 383;
+        txtName.setLayoutData(gdTxtName);
+        txtName.setBounds(0, 0, 76, 21);
+
+        Label lblConfigurationDesc = new Label(composite, SWT.NONE);
+        lblConfigurationDesc.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblConfigurationDesc.setText("Description:");
+
+        txtDesc = new Text(composite, SWT.BORDER);
+        GridData gdTxtDesc = new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1);
+        gdTxtDesc.widthHint = 383;
+        txtDesc.setLayoutData(gdTxtDesc);
+        txtDesc.setBounds(0, 0, 76, 21);
+        new Label(composite, SWT.NONE);
+        new Label(composite, SWT.NONE);
+
+        if (isConfig) {
+            btnAsComponent = new Button(composite, SWT.CHECK);
+            btnAsComponent.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1));
+            btnAsComponent.setText("Save the configuration as a component");
+            btnAsComponent.setVisible(true);
+
+            new Label(composite, SWT.NONE);
+            btnAsComponent.addSelectionListener(new SelectionAdapter() {
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    updateConfigType();
+                    update();
+                }
+            });
+        }
+
+        txtName.addModifyListener(new ModifyListener() {
+            @Override
+            public void modifyText(ModifyEvent arg0) {
+                update();
+            }
+        });
+
+        txtDesc.addModifyListener(new ModifyListener() {
+            @Override
+            public void modifyText(ModifyEvent arg0) {
+                update();
+            }
+        });
+
+        txtName.setText(currentName);
+        txtDesc.setText(currentDesc);
+
+        update();
+
+        return container;
+    }
+
+    /**
+     * Create contents of the button bar.
+     * 
+     * @param parent
+     */
+    @Override
+    protected void createButtonsForButtonBar(Composite parent) {
+        Button button = createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
+        button.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+            }
+        });
+        createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
 
         // after creating buttons update their state
         update();
-	}
-	
-	@Override
-	  protected void okPressed() {
-		if (validate(name())) {
-			newName = name();
-			newDesc = description();
+    }
+
+    @Override
+    protected void okPressed() {
+        if (validate(name())) {
+            newName = name();
+            newDesc = description();
             // Warn about overwriting if already exists
             if (isDuplicate(newName)) {
                 boolean userCancelled = askUserWhetherToOverwrite();
                 if (userCancelled) {
                     return;
-				}
+                }
             }
-			super.okPressed();
-			close();
-		}
-		// else ignore the click
-	}
+            switchToNewConfig = askUserWhetherToSwitchToNewConfig();
+            super.okPressed();
+            close();
+        }
+        // else ignore the click
+    }
 
     /**
      * @return Does the user want to overwrite the current configuration
      */
-	private boolean askUserWhetherToOverwrite() {
-		MessageBox box = new MessageBox(getShell(), SWT.YES | SWT.NO);
-		box.setMessage(String.format("The specified %s name already exists - do you want to replace it? ", getTypeName().toLowerCase()));
-		
-		//Message boxes return the ID of the button to close, so need to check that value..
-		return box.open() != SWT.YES;
-	}
-	
+    private boolean askUserWhetherToOverwrite() {
+        MessageBox box = new MessageBox(getShell(), SWT.YES | SWT.NO);
+        box.setMessage(String.format("The specified %s name already exists - do you want to replace it? ",
+                getTypeName().toLowerCase()));
+
+        // Message boxes return the ID of the button to close, so need to check
+        // that value..
+        return box.open() != SWT.YES;
+    }
+
+    /**
+     * @return Does the user want to overwrite the current configuration
+     */
+    private boolean askUserWhetherToSwitchToNewConfig() {
+        MessageBox box = new MessageBox(getShell(), SWT.YES | SWT.NO);
+        box.setMessage("Do you want to switch to this new config now? ");
+
+        // Message boxes return the ID of the button to close, so need to check
+        // that value..
+        return box.open() == SWT.YES;
+    }
+
     /**
      * @return The name of the object
      */
-	private String name() {
+    private String name() {
         return txtName.getText();
-	}
-	
+    }
+
     /**
      * @return The description of the object
      */
-	private String description() {
-		return txtDesc.getText().trim();
-	}
-	
+    private String description() {
+        return txtDesc.getText().trim();
+    }
+
     /**
      * @return The type of the object as a string, either component or
      *         configuration
      */
-	private String getTypeName() {
-		return willBeComponent() ? COMPONENT : CONFIGURATION;
-	}
-		
+    private String getTypeName() {
+        return willBeComponent() ? COMPONENT : CONFIGURATION;
+    }
+
     /**
      * Update the view by checking whether the name and description are valid.
      */
-	private void update() {
-		checkInput(name(), description());
-	}
-	
+    private void update() {
+        checkInput(name(), description());
+    }
+
     /**
      * Update whether this is a configuration or component and change the title
      * of the dialog accordingly.
      */
-	private void updateConfigType() {
-		asComponent = btnAsComponent.getSelection();
-		setTitle(String.format("Save %s", getTypeName()));
-	}
-	
+    private void updateConfigType() {
+        asComponent = btnAsComponent.getSelection();
+        setTitle(String.format("Save %s", getTypeName()));
+    }
+
     /**
-     * @param canSave The object has valid parameters and can be saved
+     * @param canSave
+     *            The object has valid parameters and can be saved
      */
-	private void allowSaving(boolean canSave) {
-		Button ok = getButton(IDialogConstants.OK_ID);
-		if (ok != null) {
-			ok.setEnabled(canSave);
-		}
-	}
-	
+    private void allowSaving(boolean canSave) {
+        Button ok = getButton(IDialogConstants.OK_ID);
+        if (ok != null) {
+            ok.setEnabled(canSave);
+        }
+    }
+
     /**
      * @return The object is a component containing components
      */
-	private boolean savingComponentWithComponents() {
-		return willBeComponent() && hasComponents;
-	}
-	
-    /**
-     * @param name The config/component name
-     * @return Whether an object already exists with this name
-     */
-	private boolean isDuplicate(final String name) {
-		List<String> prexisting = willBeComponent() ? existingComponents : existingConfigs;	
-		return Iterables.any(prexisting, new Predicate<String>() {
-			@Override
-			public boolean apply(String existing) {
-				return compareIgnoringCase(existing, name);
-			}
-		});
-	}
+    private boolean savingComponentWithComponents() {
+        return willBeComponent() && hasComponents;
+    }
 
     /**
-     * @param text The text to compare
-     * @param other The text to compare against
+     * @param name
+     *            The config/component name
+     * @return Whether an object already exists with this name
+     */
+    private boolean isDuplicate(final String name) {
+        List<String> prexisting = willBeComponent() ? existingComponents : existingConfigs;
+        return Iterables.any(prexisting, new Predicate<String>() {
+            @Override
+            public boolean apply(String existing) {
+                return compareIgnoringCase(existing, name);
+            }
+        });
+    }
+
+    /**
+     * @param text
+     *            The text to compare
+     * @param other
+     *            The text to compare against
      * @return Whether the two pieces of text match case-insensitively
      */
-	private boolean compareIgnoringCase(String text, String other) {
-		return text.toUpperCase().equals(other.toUpperCase());
-	}
-	
+    private boolean compareIgnoringCase(String text, String other) {
+        return text.toUpperCase().equals(other.toUpperCase());
+    }
+
     /**
-     * @param name The proposed name of the object
+     * @param name
+     *            The proposed name of the object
      * @return Whether the proposed name is valid
      */
-	private Boolean validate(String name) {		
-		//Must start with a letter and contain no spaces	
-		return name.matches("^[a-zA-Z][a-zA-Z0-9_]*$");
-	}
+    private Boolean validate(String name) {
+        // Must start with a letter and contain no spaces
+        return name.matches("^[a-zA-Z][a-zA-Z0-9_]*$");
+    }
 
     /**
      * Check whether the proposed name and description of the object are valid.
      * Add an error message if they aren't, allow saving if they are.
      * 
-     * @param name The proposed name of the object
-     * @param desc The proposed description of the object
+     * @param name
+     *            The proposed name of the object
+     * @param desc
+     *            The proposed description of the object
      */
-	private void checkInput(String name, String desc) {
-		setErrorMessage(null);
-		setMessage(null);
-		
-		String error = getErrorMessage(name, desc);
-		if (error.length() > 0) {
-			setErrorMessage(error);
-			allowSaving(false);
-			return;
-		}
-		
-		allowSaving(true);
-		String warning = getWarningMessage(name);
-		if (warning.length() > 0) {
-			setMessage(warning);
-		}
-	}
-	
+    private void checkInput(String name, String desc) {
+        setErrorMessage(null);
+        setMessage(null);
+
+        String error = getErrorMessage(name, desc);
+        if (error.length() > 0) {
+            setErrorMessage(error);
+            allowSaving(false);
+            return;
+        }
+
+        allowSaving(true);
+        String warning = getWarningMessage(name);
+        if (warning.length() > 0) {
+            setMessage(warning);
+        }
+    }
+
     /**
      * Get any error messages associated with proposed name/description of the
      * object.
      * 
-     * @param name Proposed name of the object
-     * @param description Proposed description of the object
+     * @param name
+     *            Proposed name of the object
+     * @param description
+     *            Proposed description of the object
      * @return The error message associated with the proposed name and
      *         description
      */
-	private String getErrorMessage(String name, String description) {
-		if (savingComponentWithComponents()) {
-			return "To be saved as a component, the configuration must have no components of its own.";
-		}
-		
-		if (name.length() == 0) {
-			return "Name cannot be blank";
-		}
-		
+    private String getErrorMessage(String name, String description) {
+        if (savingComponentWithComponents()) {
+            return "To be saved as a component, the configuration must have no components of its own.";
+        }
+
+        if (name.length() == 0) {
+            return "Name cannot be blank";
+        }
+
         if (!name.matches("^[a-zA-Z].*")) {
             return "Name must start with a letter";
         }
@@ -456,41 +482,42 @@ public class SaveConfigDialog extends TitleAreaDialog {
         if (!name.matches("[a-zA-Z0-9_]*")) {
             return "Name must only contain alphanumeric characters and underscores";
         }
-		
+
         if (nameMatchesCurrentConfig(name)) {
             return "Name matches the current configuration";
         }
 
-        BlockServerNameValidator configDescritpionRules =
-                Configurations.getInstance().variables().configDescriptionRules.getValue();
-        SummaryDescriptionValidator descriptionValidator =
-                new SummaryDescriptionValidator(null, configDescritpionRules);
-		IStatus status = descriptionValidator.validate(description);
-		if (!status.isOK()) {
-		    return status.getMessage();
-		}
-		
-		return "";
-	}
+        BlockServerNameValidator configDescritpionRules = Configurations.getInstance()
+                .variables().configDescriptionRules.getValue();
+        SummaryDescriptionValidator descriptionValidator = new SummaryDescriptionValidator(null,
+                configDescritpionRules);
+        IStatus status = descriptionValidator.validate(description);
+        if (!status.isOK()) {
+            return status.getMessage();
+        }
+
+        return "";
+    }
 
     /**
      * Get any warning messages associated with proposed name of the object.
      * 
-     * @param name Proposed name of the object
+     * @param name
+     *            Proposed name of the object
      * @return The error message associated with the proposed name
      */
-	private String getWarningMessage(String name) {	
-		if (isDuplicate(name)) {
-			return String.format("A %s with this name already exists", getTypeName().toLowerCase());
-		}
-		
-		return "";
-	}
+    private String getWarningMessage(String name) {
+        if (isDuplicate(name)) {
+            return String.format("A %s with this name already exists", getTypeName().toLowerCase());
+        }
+
+        return "";
+    }
 
     /**
      * @return The requested name matches that of the current configuration
      */
-	private boolean nameMatchesCurrentConfig(String name) {
+    private boolean nameMatchesCurrentConfig(String name) {
         return compareIgnoringCase(name, currentConfigName);
-	}
+    }
 }


### PR DESCRIPTION
### Description of work

Gave the user the option of staying on their current config, or switching to the new one when using "Save as..." while editing current config.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3203

### Acceptance criteria

- [x] When editing the current config and using "Save as...", the user is presented with the option to switch to their newly saved config or keep using the old one.
- [x] Config either switches, or doesn't.
- [x] Config is saved in either case.

### Unit tests

N/A

### System tests

N/A

### Documentation

N/A

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

