### PR TITLE
Auto selects 1st device screens macro.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/TargetPropertiesViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/TargetPropertiesViewModelTest.java
@@ -81,7 +81,7 @@ public class TargetPropertiesViewModelTest {
     @Test
     public void WHEN_no_available_properties_THEN_table_and_text_box_are_disabled() {
         // Act
-        viewModel.setPropeties(new ArrayList<PropertyDescription>());
+        viewModel.setProperties(new ArrayList<PropertyDescription>());
 
         // Assert
         assertEquals(false, viewModel.getTableEnabled());
@@ -102,9 +102,9 @@ public class TargetPropertiesViewModelTest {
     }
 
     @Test
-    public void WHEN_set_propeties_to_empty_THEN_value_changes_on_target() {
+    public void WHEN_set_properties_to_empty_THEN_value_changes_on_target() {
         // Act
-        viewModel.setPropeties(new ArrayList<PropertyDescription>());
+        viewModel.setProperties(new ArrayList<PropertyDescription>());
         
 
         // Assert
@@ -115,7 +115,7 @@ public class TargetPropertiesViewModelTest {
     @Test
     public void WHEN_set_properties_THEN_value_changes_on_target() {
         // Act
-        viewModel.setPropeties(Arrays.asList(property1));
+        viewModel.setProperties(Arrays.asList(property1));
 
         // Assert
         assertEquals(propertyValue1, viewModel.getValueText());

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/TargetPropertiesViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/TargetPropertiesViewModelTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +54,7 @@ public class TargetPropertiesViewModelTest {
 
         EditDeviceScreensDescriptionViewModel model = mock(EditDeviceScreensDescriptionViewModel.class);
         when(model.getTargetScreen()).thenReturn(desc);
-        
+
         viewModel = new TargetPropertiesViewModel(model);
     }
 
@@ -92,10 +93,34 @@ public class TargetPropertiesViewModelTest {
         // Act
         viewModel.setTableSelection(property1);
         viewModel.setValueText("Hello");
+        viewModel.setDescriptionText("Hello again.");
 
         // Assert
         assertEquals("Hello", viewModel.getValueText());
         assertEquals("Hello", property1.getValue());
+        assertEquals("Hello again.", viewModel.getDescriptionText());
     }
+
+    @Test
+    public void WHEN_set_propeties_to_empty_THEN_value_changes_on_target() {
+        // Act
+        viewModel.setPropeties(new ArrayList<PropertyDescription>());
+        
+
+        // Assert
+        assertEquals("", viewModel.getValueText());
+        assertEquals("", viewModel.getDescriptionText());
+    }
+
+    @Test
+    public void WHEN_set_properties_THEN_value_changes_on_target() {
+        // Act
+        viewModel.setPropeties(Arrays.asList(property1));
+
+        // Assert
+        assertEquals(propertyValue1, viewModel.getValueText());
+        assertEquals(propertyDescription1, viewModel.getDescriptionText());
+    }
+
 }
 //CHECKSTYLE:ON

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/dialogs/TargetPropertiesWidget.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/dialogs/TargetPropertiesWidget.java
@@ -21,7 +21,9 @@ package uk.ac.stfc.isis.ibex.ui.devicescreens.dialogs;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.IOException;
 
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.jface.databinding.swt.SWTObservables;
@@ -142,6 +144,9 @@ public class TargetPropertiesWidget extends Composite {
             @Override
             public void propertyChange(PropertyChangeEvent evt) {
                 table.setRows(viewModel.getProperties());
+                if (!viewModel.getProperties().isEmpty()) {
+                    table.setSelected(viewModel.getProperties().get(0));
+                }
             }
         });
 

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/dialogs/TargetPropertiesWidget.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/dialogs/TargetPropertiesWidget.java
@@ -21,9 +21,7 @@ package uk.ac.stfc.isis.ibex.ui.devicescreens.dialogs;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.IOException;
 
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.jface.databinding.swt.SWTObservables;

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/models/TargetPropertiesViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/models/TargetPropertiesViewModel.java
@@ -24,6 +24,7 @@ package uk.ac.stfc.isis.ibex.ui.devicescreens.models;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import uk.ac.stfc.isis.ibex.devicescreens.desc.PropertyDescription;
@@ -61,9 +62,9 @@ public class TargetPropertiesViewModel extends ModelObject {
             public void propertyChange(PropertyChangeEvent evt) {
                 DeviceDescriptionWrapper target = (DeviceDescriptionWrapper) evt.getNewValue();
                 if (target == null) {
-                    setPropeties(new ArrayList<PropertyDescription>());
+                    setProperties(new ArrayList<PropertyDescription>());
                 } else {
-                    setPropeties(target.getProperties());
+                    setProperties(target.getProperties());
                 }
             }
         });
@@ -74,9 +75,9 @@ public class TargetPropertiesViewModel extends ModelObject {
             public void propertyChange(PropertyChangeEvent evt) {
                 String key = (String) evt.getNewValue();
                 if (key == null || key == "") {
-                    setPropeties(new ArrayList<PropertyDescription>());
+                    setProperties(new ArrayList<PropertyDescription>());
                 } else {
-                    setPropeties(viewModel.getTargetScreen().getProperties());
+                    setProperties(viewModel.getTargetScreen().getProperties());
                 }
             }
         });
@@ -88,8 +89,8 @@ public class TargetPropertiesViewModel extends ModelObject {
      * @param newProperties
      *            The properties that can be set on the OPI.
      */
-    public void setPropeties(List<PropertyDescription> newProperties) {
-        boolean hasProperties = newProperties.size() > 0;
+    public void setProperties(List<PropertyDescription> newProperties) {
+        boolean hasProperties = !newProperties.isEmpty();
         if (hasProperties) {
             setTableSelection(newProperties.get(0));
         } else {

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/models/TargetPropertiesViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/models/TargetPropertiesViewModel.java
@@ -89,8 +89,12 @@ public class TargetPropertiesViewModel extends ModelObject {
      *            The properties that can be set on the OPI.
      */
     public void setPropeties(List<PropertyDescription> newProperties) {
-        setTableSelection(null);
         boolean hasProperties = newProperties.size() > 0;
+        if (hasProperties) {
+            setTableSelection(newProperties.get(0));
+        } else {
+            setTableSelection(null);
+        }
         setTableEnabled(hasProperties);
         setValueTextEnabled(hasProperties);
         firePropertyChange("properties", properties, properties = newProperties);


### PR DESCRIPTION
### Description of work

Auto selects first device screens macro.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2835

### Acceptance criteria

- When a device screen is selected the first macro becomes active ready for entering data without needing to be selected specifically.

### Unit tests
 
None required.

### System tests

None required.

### Documentation
None related

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

