### PR TITLE
Added option to copy blocks when editing a configuration.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/DefaultName.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/DefaultName.java
@@ -87,6 +87,14 @@ public class DefaultName {
                 + NUMBER_REGEX + closingBracketRegex + CLOSING_GROUP_REGEX);
 	}
 	
+    /**
+     * Method that returns a unique name given a set of already existing names.
+     *
+     * @param existingNames
+     *                      Names that already exist.
+     * @return
+     *          A unique name.
+     */
 	public String getUnique(Collection<String> existingNames) {
 		return uniqueName(existingNames);
 	}

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/DefaultName.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/DefaultName.java
@@ -19,6 +19,7 @@
 
 package uk.ac.stfc.isis.ibex.configserver.editing;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -84,7 +85,7 @@ public class DefaultName {
         }
 
         namePattern = Pattern.compile(getNameRoot(name) + OPENING_GROUP_REGEX + separator + openingBracketRegex
-                + NUMBER_REGEX + closingBracketRegex + CLOSING_GROUP_REGEX);
+                + NUMBER_REGEX + closingBracketRegex + CLOSING_GROUP_REGEX + "$");
 	}
 	
     /**
@@ -98,7 +99,7 @@ public class DefaultName {
 	public String getUnique(Collection<String> existingNames) {
 		return uniqueName(existingNames);
 	}
-
+	
 	private String uniqueName(Collection<String> names) {
 		Set<Integer> taken = new HashSet<>();
 		for (String name : names) {
@@ -135,13 +136,44 @@ public class DefaultName {
      */
     private String getNameRoot(String name) {
         Pattern pattern = Pattern
-                .compile("(" + separator + openingBracketRegex + NUMBER_REGEX + closingBracketRegex + ")");
+                .compile("(" + separator + openingBracketRegex + NUMBER_REGEX + closingBracketRegex + ")" + "$");
         Matcher match = pattern.matcher(name);
         String nameRoot = name;
         if (match.find()) {
-            nameRoot = name.replace(match.group(1), "");
+            nameRoot = replaceLast(name, match.group(1), "");
         }
-
         return nameRoot;
+    }
+    
+    /**
+     * Replaces last occurrence of the target by the replacement in the given word, assuming the word ends with the target.
+     * @param word
+     *              The word to act upon.
+     * @param target
+     *              The sequence to change.
+     * @param target
+     *              The replacement sequence.
+     * @return
+     *         The new word with the replaced last sequence.
+     */
+    private String replaceLast(String word, String target, String replacement) {
+        ArrayList<String> substrings = new ArrayList<String>();
+        boolean finished = false;
+        while (!finished) {
+            String substring = word.substring(0, word.lastIndexOf(target));
+            word = word.substring(word.lastIndexOf(target));
+            if (word.equals(target)) {
+                substring.replace(target, replacement);
+                substrings.add(substring);
+                finished = true;
+            } else {
+                substrings.add(substring);
+            }
+        }
+        word = "";
+        for (String string : substrings) {
+            word += string;
+        }
+        return word;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/tests/BlocksEditorViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/tests/BlocksEditorViewModelTest.java
@@ -1,0 +1,183 @@
+
+/*
+ * This file is part of the ISIS IBEX application. Copyright (C) 2012-2016
+ * Science & Technology Facilities Council. All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful. This program
+ * and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution. EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM AND
+ * ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND. See the Eclipse Public License v1.0 for more
+ * details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0 along with
+ * this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+package uk.ac.stfc.isis.ibex.ui.configserver.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.configserver.editing.EditableBlock;
+import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
+import uk.ac.stfc.isis.ibex.ui.configserver.editing.blocks.BlocksEditorViewModel;
+
+public class BlocksEditorViewModelTest {
+
+    private EditableConfiguration mockConfig;
+    private BlocksEditorViewModel blockViewModel;
+
+    @Before
+    public void setUp() {
+        mockConfig = mock(EditableConfiguration.class);
+        blockViewModel = new BlocksEditorViewModel(mockConfig);
+    }
+
+    @Test
+    public void GIVEN_a_name_that_is_not_in_config_WHEN_getUniqueName_called_THEN_passed_name_not_changed() {
+        String name = "NAME"; 
+        String expected = name;   
+        String actual = blockViewModel.getUniqueName(expected);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_is_in_config_WHEN_getUniqueName_called_THEN_passed_name_changed_to_the_name_with_a_1_in_parenthesis() {
+        EditableBlock blockThatExists = mock(EditableBlock.class);
+        when(blockThatExists.getName()).thenReturn("NAME");
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
+        String name = "NAME"; 
+        String expected = name + " (1)";
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_is_in_config_and_another_similar_name_WHEN_getUniqueName_called_THEN_passed_name_changed_to_the_name_with_a_2_in_parenthesis() {
+        EditableBlock blockThatExists1 = mock(EditableBlock.class);
+        EditableBlock blockThatExists2 = mock(EditableBlock.class);
+        when(blockThatExists1.getName()).thenReturn("NAME");
+        when(blockThatExists2.getName()).thenReturn("NAME (1)");
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists1, blockThatExists2));
+        String name = "NAME"; 
+        String expected = name + " (2)";
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_is_in_config_and_10_similar_names_WHEN_getUniqueName_called_THEN_passed_name_changed_to_the_name_with_a_10_in_parenthesis() {
+        EditableBlock blockThatExists1 = mock(EditableBlock.class);
+        EditableBlock blockThatExists2 = mock(EditableBlock.class);
+        EditableBlock blockThatExists3 = mock(EditableBlock.class);
+        EditableBlock blockThatExists4 = mock(EditableBlock.class);
+        EditableBlock blockThatExists5 = mock(EditableBlock.class);
+        EditableBlock blockThatExists6 = mock(EditableBlock.class);
+        EditableBlock blockThatExists7 = mock(EditableBlock.class);
+        EditableBlock blockThatExists8 = mock(EditableBlock.class);
+        EditableBlock blockThatExists9 = mock(EditableBlock.class);
+        EditableBlock blockThatExists10 = mock(EditableBlock.class);
+        EditableBlock blockThatExists11 = mock(EditableBlock.class);
+        when(blockThatExists1.getName()).thenReturn("NAME");
+        when(blockThatExists2.getName()).thenReturn("NAME (1)");
+        when(blockThatExists3.getName()).thenReturn("NAME (2)");
+        when(blockThatExists4.getName()).thenReturn("NAME (3)");
+        when(blockThatExists5.getName()).thenReturn("NAME (4)");
+        when(blockThatExists6.getName()).thenReturn("NAME (5)");
+        when(blockThatExists7.getName()).thenReturn("NAME (6)");
+        when(blockThatExists8.getName()).thenReturn("NAME (7)");
+        when(blockThatExists9.getName()).thenReturn("NAME (8)");
+        when(blockThatExists10.getName()).thenReturn("NAME (9)");
+        when(blockThatExists11.getName()).thenReturn("NAME (10)");
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists1, blockThatExists2,blockThatExists3, blockThatExists4,blockThatExists5, blockThatExists6,blockThatExists7, blockThatExists8, blockThatExists9, blockThatExists10, blockThatExists11));
+        String name = "NAME"; 
+        String expected = name + " (11)";
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_is_only_numbers_and_not_in_config_WHEN_getUniqueName_called_THEN_name_is_not_changed() {
+        String name = "1234"; 
+        String expected = name;
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_is_only_numbers_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_a_1_in_parenthesis() {
+        EditableBlock blockThatExists = mock(EditableBlock.class);
+        when(blockThatExists.getName()).thenReturn("1234");
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
+        String name = "1234"; 
+        String expected = name + " (1)";
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_is_only_underscores_and_not_in_config_WHEN_getUniqueName_called_THEN_name_is_not_changed() {
+        String name = "_"; 
+        String expected = name;
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_is_only_underscores_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_a_1_in_parenthesis() {
+        EditableBlock blockThatExists = mock(EditableBlock.class);
+        when(blockThatExists.getName()).thenReturn("_");
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
+        String name = "_"; 
+        String expected = name + " (1)";
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_is_only_underscores_and_numbers_and_not_in_config_WHEN_getUniqueName_called_THEN_name_is_not_changed() {
+        String name = "21_21_21_"; 
+        String expected = name;
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_is_only_underscores_and_numbers_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_a_1_in_parenthesis() {
+        EditableBlock blockThatExists = mock(EditableBlock.class);
+        when(blockThatExists.getName()).thenReturn("_21_21_21");
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
+        String name = "_21_21_21"; 
+        String expected = name + " (1)";
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_has_underscores_and_numbers_and_not_in_config_WHEN_getUniqueName_called_THEN_name_is_not_changed() {
+        String name = "NAME_21_21_21_"; 
+        String expected = name;
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+    
+    @Test
+    public void GIVEN_a_name_that_has_underscores_and_numbers_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_a_1_in_parenthesis() {
+        EditableBlock blockThatExists = mock(EditableBlock.class);
+        when(blockThatExists.getName()).thenReturn("NAME_21_21_21");
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
+        String name = "NAME_21_21_21"; 
+        String expected = name + " (1)";
+        String actual = blockViewModel.getUniqueName(name);
+        assertEquals(expected , actual);
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/tests/BlocksEditorViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/tests/BlocksEditorViewModelTest.java
@@ -51,56 +51,44 @@ public class BlocksEditorViewModelTest {
     }
     
     @Test
-    public void GIVEN_a_name_that_is_in_config_WHEN_getUniqueName_called_THEN_passed_name_changed_to_the_name_with_a_1_in_parenthesis() {
+    public void GIVEN_a_name_that_is_in_config_WHEN_getUniqueName_called_THEN_passed_name_changed_to_the_name_with_underscore_1() {
         EditableBlock blockThatExists = mock(EditableBlock.class);
-        when(blockThatExists.getName()).thenReturn("NAME");
+        String name = "NAME"; 
+        when(blockThatExists.getName()).thenReturn(name);
         when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
-        String name = "NAME"; 
-        String expected = name + " (1)";
+        String expected = name + "_1";
         String actual = blockViewModel.getUniqueName(name);
         assertEquals(expected , actual);
     }
     
     @Test
-    public void GIVEN_a_name_that_is_in_config_and_another_similar_name_WHEN_getUniqueName_called_THEN_passed_name_changed_to_the_name_with_a_2_in_parenthesis() {
+    public void GIVEN_a_name_that_is_in_config_and_another_similar_name_WHEN_getUniqueName_called_THEN_passed_name_changed_to_the_name_with_underscore_2() {
         EditableBlock blockThatExists1 = mock(EditableBlock.class);
         EditableBlock blockThatExists2 = mock(EditableBlock.class);
-        when(blockThatExists1.getName()).thenReturn("NAME");
-        when(blockThatExists2.getName()).thenReturn("NAME (1)");
+        String name = "NAME"; 
+        when(blockThatExists1.getName()).thenReturn(name);
+        when(blockThatExists2.getName()).thenReturn(name + "_1");
         when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists1, blockThatExists2));
-        String name = "NAME"; 
-        String expected = name + " (2)";
+        String expected = name + "_2";
         String actual = blockViewModel.getUniqueName(name);
         assertEquals(expected , actual);
     }
     
     @Test
-    public void GIVEN_a_name_that_is_in_config_and_10_similar_names_WHEN_getUniqueName_called_THEN_passed_name_changed_to_the_name_with_a_10_in_parenthesis() {
-        EditableBlock blockThatExists1 = mock(EditableBlock.class);
-        EditableBlock blockThatExists2 = mock(EditableBlock.class);
-        EditableBlock blockThatExists3 = mock(EditableBlock.class);
-        EditableBlock blockThatExists4 = mock(EditableBlock.class);
-        EditableBlock blockThatExists5 = mock(EditableBlock.class);
-        EditableBlock blockThatExists6 = mock(EditableBlock.class);
-        EditableBlock blockThatExists7 = mock(EditableBlock.class);
-        EditableBlock blockThatExists8 = mock(EditableBlock.class);
-        EditableBlock blockThatExists9 = mock(EditableBlock.class);
-        EditableBlock blockThatExists10 = mock(EditableBlock.class);
-        EditableBlock blockThatExists11 = mock(EditableBlock.class);
-        when(blockThatExists1.getName()).thenReturn("NAME");
-        when(blockThatExists2.getName()).thenReturn("NAME (1)");
-        when(blockThatExists3.getName()).thenReturn("NAME (2)");
-        when(blockThatExists4.getName()).thenReturn("NAME (3)");
-        when(blockThatExists5.getName()).thenReturn("NAME (4)");
-        when(blockThatExists6.getName()).thenReturn("NAME (5)");
-        when(blockThatExists7.getName()).thenReturn("NAME (6)");
-        when(blockThatExists8.getName()).thenReturn("NAME (7)");
-        when(blockThatExists9.getName()).thenReturn("NAME (8)");
-        when(blockThatExists10.getName()).thenReturn("NAME (9)");
-        when(blockThatExists11.getName()).thenReturn("NAME (10)");
-        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists1, blockThatExists2,blockThatExists3, blockThatExists4,blockThatExists5, blockThatExists6,blockThatExists7, blockThatExists8, blockThatExists9, blockThatExists10, blockThatExists11));
-        String name = "NAME"; 
-        String expected = name + " (11)";
+    public void GIVEN_a_name_that_is_in_config_and_11_similar_names_WHEN_getUniqueName_called_THEN_passed_name_changed_to_the_name_with_underscore_11() {
+        EditableBlock blockList[] = new EditableBlock[11];
+        String name = "NAME";
+        for (int i = 0; i < 11 ; i++){
+            EditableBlock blockThatExists = mock(EditableBlock.class);
+            blockList[i] = blockThatExists;
+            if (i == 0 ) {
+                when(blockList[i].getName()).thenReturn(name);
+            } else{
+                when(blockList[i].getName()).thenReturn(name + "_" + i);
+            }
+        }
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockList));
+        String expected = name + "_11";
         String actual = blockViewModel.getUniqueName(name);
         assertEquals(expected , actual);
     }
@@ -114,12 +102,12 @@ public class BlocksEditorViewModelTest {
     }
     
     @Test
-    public void GIVEN_a_name_that_is_only_numbers_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_a_1_in_parenthesis() {
+    public void GIVEN_a_name_that_is_only_numbers_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_undercore_1() {
         EditableBlock blockThatExists = mock(EditableBlock.class);
-        when(blockThatExists.getName()).thenReturn("1234");
-        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
         String name = "1234"; 
-        String expected = name + " (1)";
+        when(blockThatExists.getName()).thenReturn(name);
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
+        String expected = name + "_1";
         String actual = blockViewModel.getUniqueName(name);
         assertEquals(expected , actual);
     }
@@ -133,12 +121,12 @@ public class BlocksEditorViewModelTest {
     }
     
     @Test
-    public void GIVEN_a_name_that_is_only_underscores_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_a_1_in_parenthesis() {
+    public void GIVEN_a_name_that_is_only_underscores_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_underscore_1() {
         EditableBlock blockThatExists = mock(EditableBlock.class);
-        when(blockThatExists.getName()).thenReturn("_");
-        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
         String name = "_"; 
-        String expected = name + " (1)";
+        when(blockThatExists.getName()).thenReturn(name);
+        when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
+        String expected = name + "_1";
         String actual = blockViewModel.getUniqueName(name);
         assertEquals(expected , actual);
     }
@@ -152,12 +140,12 @@ public class BlocksEditorViewModelTest {
     }
     
     @Test
-    public void GIVEN_a_name_that_is_only_underscores_and_numbers_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_a_1_in_parenthesis() {
+    public void GIVEN_a_name_that_is_only_underscores_and_numbers_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_underscore_1() {
         EditableBlock blockThatExists = mock(EditableBlock.class);
-        when(blockThatExists.getName()).thenReturn("_21_21_21");
+        String name = "_21_21_21_"; 
+        when(blockThatExists.getName()).thenReturn(name);
         when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
-        String name = "_21_21_21"; 
-        String expected = name + " (1)";
+        String expected = name + "_1";
         String actual = blockViewModel.getUniqueName(name);
         assertEquals(expected , actual);
     }
@@ -171,12 +159,12 @@ public class BlocksEditorViewModelTest {
     }
     
     @Test
-    public void GIVEN_a_name_that_has_underscores_and_numbers_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_a_1_in_parenthesis() {
+    public void GIVEN_a_name_that_has_underscores_and_numbers_and_in_config_WHEN_getUniqueName_called_THEN_name_changed_to_the_name_with_underscore_1() {
         EditableBlock blockThatExists = mock(EditableBlock.class);
-        when(blockThatExists.getName()).thenReturn("NAME_21_21_21");
+        String name = "NAME_21_21_21_NAME"; 
+        when(blockThatExists.getName()).thenReturn(name);
         when(mockConfig.getAllBlocks()).thenReturn(Arrays.asList(blockThatExists));
-        String name = "NAME_21_21_21"; 
-        String expected = name + " (1)";
+        String expected = name + "_1";
         String actual = blockViewModel.getUniqueName(name);
         assertEquals(expected , actual);
     }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/ConfigDetailsDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/ConfigDetailsDialog.java
@@ -82,10 +82,9 @@ public class ConfigDetailsDialog extends TitleAreaDialog implements
 
 	@Override
 	protected Control createDialogArea(Composite parent) {
-        editor = new ConfigEditorPanel(parent, SWT.NONE, this, config.getIsComponent(), configurationViewModels);
+        editor = new ConfigEditorPanel(parent, SWT.NONE, this, config, configurationViewModels);
 		editor.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 		setTitle(subTitle);
-        editor.setConfigToEdit(config);
 		return editor;
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
@@ -29,6 +29,7 @@ import org.eclipse.swt.widgets.TabItem;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.ui.configserver.ConfigurationViewModels;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.blocks.BlocksEditorPanel;
+import uk.ac.stfc.isis.ibex.ui.configserver.editing.blocks.BlocksEditorViewModel;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.components.ComponentEditorPanel;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.groups.GroupsEditorPanel;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs.IocOverviewPanel;
@@ -58,14 +59,13 @@ public class ConfigEditorPanel extends Composite {
      *            An integer giving the panel style using SWT style flags.
      * @param dialog
      *            The message displayer used to show error messages to the user.
-     * @param isComponent
-     *            Whether the configuration being displayed is a component or
-     *            not.
+     * @param config
+     *            The current config
      * @param configurationViewModels
      *            A class holding a number of view models for displaying
      *            configuration data to the user.
      */
-    public ConfigEditorPanel(Composite parent, int style, MessageDisplayer dialog, boolean isComponent,
+    public ConfigEditorPanel(Composite parent, int style, MessageDisplayer dialog, EditableConfiguration config,
             ConfigurationViewModels configurationViewModels) {
 		super(parent, style);
 		GridLayout gridLayout = new GridLayout(1, false);
@@ -81,7 +81,7 @@ public class ConfigEditorPanel extends Composite {
         editorTabs = new TabFolder(this, SWT.NONE);
 		editorTabs.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 
-        if (isComponent) {
+        if (config.getIsComponent()) {
             components = null;
         } else {
             TabItem componentsTab = new TabItem(editorTabs, SWT.NONE);
@@ -100,7 +100,7 @@ public class ConfigEditorPanel extends Composite {
         blocksTab = new TabItem(editorTabs, SWT.NONE);
         blocksTab.setText("Blocks");
 		
-		blocks = new BlocksEditorPanel(editorTabs, SWT.NONE);
+		blocks = new BlocksEditorPanel(editorTabs, SWT.NONE, new BlocksEditorViewModel(config));
 		blocksTab.setControl(blocks);
 		
 		TabItem groupsTab = new TabItem(editorTabs, SWT.NONE);
@@ -108,6 +108,8 @@ public class ConfigEditorPanel extends Composite {
 		
         groups = new GroupsEditorPanel(editorTabs, SWT.NONE, dialog, configurationViewModels);
 		groupsTab.setControl(groups);
+		
+		setConfigToEdit(config);
 	}
 
     /**
@@ -116,7 +118,7 @@ public class ConfigEditorPanel extends Composite {
      * @param config
      *            The configuration to edit.
      */
-	public void setConfigToEdit(EditableConfiguration config) {		
+	private void setConfigToEdit(EditableConfiguration config) {		
 		iocs.setConfig(config);
 		blocks.setConfig(config);
 		if (components != null) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -221,12 +221,6 @@ public class BlocksEditorPanel extends Composite {
 	    char[] blockNameChars = block.getName().toCharArray();
         int length = blockNameChars.length;
         
-        //Removes the "_1" from the name of block, if it's present.
-        if (blockNameChars[length - 2] == '_') {
-            char[] newBlockNameChars = Arrays.copyOfRange(blockNameChars, 0, length - 2);
-            block.setName(String.valueOf(newBlockNameChars));
-        }
-        
         //Assumes the block won't be copied 50 times or more.
         for (int i = 1; i < 50; i++) {
             for (EditableBlock blockInConfig : config.getAllBlocks()) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -95,7 +95,7 @@ public class BlocksEditorPanel extends Composite {
                 } else if (e.character == 0x01) {
                     addNew();
                 //edits first selected block if press "Ctrl +E".
-                } else if (e.character == 0x5) {
+                } else if (e.character == 0x5 && editEnabled(Arrays.asList(table.firstSelectedRow()))) {
                     openEditBlockDialog(table.firstSelectedRow());
                 }
             }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -217,16 +217,13 @@ public class BlocksEditorPanel extends Composite {
      * 
      * @param block The block whose name should be changed.
      */
-	private void setSimilarName(EditableBlock block) {
-	    char[] blockNameChars = block.getName().toCharArray();
-        int length = blockNameChars.length;
-        
+	private void setSimilarName(EditableBlock block) {     
         //Assumes the block won't be copied 50 times or more.
         for (int i = 1; i < 50; i++) {
             for (EditableBlock blockInConfig : config.getAllBlocks()) {
                 if (block.getName().equals(blockInConfig.getName())) {
                     char[] blockInConfigChars = blockInConfig.getName().toCharArray();
-                    length = blockInConfigChars.length;
+                    int length = blockInConfigChars.length;
                     if (blockInConfigChars[length - 2] == '_') {
                         char[] newBlockInConfigChars = Arrays.copyOfRange(blockInConfigChars, 0, length - 1);
                         block.setName(String.valueOf(newBlockInConfigChars) + i);

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.ui.configserver.editing.blocks;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -54,12 +55,14 @@ public class BlocksEditorPanel extends Composite {
 	private final Button edit;
 	private final Button remove;
 	private final Button copy;
+	private final BlocksEditorViewModel viewModel;
 	
 	private EditableConfiguration config;
 	
-	public BlocksEditorPanel(Composite parent, int style) {
+	public BlocksEditorPanel(Composite parent, int style, BlocksEditorViewModel viewModel) {
 		super(parent, style);
 		setLayout(new GridLayout(1, false));
+		this.viewModel = viewModel;
 		
 		table = new BlocksTable(this, SWT.NONE, SWT.V_SCROLL | SWT.MULTI | SWT.FULL_SELECTION, true);
 		GridData gd_table = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
@@ -198,7 +201,7 @@ public class BlocksEditorPanel extends Composite {
 	    if (!table.selectedRows().isEmpty()) {
     	    for (Block block : table.selectedRows()) {
                 EditableBlock added = new EditableBlock(block);
-                setSimilarName(added);
+                added.setName(viewModel.getUniqueName(added.getName()));
                 try {
                     config.addNewBlock(added);
                 } catch (DuplicateBlockNameException e1) {
@@ -212,33 +215,7 @@ public class BlocksEditorPanel extends Composite {
 	    } 
 	}
 	
-	/**
-     * This method is responsible for setting a similar name to the passed block so that two blocks don't have the same name.
-     * 
-     * @param block The block whose name should be changed.
-     */
-	private void setSimilarName(EditableBlock block) {     
-        //Assumes the block won't be copied 50 times or more.
-        for (int i = 1; i < 50; i++) {
-            for (EditableBlock blockInConfig : config.getAllBlocks()) {
-                if (block.getName().equals(blockInConfig.getName())) {
-                    char[] blockInConfigChars = blockInConfig.getName().toCharArray();
-                    int length = blockInConfigChars.length;
-                    if (blockInConfigChars[length - 2] == '_') {
-                        char[] newBlockInConfigChars = Arrays.copyOfRange(blockInConfigChars, 0, length - 1);
-                        block.setName(String.valueOf(newBlockInConfigChars) + i);
-                        
-                    } else if (blockInConfigChars[length - 3] == '_') {
-                        char[] newBlockInConfigChars = Arrays.copyOfRange(blockInConfigChars, 0, length - 2);
-                        block.setName(String.valueOf(newBlockInConfigChars) + i);
-                    } else {
-                        block.setName(block.getName() + "_" + i);
-                    }
-                }
-            }
-        }  
-	}
-
+	
 	private void setBlocks(EditableConfiguration config) {
 		table.setRows(config.getAllBlocks());
 		table.refresh();

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -237,6 +237,9 @@ public class BlocksEditorPanel extends Composite {
                         char[] newBlockInConfigChars = Arrays.copyOfRange(blockInConfigChars, 0, length - 1);
                         block.setName(String.valueOf(newBlockInConfigChars) + i);
                         
+                    } else if (blockInConfigChars[length - 3] == '_') {
+                        char[] newBlockInConfigChars = Arrays.copyOfRange(blockInConfigChars, 0, length - 2);
+                        block.setName(String.valueOf(newBlockInConfigChars) + i);
                     } else {
                         block.setName(block.getName() + "_" + i);
                     }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorViewModel.java
@@ -38,9 +38,8 @@ public class BlocksEditorViewModel extends ModelObject {
         for (Block blockInConfig : config.getAllBlocks()) {
             allBlocksInConfigNames.add(blockInConfig.getName());
         }
-        DefaultName namer = new DefaultName(blockName, " ", true);
+        DefaultName namer = new DefaultName(blockName);
         return namer.getUnique(allBlocksInConfigNames);
     }
-    
 }
 

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorViewModel.java
@@ -1,0 +1,46 @@
+package uk.ac.stfc.isis.ibex.ui.configserver.editing.blocks;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
+import uk.ac.stfc.isis.ibex.configserver.editing.DefaultName;
+import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
+import uk.ac.stfc.isis.ibex.model.ModelObject;
+
+
+/**
+ * The view model of the block editor panel.
+ */
+public class BlocksEditorViewModel extends ModelObject {
+    EditableConfiguration config;
+    
+    /**
+     * Constructor for the block editor panel view model.
+     * 
+     * @param config 
+     *                  The configuration used by the block editor panel.
+     */
+    public BlocksEditorViewModel(EditableConfiguration config) {
+        this.config = config;
+    }
+    
+    /**
+     * This method is responsible for returning a unique name to the name passed so that two blocks don't have the same name.
+     * 
+     * @param blockName 
+     *                  The name that should be changed.
+     * @return
+     *          The new unique name for the block.
+     */
+    public String getUniqueName(String blockName) {
+        Collection<String> allBlocksInConfigNames = new ArrayList<String>();
+        for (Block blockInConfig : config.getAllBlocks()) {
+            allBlocksInConfigNames.add(blockInConfig.getName());
+        }
+        DefaultName namer = new DefaultName(blockName, " ", true);
+        return namer.getUnique(allBlocksInConfigNames);
+    }
+    
+}
+


### PR DESCRIPTION
### Description of work

I added the option to copy blocks when editing a configuration. For this, I added:
- A copy button to the block tab of the config editing panel.
- A method that copies one or more blocks when they are selected in the table.
- A method to rename these blocks so that each block has a unique name.
- A keyboard listener that allows for the key combination ctrl+c to be detected and used as a shortcut to copy the selected blocks in the table.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3293

### Acceptance criteria

- The blocks are copied correctly, are added to the configuration and are displayed in the table.
- Both the shortcut and the button work, for one or more blocks.
- The button is correctly placed.
- A unique name is given to the copied block or blocks.

### Unit tests

Unit tests added to test the view model for the Block Editor Panel.

### System tests

None required. 

### Documentation
Added a sentence explaining that blocks can be copied both with the copy button or the keyboard shortcut, so that users are aware of the keyboard shortcut, in the user manual (at https://github.com/ISISComputingGroup/ibex_user_manual/wiki/CreateandManageConfigurations).

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

