### PR TITLE
Fixed config saving issue.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServer.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServer.java
@@ -26,6 +26,7 @@ import uk.ac.stfc.isis.ibex.configserver.configuration.ComponentInfo;
 import uk.ac.stfc.isis.ibex.configserver.configuration.ConfigInfo;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.configserver.configuration.PV;
+import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
 import uk.ac.stfc.isis.ibex.epics.conversion.DoNothingConverter;
 import uk.ac.stfc.isis.ibex.epics.observing.FilteredCollectionObservable;
@@ -341,4 +342,53 @@ public class ConfigServer extends Closer {
     public ComponentDependenciesModel getDependenciesModel() {
         return dependenciesModel;
     }
+    
+    /**
+     * If a user chooses to save a configuration as a component or not then the way the config is saved will change.
+     * The following method calls or other methods that apply similar logic to choose the way a config will be saved.
+     * 
+     * @param config
+     *               The config in which the save is being made.
+     * @param isCurrent
+     *                  True if the config being saved is the current config.
+     * @param doAsComponent
+     *                  True if the config being saved is to be saved to a component.
+     * @param switchConfigOnSaveAs
+     *                  True if the config should be switched on save as.
+     * @param calledSwitchConfigOnSaveAs
+     *                  True if the dialog to switch config on save as has been called.
+     */
+    public void ifDoAsComponentChooseSave(EditableConfiguration config, boolean isCurrent, boolean doAsComponent, 
+            boolean switchConfigOnSaveAs, boolean calledSwitchConfigOnSaveAs) {      
+        if (doAsComponent) {
+            saveAsComponent().uncheckedWrite(config.asComponent());
+        } else {
+            ifIsCurrentConfigChooseSave(config, isCurrent, switchConfigOnSaveAs, calledSwitchConfigOnSaveAs);
+        }
+    }
+    
+    private void ifIsCurrentConfigChooseSave(EditableConfiguration config, boolean isCurrent, boolean switchConfigOnSaveAs, boolean calledSwitchConfigOnSaveAs) {
+        if (isCurrent) {
+            ifCalledSwitchConfigOnSaveAsChooseSave(config, switchConfigOnSaveAs, calledSwitchConfigOnSaveAs);
+        } else {
+            switchConfigOnSaveAs(config, switchConfigOnSaveAs);
+        }
+    }
+    
+    private void ifCalledSwitchConfigOnSaveAsChooseSave(EditableConfiguration config, boolean switchConfigOnSaveAs, boolean calledSwitchConfigOnSaveAs) {
+        if (calledSwitchConfigOnSaveAs) {
+            switchConfigOnSaveAs(config, switchConfigOnSaveAs);
+        } else {
+            setCurrentConfig().uncheckedWrite(config.asConfiguration());
+        }
+    }
+    
+    private void switchConfigOnSaveAs(EditableConfiguration config, boolean switchConfigOnSaveAs) {
+        if (switchConfigOnSaveAs) {
+            setCurrentConfig().uncheckedWrite(config.asConfiguration());
+        } else {
+            saveAs().uncheckedWrite(config.asConfiguration());
+        }
+    }
+    
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewConfigHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewConfigHandler.java
@@ -67,7 +67,11 @@ public class NewConfigHandler extends DisablingConfigHandler<Configuration> {
             if (editDialog.doAsComponent()) {
                 SERVER.saveAsComponent().uncheckedWrite(editDialog.getComponent());
             } else {
-                SERVER.saveAs().uncheckedWrite(editDialog.getConfig());
+                if (editDialog.switchConfigOnSaveAs()) {
+                    SERVER.setCurrentConfig().uncheckedWrite(editDialog.getConfig());
+                } else {
+                    SERVER.saveAs().uncheckedWrite(editDialog.getConfig());
+                }
             }
         }
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
@@ -62,28 +62,9 @@ public class EditConfigHelper extends ConfigHelper {
                 new EditConfigDialog(shell, title, subTitle, config, false, configurationViewModels,
                         editBlockFirst);
         if (dialog.open() == Window.OK) {
-            if (dialog.doAsComponent()) {
-                server.saveAsComponent().uncheckedWrite(dialog.getComponent());
-            } else {
-                if (isCurrent) {
-                    if (dialog.calledSwitchConfigOnSaveAs()) {
-                        if (dialog.switchConfigOnSaveAs()) {
-                            server.setCurrentConfig().uncheckedWrite(dialog.getConfig());
-                        } else {
-                            server.saveAs().uncheckedWrite(dialog.getConfig());
-                        }
-                    } else {
-                        server.setCurrentConfig().uncheckedWrite(dialog.getConfig());
-                    }
-                } else {
-                    if (dialog.switchConfigOnSaveAs()) {
-                            server.setCurrentConfig().uncheckedWrite(dialog.getConfig());
-                    } else {
-                        server.saveAs().uncheckedWrite(dialog.getConfig());
-                    }
-                }
-            }
+            server.ifDoAsComponentChooseSave(config, isCurrent, dialog.doAsComponent(), dialog.switchConfigOnSaveAs(), dialog.calledSwitchConfigOnSaveAs());
         }
     }
+    
 }
 

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
@@ -65,12 +65,25 @@ public class EditConfigHelper extends ConfigHelper {
             if (dialog.doAsComponent()) {
                 server.saveAsComponent().uncheckedWrite(dialog.getComponent());
             } else {
-                if (isCurrent && dialog.switchConfigOnSaveAs()) {
-                    server.setCurrentConfig().uncheckedWrite(dialog.getConfig());
+                if (isCurrent) {
+                    if (dialog.calledSwitchConfigOnSaveAs()) {
+                        if (dialog.switchConfigOnSaveAs()) {
+                            server.setCurrentConfig().uncheckedWrite(dialog.getConfig());
+                        } else {
+                            server.saveAs().uncheckedWrite(dialog.getConfig());
+                        }
+                    } else {
+                        server.setCurrentConfig().uncheckedWrite(dialog.getConfig());
+                    }
                 } else {
-                    server.saveAs().uncheckedWrite(dialog.getConfig());
+                    if (dialog.switchConfigOnSaveAs()) {
+                            server.setCurrentConfig().uncheckedWrite(dialog.getConfig());
+                    } else {
+                        server.saveAs().uncheckedWrite(dialog.getConfig());
+                    }
                 }
             }
         }
     }
 }
+

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
@@ -44,6 +44,7 @@ public class EditConfigDialog extends ConfigDetailsDialog {
     private Button saveAsBtn;
     private boolean editBlockFirst;
     private boolean switchConfigOnSaveAs;
+    private boolean calledSwitchConfigOnSaveAs = false;
 
     private ConfigServer server = Configurations.getInstance().server();
 
@@ -99,6 +100,7 @@ public class EditConfigDialog extends ConfigDetailsDialog {
                         configNames, componentNames, !config.getIsComponent(), hasComponents, currentConfigName);
                 if (dlg.open() == Window.OK) {
                     switchConfigOnSaveAs = dlg.shouldSwitchConfig();
+                    calledSwitchConfigOnSaveAs = true;
                     if (dlg.getNewName() != config.getName()) {
                         config.setName(dlg.getNewName());
                     }
@@ -146,5 +148,12 @@ public class EditConfigDialog extends ConfigDetailsDialog {
      */
     public boolean switchConfigOnSaveAs() {
         return switchConfigOnSaveAs;
+    }
+    /**
+     *
+     * @return true if switchConfigOnSaveAs() has been called.
+     */
+    public boolean calledSwitchConfigOnSaveAs() {
+        return calledSwitchConfigOnSaveAs;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/SaveConfigDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/SaveConfigDialog.java
@@ -130,6 +130,8 @@ public class SaveConfigDialog extends TitleAreaDialog {
     private final String currentConfigName;
 
     private boolean switchToNewConfig;
+    
+    private boolean asComponentSelected;
 
     /**
      * Instantiates a new save configuration dialog.
@@ -247,6 +249,7 @@ public class SaveConfigDialog extends TitleAreaDialog {
                 public void widgetSelected(SelectionEvent e) {
                     updateConfigType();
                     update();
+                    asComponentSelected = true;
                 }
             });
         }
@@ -304,11 +307,22 @@ public class SaveConfigDialog extends TitleAreaDialog {
                     return;
                 }
             }
-            switchToNewConfig = askUserWhetherToSwitchToNewConfig();
+            if (isConfig) {
+                if (!asComponentSelected()) {
+                    switchToNewConfig = askUserWhetherToSwitchToNewConfig();
+                }
+            }
             super.okPressed();
             close();
         }
         // else ignore the click
+    }
+    
+    /**
+     * @return Has the option to save as component been selected.
+     */
+    private boolean asComponentSelected() {
+        return asComponentSelected;
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.experimentdetails/src/uk/ac/stfc/isis/ibex/ui/experimentdetails/rblookup/RBLookupViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.experimentdetails/src/uk/ac/stfc/isis/ibex/ui/experimentdetails/rblookup/RBLookupViewModel.java
@@ -106,13 +106,6 @@ public class RBLookupViewModel extends ModelObject {
 	}
 
     /**
-     * @return name to search for. 
-     */
-	public String getNameSearch() {
-		return nameSearch;
-	}
-
-    /**
      * Get the name to search for.
      * 
      * @return the name


### PR DESCRIPTION
### Description of work

I refined the logic as to when the changes should be saved to the current config or not. To do so, I added a method to check if the confirmation dialog asking whether or not to switch to the current config had been called. The reason for doing so is that the same save dialog (not the confirmation dialog) is called for "save as" and for "save". This means that checking if the confirmation dialog has been okayed happens both for "save" and "save as", and therefore if the user clicks "save", the confirmation dialog doesn't open and the previous logic assumed that the confirmation dialog had been refuted. This lead to the configuration not being saved when the "save" button was used. Adding a method to check if the confirmation dialog has been called or not allows to distinguish between when "save" and "save as" are pressed.  

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3303

### Acceptance criteria

- [x] Saving the current configuration does not produce the IOC log error.
- [x] Save as on a non current configuration allows to switch to the new configuration.
- [x] Any other configuration save pattern works.

### Unit tests

None required.

### System tests

None required.

### Documentation
None found.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

