### PR TITLE
Trimmed any leading or following whitespace from the various names.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/UserDetails.java
+++ b/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/UserDetails.java
@@ -73,7 +73,7 @@ public class UserDetails extends ModelObject {
      * @return The user's full name.
      */
 	public String getName() {
-		return name.replaceAll("^\\s+|\\s+$", "");
+		return name.trim();
 	}
 
 	/**
@@ -81,7 +81,7 @@ public class UserDetails extends ModelObject {
 	 * @param name The new name to give the user.
 	 */
 	public void setName(String name) {
-		firePropertyChange("name", this.name, this.name = name.replaceAll("^\\s+|\\s+$", ""));
+		firePropertyChange("name", this.name, this.name = name.trim());
 	}
 
 	/**
@@ -89,7 +89,7 @@ public class UserDetails extends ModelObject {
 	 * @return The institute the user works for.
 	 */
 	public String getInstitute() {
-		return institute.replaceAll("^\\s+|\\s+$", "");
+		return institute.trim();
 	}
 
 	/**
@@ -97,7 +97,7 @@ public class UserDetails extends ModelObject {
 	 * @param institute The institute to assign the user.
 	 */
 	public void setInstitute(String institute) {
-		firePropertyChange("institute", this.institute, this.institute = institute.replaceAll("^\\s+|\\s+$", ""));
+		firePropertyChange("institute", this.institute, this.institute = institute.trim());
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/UserDetails.java
+++ b/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/UserDetails.java
@@ -73,7 +73,7 @@ public class UserDetails extends ModelObject {
      * @return The user's full name.
      */
 	public String getName() {
-		return name;
+		return name.replaceAll("^\\s+|\\s+$", "");
 	}
 
 	/**
@@ -81,7 +81,7 @@ public class UserDetails extends ModelObject {
 	 * @param name The new name to give the user.
 	 */
 	public void setName(String name) {
-		firePropertyChange("name", this.name, this.name = name);
+		firePropertyChange("name", this.name, this.name = name.replaceAll("^\\s+|\\s+$", ""));
 	}
 
 	/**
@@ -89,7 +89,7 @@ public class UserDetails extends ModelObject {
 	 * @return The institute the user works for.
 	 */
 	public String getInstitute() {
-		return institute;
+		return institute.replaceAll("^\\s+|\\s+$", "");
 	}
 
 	/**
@@ -97,7 +97,7 @@ public class UserDetails extends ModelObject {
 	 * @param institute The institute to assign the user.
 	 */
 	public void setInstitute(String institute) {
-		firePropertyChange("institute", this.institute, this.institute = institute);
+		firePropertyChange("institute", this.institute, this.institute = institute.replaceAll("^\\s+|\\s+$", ""));
 	}
 
 	/**


### PR DESCRIPTION
### Description of work

I trimmed any leading or following white space (tabs, spaces etc.) from the user name and institute name in the experiment team table.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3305


### NB:
Please notice the name of this branch starts with two Ts (TT) when trying to check it out.

### Acceptance criteria

- [x] Institute name and user name should be trimmed.
- [x] Tabs and other white space should be trimmed.
- [x] When setting a name followed by a space (e.g. "Richard Tyson "), the user field is not blank.

### Unit tests

None required.

### System tests

None required.

### Documentation
None found.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

