### PR TITLE
Addded a warning when creating a bad PV.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlockDetailsViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlockDetailsViewModel.java
@@ -189,10 +189,16 @@ public class BlockDetailsViewModel extends ErrorMessageProvider {
         
     	if (!(nameVal.isValidName(name, currentRules))) {
     		setError(true, nameVal.getErrorMessage());
+    		setWarning(false, null);
     	} else if (!(addressValid.validatePvAddress(pvAddress))) {
     		setError(true, addressValid.getErrorMessage());
+    		setWarning(false, null);
+    	} else if (!(addressValid.warningPvAddress(pvAddress))) {
+    	    setWarning(true, addressValid.getWarningMessage());
+    	    setError(false, null);
     	} else {
     		setError(false, null);
+    		setWarning(false, null);
     	}
     }
 

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/EditBlockDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/EditBlockDialog.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
 import org.eclipse.swt.SWT;
@@ -68,7 +69,7 @@ public class EditBlockDialog extends TitleAreaDialog {
             for (ErrorMessageProvider model : viewModels) {
                 WarningMessage warning = model.getWarning();
                 if (warning.isWarning()) {
-                    setMessage(warning.getMessage(), 2);
+                    setMessage(warning.getMessage(), IMessageProvider.WARNING);
                     return;
                 }
             }
@@ -99,11 +100,9 @@ public class EditBlockDialog extends TitleAreaDialog {
 		
 		for (ErrorMessageProvider provider : viewModels) {
 			provider.addPropertyChangeListener("error", errorListener);
+			provider.addPropertyChangeListener("warning", warningListener);
         }
 
-		for (ErrorMessageProvider provider : viewModels) {
-            provider.addPropertyChangeListener("warning", warningListener);
-        }
 	}
 	
     @Override

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/EditBlockDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/EditBlockDialog.java
@@ -22,6 +22,7 @@ import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.runcontrol.RunControlServer;
 import uk.ac.stfc.isis.ibex.validators.ErrorMessage;
 import uk.ac.stfc.isis.ibex.validators.ErrorMessageProvider;
+import uk.ac.stfc.isis.ibex.validators.WarningMessage;
 
 /**
  * A dialog for editing blocks.
@@ -61,6 +62,20 @@ public class EditBlockDialog extends TitleAreaDialog {
         }
     };
 
+    private PropertyChangeListener warningListener = new PropertyChangeListener() {
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+            for (ErrorMessageProvider model : viewModels) {
+                WarningMessage warning = model.getWarning();
+                if (warning.isWarning()) {
+                    setMessage(warning.getMessage(), 2);
+                    return;
+                }
+            }
+            setMessage(null);
+        }
+    };
+
     /**
      * Default constructor.
      * 
@@ -84,6 +99,10 @@ public class EditBlockDialog extends TitleAreaDialog {
 		
 		for (ErrorMessageProvider provider : viewModels) {
 			provider.addPropertyChangeListener("error", errorListener);
+        }
+
+		for (ErrorMessageProvider provider : viewModels) {
+            provider.addPropertyChangeListener("warning", warningListener);
         }
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/validators/ComponentValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/validators/ComponentValidator.java
@@ -41,7 +41,7 @@ public class ComponentValidator extends ErrorAggregator {
     private Map<Integer, SynopticPvValidator> validators = new HashMap<>();
     
     /**
-     * Default constructor. Adds change listners to the component.
+     * Default constructor. Adds change listeners to the component.
      * 
      * @param component
      *            The component to validate

--- a/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/PvValidatorTest.java
+++ b/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/PvValidatorTest.java
@@ -219,7 +219,22 @@ public class PvValidatorTest {
      * .
      */
     @Test
-    public void GIVEN_pv_address_containing_colon_SP_WHEN_check_warning_THEN_warning() {
+    public void GIVEN_pv_address_containing_but_not_ending_with_colon_SP_WHEN_check_warning_THEN_valid() {
+        // Arrange
+        String testAddress = "NAME:SP:ETC";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertTrue(addressValid.warningPvAddress(testAddress));
+    }
+    
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#warningPvAddress(java.lang.String)}
+     * .
+     */
+    @Test
+    public void GIVEN_pv_address_ending_with_colon_SP_WHEN_check_warning_THEN_warning() {
         // Arrange
         String testAddress = "NAME:SP";
         // Act
@@ -234,13 +249,28 @@ public class PvValidatorTest {
      * .
      */
     @Test
-    public void GIVEN_pv_address_containing_colon_SP_colon_RBV_WHEN_check_warning_THEN_warning() {
+    public void GIVEN_pv_address_ending_with_colon_SP_colon_RBV_WHEN_check_warning_THEN_warning() {
         // Arrange
-        String testAddress = "NAME:SP:RBV";
+        String testAddress = "NAME:SP";
         // Act
         PvValidator addressValid = new PvValidator();
         // Assert
         assertFalse(addressValid.warningPvAddress(testAddress));
+    }
+    
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#warningPvAddress(java.lang.String)}
+     * .
+     */
+    @Test
+    public void GIVEN_pv_address_containing_but_not_ending_with_colon_SP_colon_RBV_WHEN_check_warning_THEN_valid() {
+        // Arrange
+        String testAddress = "NAME:SP:RBV:ETC";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertTrue(addressValid.warningPvAddress(testAddress));
     }
 
     /**
@@ -264,7 +294,7 @@ public class PvValidatorTest {
     @Test
     public void GIVEN_valid_pv_address_WHEN_get_error_message_THEN_get_blanck() {
         // Arrange
-        String expected = "";
+        String expected = PvValidator.NO_ERROR;
         String testAddress = "valid";
         // Act
         PvValidator addressValid = new PvValidator();
@@ -310,7 +340,39 @@ public class PvValidatorTest {
      * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getWarningMessage()}.
      */
     @Test
-    public void GIVEN_pv_address_containing_colon_SP_WHEN_get_warning_message_THEN_get_address_SP_warning_message() {
+    public void GIVEN_pv_address_containing_but_not_ending_with_colon_SP_WHEN_get_warning_message_THEN_get_empty_message() {
+        // Arrange
+        String expected = PvValidator.NO_ERROR;
+        String testAddress = "NAME:SP:ETC";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        addressValid.warningPvAddress(testAddress);
+        // Assert
+        assertEquals(expected, addressValid.getWarningMessage());
+    }
+    
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getWarningMessage()}.
+     */
+    @Test
+    public void GIVEN_pv_address_containing_but_not_ending_with_colon_SP_colon_RBV_WHEN_get_warning_message_THEN_get_empty_message() {
+        // Arrange
+        String expected = PvValidator.NO_ERROR;
+        String testAddress = "NAME:SP:RBV:ETC";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        addressValid.warningPvAddress(testAddress);
+        // Assert
+        assertEquals(expected, addressValid.getWarningMessage());
+    }
+
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getWarningMessage()}.
+     */
+    @Test
+    public void GIVEN_pv_address_ending_with_colon_SP_WHEN_get_warning_message_THEN_get_address_SP_warning_message() {
         // Arrange
         String expected = PvValidator.ADDRESS_SP;
         String testAddress = "NAME:SP";
@@ -326,7 +388,7 @@ public class PvValidatorTest {
      * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getWarningMessage()}.
      */
     @Test
-    public void GIVEN_pv_address_containing_colon_SP_colon_RBV_WHEN_get_warning_message_THEN_get_address_SP_RBV_warning_message() {
+    public void GIVEN_pv_address_ending_with_colon_SP_colon_RBV_WHEN_get_warning_message_THEN_get_address_SP_RBV_warning_message() {
         // Arrange
         String expected = PvValidator.ADDRESS_SP_RBV;
         String testAddress = "NAME:SP:RBV";

--- a/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/PvValidatorTest.java
+++ b/base/uk.ac.stfc.isis.ibex.validators.tests/src/uk/ac/stfc/isis/ibex/validators/tests/PvValidatorTest.java
@@ -45,6 +45,19 @@ public class PvValidatorTest {
     }
 
     /**
+     * Test method for {@link uk.ac.stfc.isis.ibex.validators.PvValidator#warningPvAddress(java.lang.String)}.
+     */
+    @Test
+    public void GIVEN_plain_pv_address_WHEN_check_warning_THEN_valid() {
+        // Arrange
+        String testAddress = "valid";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertTrue(addressValid.warningPvAddress(testAddress));
+    }
+
+    /**
      * Test method for
      * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#validatePvAddress(java.lang.String)}.
      */
@@ -56,6 +69,20 @@ public class PvValidatorTest {
         PvValidator addressValid = new PvValidator();
         // Assert
         assertTrue(addressValid.validatePvAddress(testAddress));
+    }
+
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#warningPvAddress(java.lang.String)}.
+     */
+    @Test
+    public void GIVEN_pv_address_with_field_WHEN_check_warning_THEN_valid() {
+        // Arrange
+        String testAddress = "valid.field";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertTrue(addressValid.warningPvAddress(testAddress));
     }
 
     /**
@@ -74,6 +101,20 @@ public class PvValidatorTest {
 
     /**
      * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#warningPvAddress(java.lang.String)}.
+     */
+    @Test
+    public void GIVEN_pv_address_with_non_alpha_character_WHEN_check_warning_THEN_valid() {
+        // Arrange
+        String testAddress = "va_:lid.fi_:eld";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertTrue(addressValid.warningPvAddress(testAddress));
+    }
+
+    /**
+     * Test method for
      * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#validatePvAddress(java.lang.String)}.
      */
     @Test
@@ -84,6 +125,20 @@ public class PvValidatorTest {
         PvValidator addressValid = new PvValidator();
         // Assert
         assertTrue(addressValid.validatePvAddress(testAddress));
+    }
+
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#warningPvAddress(java.lang.String)}.
+     */
+    @Test
+    public void GIVEN_pv_address_with_dash_WHEN_check_warning_THEN_valid() {
+        // Arrange
+        String testAddress = "va_:l-d.fi_:eld";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertTrue(addressValid.warningPvAddress(testAddress));
     }
 
     /**
@@ -149,7 +204,7 @@ public class PvValidatorTest {
      * .
      */
     @Test
-    public void invalid_pv_address() {
+    public void GIVEN_invalid_pv_address_WHEN_validate_THEN_error() {
         // Arrange
         String testAddress = "invalid@";
         // Act
@@ -159,10 +214,55 @@ public class PvValidatorTest {
     }
 
     /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#warningPvAddress(java.lang.String)}
+     * .
+     */
+    @Test
+    public void GIVEN_pv_address_containing_colon_SP_WHEN_check_warning_THEN_warning() {
+        // Arrange
+        String testAddress = "NAME:SP";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertFalse(addressValid.warningPvAddress(testAddress));
+    }
+
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#warningPvAddress(java.lang.String)}
+     * .
+     */
+    @Test
+    public void GIVEN_pv_address_containing_colon_SP_colon_RBV_WHEN_check_warning_THEN_warning() {
+        // Arrange
+        String testAddress = "NAME:SP:RBV";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertFalse(addressValid.warningPvAddress(testAddress));
+    }
+
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#warningPvAddress(java.lang.String)}
+     * .
+     */
+    @Test
+    public void GIVEN_pv_address_containing_CS_colon_SB_colon_WHEN_check_warning_THEN_warning() {
+        // Arrange
+        String testAddress = "CS:SB:NAME";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        // Assert
+        assertFalse(addressValid.warningPvAddress(testAddress));
+    }
+
+    /**
      * Test method for {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getErrorMessage()}.
      */
     @Test
-    public void get_message_for_valid() {
+    public void GIVEN_valid_pv_address_WHEN_get_error_message_THEN_get_blanck() {
         // Arrange
         String expected = "";
         String testAddress = "valid";
@@ -178,7 +278,7 @@ public class PvValidatorTest {
      * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getErrorMessage()}.
      */
     @Test
-    public void get_message_for_invalid() {
+    public void GIVEN_invalid_pv_address_WHEN_get_error_message_THEN_get_invalid_address_error_message() {
         // Arrange
         String expected = PvValidator.ADDRESS_FORMAT;
         String testAddress = "invalid@";
@@ -194,7 +294,7 @@ public class PvValidatorTest {
      * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getErrorMessage()}.
      */
     @Test
-    public void get_message_for_empty_address_string() {
+    public void GIVEN_empty_pv_address_WHEN_get_error_message_THEN_get_empty_error_message() {
         // Arrange
         String expected = PvValidator.ADDRESS_EMPTY;
         String testAddress = "";
@@ -203,6 +303,54 @@ public class PvValidatorTest {
         addressValid.validatePvAddress(testAddress);
         // Assert
         assertEquals(expected, addressValid.getErrorMessage());
+    }
+
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getWarningMessage()}.
+     */
+    @Test
+    public void GIVEN_pv_address_containing_colon_SP_WHEN_get_warning_message_THEN_get_address_SP_warning_message() {
+        // Arrange
+        String expected = PvValidator.ADDRESS_SP;
+        String testAddress = "NAME:SP";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        addressValid.warningPvAddress(testAddress);
+        // Assert
+        assertEquals(expected, addressValid.getWarningMessage());
+    }
+
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getWarningMessage()}.
+     */
+    @Test
+    public void GIVEN_pv_address_containing_colon_SP_colon_RBV_WHEN_get_warning_message_THEN_get_address_SP_RBV_warning_message() {
+        // Arrange
+        String expected = PvValidator.ADDRESS_SP_RBV;
+        String testAddress = "NAME:SP:RBV";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        addressValid.warningPvAddress(testAddress);
+        // Assert
+        assertEquals(expected, addressValid.getWarningMessage());
+    }
+
+    /**
+     * Test method for
+     * {@link uk.ac.stfc.isis.ibex.validators.PvValidator#getWarningMessage()}.
+     */
+    @Test
+    public void GIVEN_pv_address_containing_CS_colon_SB_colon_WHEN_get_warning_message_THEN_get_address_CS_SB_warning_message() {
+        // Arrange
+        String expected = PvValidator.ADDRESS_CS_SB;
+        String testAddress = "CS:SB:NAME";
+        // Act
+        PvValidator addressValid = new PvValidator();
+        addressValid.warningPvAddress(testAddress);
+        // Assert
+        assertEquals(expected, addressValid.getWarningMessage());
     }
 
 }

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorAggregator.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorAggregator.java
@@ -55,7 +55,7 @@ public abstract class ErrorAggregator extends ErrorMessageProvider {
 
         setError(false, null);
     }
-    
+
     /**
      * Get the list of error messages from all children.
      * 

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorMessage.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorMessage.java
@@ -18,28 +18,72 @@
 
 package uk.ac.stfc.isis.ibex.validators;
 
+/**
+ * Error message class.
+ *
+ */
 public class ErrorMessage {
 	private String message;
 	private boolean error;
-	
+
+	/**
+     * Creator for an empty error message (ie when no error exists).
+     *
+     */
 	public ErrorMessage() {
 		error = false;
 	}
 	
+	/**
+     * Creator for an error message.
+     *
+     *@param error
+     *              true if there is an error.
+     *
+     *@param message
+     *                  the error message.
+     */
 	public ErrorMessage(boolean error, String message) {
 		this.error = error;
 		this.message = message;
 	}
-	
+
+	/**
+     * Allows to get the error message.
+     *
+     * @return
+     *          the error message.
+     */
 	public String getMessage() {
 		return message;
 	}
+
+	/**
+     * Class used to set an error message..
+     *
+     * @param message
+     *                  the error message to set.
+     */
 	public void setMessage(String message) {
 		this.message = message;
 	}
+
+	/**
+     * Check if there is an error.
+     *
+     * @return
+     *          true if there is an error, false otherwise.
+     */
 	public boolean isError() {
 		return error;
 	}
+
+	/**
+	    *Class to set the existence of an error.
+	    *
+	    * @param inError
+	    *                  true if there is an error.
+	    */
 	public void setError(boolean inError) {
 		this.error = inError;
 	}

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorMessageProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorMessageProvider.java
@@ -20,14 +20,57 @@ package uk.ac.stfc.isis.ibex.validators;
 
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
+/**
+ * Provides error message.
+ *
+ */
 public abstract class ErrorMessageProvider extends ModelObject {
     protected ErrorMessage error = new ErrorMessage();
+    protected WarningMessage warning = new WarningMessage();
     
+    /**
+     * Sets warning to listener.
+     *
+     *@param inError
+     *                  true if there is an error.
+     *
+     *@param message
+     *                  the warning message.
+     */
     protected void setError(boolean inError, String message) {
     	firePropertyChange("error", this.error, this.error = new ErrorMessage(inError, message));
     }
     
+    /**
+     * Returns the error.
+     *
+     *@return
+     *       the error.
+     */
     public ErrorMessage getError() {
     	return error;
+    }
+    
+    /**
+     * Sets warning to listener.
+     * 
+     * @param inWarning
+     *                  true if there is a warning.
+     *
+     *@param message
+     *                  the warning message.
+     */
+    public void setWarning(boolean inWarning, String message) {
+        firePropertyChange("warning", this.warning, this.warning = new WarningMessage(inWarning, message));
+    }
+    
+    /**
+     * Returns the warning.
+     *
+     *@return
+     *       the warning.
+     */
+    public WarningMessage getWarning() {
+        return warning;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/PvValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/PvValidator.java
@@ -38,9 +38,27 @@ public class PvValidator {
      * Message displayed when the PV name is empty.
      */
     public static final String ADDRESS_EMPTY = "PV Address invalid, must not be empty";    
-    private static final String NO_ERROR = "";
+    
+    /**
+     * Message displayed when the PV name contains ":SP".
+     */
+    public static final String ADDRESS_SP = "Block should usually point at the measured quantity. Doing cset on the block will set the SP value if it exists.";
+    
+    /**
+     * Message displayed when the PV name contains ":SP:RBV".
+     */
+    public static final String ADDRESS_SP_RBV = "The setpoint value read back from the device is not a measurement of the value but the value the device is trying to get to.";
 
+    /**
+     * Message displayed when the PV name contains ":CS:SB".
+     */
+    public static final String ADDRESS_CS_SB = "This is an IBEX internal pv are you sure you want a block pointing at it?";
+    
+    private static final String NO_ERROR = "";
+    
     private String errorMessage;
+    
+    private String warningMessage;
 
     /**
      * Creates a PV validator initialised with no error message.
@@ -73,6 +91,31 @@ public class PvValidator {
 
         return isValid;
     }
+    
+    /**
+     * Checks if the Pv Name contains ":SP", ":SP:RBV" and "CS:SB" as these are typical of bad PVs.
+     * 
+     * @param pvAddress the address to validate
+     * @return Boolean addressValid
+     */
+    public Boolean warningPvAddress(String pvAddress) {
+        boolean isValid = false;
+
+        if (pvAddress.contains(":SP")) {
+            if (pvAddress.contains(":SP:RBV")) {
+                setWarningMessage(ADDRESS_SP_RBV);
+            } else {
+                setWarningMessage(ADDRESS_SP);
+            }
+        } else if (pvAddress.contains("CS:SB")) {
+            setWarningMessage(ADDRESS_CS_SB);
+        } else {
+            isValid = true;
+            setWarningMessage(NO_ERROR);
+        }
+
+        return isValid;
+    }
 
     private void setErrorMessage(String errorMessage) {
         this.errorMessage = errorMessage;
@@ -83,6 +126,17 @@ public class PvValidator {
      */
     public String getErrorMessage() {
         return errorMessage;
+    }
+    
+    private void setWarningMessage(String warningMessage) {
+        this.warningMessage = warningMessage;
+    }
+
+    /**
+     * @return the last warning message
+     */
+    public String getWarningMessage() {
+        return warningMessage;
     }
 
 }

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/PvValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/PvValidator.java
@@ -54,7 +54,10 @@ public class PvValidator {
      */
     public static final String ADDRESS_CS_SB = "This is an IBEX internal pv are you sure you want a block pointing at it?";
     
-    private static final String NO_ERROR = "";
+    /**
+     * Message displayed when the PV name is correct.
+     */
+    public static final String NO_ERROR = "";
     
     private String errorMessage;
     
@@ -93,7 +96,7 @@ public class PvValidator {
     }
     
     /**
-     * Checks if the Pv Name contains ":SP", ":SP:RBV" and "CS:SB" as these are typical of bad PVs.
+     * Checks if the Pv Name ends with ":SP", ":SP:RBV" or contains "CS:SB" as these are typical of bad PVs.
      * 
      * @param pvAddress the address to validate
      * @return Boolean addressValid
@@ -101,12 +104,10 @@ public class PvValidator {
     public Boolean warningPvAddress(String pvAddress) {
         boolean isValid = false;
 
-        if (pvAddress.contains(":SP")) {
-            if (pvAddress.contains(":SP:RBV")) {
-                setWarningMessage(ADDRESS_SP_RBV);
-            } else {
-                setWarningMessage(ADDRESS_SP);
-            }
+        if (pvAddress.endsWith(":SP")) {
+            setWarningMessage(ADDRESS_SP);
+        } else if (pvAddress.endsWith(":SP:RBV")) {
+            setWarningMessage(ADDRESS_SP_RBV);
         } else if (pvAddress.contains("CS:SB")) {
             setWarningMessage(ADDRESS_CS_SB);
         } else {

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/WarningMessage.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/WarningMessage.java
@@ -1,0 +1,72 @@
+package uk.ac.stfc.isis.ibex.validators;
+
+/**
+ * Warning message class.
+ *
+ */
+public class WarningMessage {
+    private String message;
+    private boolean warning;
+    
+    /**
+     * Creator for an empty warning message (ie when no warning is given).
+     *
+     */
+    public WarningMessage() {
+        warning = false;
+    }
+    
+    /**
+     * Creator for a warning message.
+     *
+     *@param warning
+     *              true if there is a warning.
+     *
+     *@param message
+     *                  the warning message.
+     */
+    public WarningMessage(boolean warning, String message) {
+        this.warning = warning;
+        this.message = message;
+    }
+    
+    /**
+     * Allows to get the warning message.
+     * 
+     * @return
+     *          the warning message.
+     */
+    public String getMessage() {
+        return message;
+    }
+    
+    /**
+     * Class used to set a warning.
+     * 
+     * @param message
+     *                  the warning message to set.
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    
+    /**
+     * Check if there is a warning.
+     * 
+     * @return
+     *          true if there is a warning, false otherwise.
+     */
+    public boolean isWarning() {
+        return warning;
+    }
+    
+    /**
+    *Class to set the existence of a warning.
+    * 
+    * @param inWarning
+    *                  true if there is a warning.
+    */
+    public void setWarning(boolean inWarning) {
+        this.warning = inWarning;
+    }
+}


### PR DESCRIPTION
### Description of work

I added a warning in the block editor when you try to create a block containing `<pv name>:SP`, `<pv name>:SP:RBV`, `CS:SB:*` . This warning will not be called when an error message is to be displayed and does not stop the user from setting the block. I decided to set this warning in the block editing dialog as that is when the decision to create a block pointing to a certain PV is taken. See ticket for warning messages.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2620

### Acceptance criteria

- [x] When you try pointing a block to a bad PV, a warning is issued.
- [x] A warning does not stop an error from being displayed (try for example `:SP::RBV` ) as the two colons trigger a error but `:SP:RBV` triggers a warning.
- [x] A warning does not stop the user from setting a block pointing to a bad PV.

### Unit tests

I added unit tests to check that the warning is triggered and that it contains the correct message.

### System tests

NA

### Documentation
None found.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

