### PR TITLE
Remove need to have diirt config files in user area

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.epics/.classpath
+++ b/base/uk.ac.stfc.isis.ibex.epics/.classpath
@@ -9,6 +9,7 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="resources"/>
 	<classpathentry kind="src" path="lib"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/base/uk.ac.stfc.isis.ibex.epics/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.epics/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Bundle-ClassPath: lib/commons-codec-1.9-javadoc.jar,
  lib/joda-time-2.3-javadoc.jar,
  lib/joda-time-2.3-sources.jar,
  lib/joda-time-2.3.jar,
- .
+ .,
+ resources/
 Require-Bundle: uk.ac.stfc.isis.ibex.logger,
  org.eclipse.ui;bundle-version="3.8.2",
  uk.ac.stfc.isis.ibex.model;bundle-version="1.0.0",
@@ -19,7 +20,9 @@ Require-Bundle: uk.ac.stfc.isis.ibex.logger,
  org.diirt.util;bundle-version="3.1.5",
  com.google.guava,
  org.diirt.datasource,
- org.csstudio.platform.libs.jdbc
+ org.csstudio.platform.libs.jdbc,
+ uk.ac.stfc.isis.ibex.e4.ui,
+ org.eclipse.equinox.registry
 Export-Package: uk.ac.stfc.isis.ibex.epics.adapters,
  uk.ac.stfc.isis.ibex.epics.conversion,
  uk.ac.stfc.isis.ibex.epics.conversion.json,

--- a/base/uk.ac.stfc.isis.ibex.epics/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.epics/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Eclipse-BundleShape: dir
 Bundle-ManifestVersion: 2
 Bundle-Name: Epics
 Bundle-SymbolicName: uk.ac.stfc.isis.ibex.epics

--- a/base/uk.ac.stfc.isis.ibex.epics/build.properties
+++ b/base/uk.ac.stfc.isis.ibex.epics/build.properties
@@ -8,4 +8,5 @@ bin.includes = META-INF/,\
                lib/commons-codec-1.9.jar,\
                lib/joda-time-2.3-javadoc.jar,\
                lib/joda-time-2.3-sources.jar,\
-               lib/joda-time-2.3.jar
+               lib/joda-time-2.3.jar,\
+               resources/

--- a/base/uk.ac.stfc.isis.ibex.epics/resources/diirt/datasources/ca/ca.xml
+++ b/base/uk.ac.stfc.isis.ibex.epics/resources/diirt/datasources/ca/ca.xml
@@ -1,0 +1,68 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<ca version="1">
+    <!--
+        Channel Access client configuration
+        ===================================
+
+        The core parameter for Channel Access are configured through
+        the JCA Context. This includes what implementation of JCA is used
+        (JCA-JNI or CAJ-PureJava) and the configuration parameters for those
+        implementations.
+
+        By default, CAJ is used with the default CAJ configuration.
+        CAJ should, by default, honor the standard EPICS environment variables
+        to configure the client. One can still override that configuration
+        by specifying the configuration properties here. Please, refer
+        to the JCA/CAJ instructions for details on these properties.
+
+        We recommend to use the CAJ (pure java) implementation, as the JCA (JNI)
+        implementation currently lacks an official maintainer.
+    -->
+
+    <!-- This examples uses the pure java implementation (CAJ) with the given
+        configuration parameters -->
+    <jcaContext pureJava="true" addr_list="" auto_addr_list="true" connection_timeout="30.0"
+                beacon_period="15.0" repeater_port="5065" server_port="5064"
+                max_array_bytes="5000000" />
+
+    <!-- This examples uses the JNI over C implementation (JCA) with the given
+        configuration parameters -->
+    <!--<jcaContext pureJava="false" preemptive_callback="true" addr_list="" auto_addr_list="true" connection_timeout="30.0"
+                beacon_period="15.0" repeater_port="5065" server_port="5064"
+                max_array_bytes="16384" />-->
+
+
+    <!--
+        Channel Access data source options
+        ===================================
+
+        The data source itself si configurable through the following parameters:
+
+        monitorMask - this allows to change what is the mask used for
+            the CA monitor. The possible values are:
+                VALUE (default) - corresponds to a monitor mask on both VALUE and ALARM
+                ARCHIVE - corresponds to a monitor mask on LOG
+                ALARM - corresponds to a monitor mask on ALARM
+                [int] - a numer corresponding to the mask itself
+        dbePropertySupported - whether to subscribe to DBE_PROPERTY to monitor
+            metadata chances. Possible values are "true" or "false". The default
+            is "false" (the safe chioce since old versions of EPICS do not handle it)
+        honorZeroPrecision - whether zero precision on numberic metadata should
+            be used or disregarded. This may be useful if too many IOCs are not
+            configured propertly. Possible values are "true" or "false". The default
+            is "true".
+        rtypeValueOnly - whether .RTYP should be monitored as value only or not.
+            this is a workaround for old IOCs. Possible values are "true" or "false".
+            The default is "false".
+        varArraySupported - whether variable length arrays are supported by
+            the client. Possible values are "auto", "true" or "false". "auto"
+            tries to detect the version of the client and act accordingly.
+            Auto detection may not work on JNI implementation.
+    -->
+
+    <!-- Example to configure the dataSource option -->
+    <!--<dataSourceOptions monitorMask="VALUE" dbePropertySupported="false"
+                       honorZeroPrecision="true" rtypValueOnly="false"
+                       varArraySupported="auto" />-->
+
+</ca>

--- a/base/uk.ac.stfc.isis.ibex.epics/resources/diirt/datasources/datasources.xml
+++ b/base/uk.ac.stfc.isis.ibex.epics/resources/diirt/datasources/datasources.xml
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataSources version="1">
+    <!-- This file controls the configuration of how the different data sources
+        are combined and made accessible to DIIRT.
+
+        The composite data source allows multiple data sources to be
+        made available by breaking up the channel name into three parts:
+            [dataSourceName][delimiter][channelName]
+        It also allows to set a default data source so that names that do not
+        match the pattern are forwarded to the datasource. Effectively:
+            [umatchedChannelName] -> [defaultDataSource][delimiter][unmatchedChannelName]
+
+        By default, the delimiter is ://
+        By default, there is no default data source. -->
+    <!--<compositeDataSource delimiter="://" />-->
+
+    <!-- This changes the default data source to Channel Access, while leaving
+        the default delimiter to :// -->
+    <compositeDataSource defaultDataSource="ca" />
+</dataSources>

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pv/ObservablePV.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pv/ObservablePV.java
@@ -39,6 +39,10 @@ public abstract class ObservablePV<T extends VType> extends ClosableObservable<T
 
 	private final PVInfo<T> info;
 
+	/**
+	 * Create a new observable PV.
+	 * @param info the parameters to create this PV with
+	 */
 	public ObservablePV(PVInfo<T> info) {
         if (info.address().contains("BLOCKSERVER:IOCS")) {
             Logger.getGlobal().info("(Ticket 2161) ObservablePV initialized looking at " + info.address());
@@ -46,6 +50,9 @@ public abstract class ObservablePV<T extends VType> extends ClosableObservable<T
 		this.info = info;
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public PVInfo<T> details() {
 		return info;

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pv/ObservablePV.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pv/ObservablePV.java
@@ -24,6 +24,7 @@ import java.util.logging.Logger;
 import org.diirt.vtype.VType;
 
 import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
+import uk.ac.stfc.isis.ibex.epics.pvmanager.PVManagerSettings;
 
 /**
  * A class for observing an EPICS process variable.
@@ -31,6 +32,10 @@ import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
  * @param <T> the PV type (must be a VType)
  */
 public abstract class ObservablePV<T extends VType> extends ClosableObservable<T> implements PV<T> {
+	
+	static {
+		PVManagerSettings.setUp();
+	}
 
 	private final PVInfo<T> info;
 

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerObservable.java
@@ -26,7 +26,6 @@ import org.diirt.datasource.PVManager;
 import org.diirt.datasource.PVReader;
 import org.diirt.datasource.PVReaderEvent;
 import org.diirt.datasource.PVReaderListener;
-import org.diirt.datasource.DataSource;
 import org.diirt.vtype.VType;
 import uk.ac.stfc.isis.ibex.epics.pv.ObservablePV;
 import uk.ac.stfc.isis.ibex.epics.pv.PVInfo;
@@ -37,6 +36,10 @@ import uk.ac.stfc.isis.ibex.epics.pv.PVInfo;
  * @param <R> the PV type (must be a VType)
  */
 public class PVManagerObservable<R extends VType> extends ObservablePV<R> {
+	
+	static {
+		PVManagerSettings.setUp();
+	}
 
     private static final int UPDATE_FREQUENCY = 10;
 
@@ -65,8 +68,6 @@ public class PVManagerObservable<R extends VType> extends ObservablePV<R> {
 	
 	public PVManagerObservable(PVInfo<R> info) {
 		super(info);
-		
-		DataSource a = PVManager.getDefaultDataSource();
 		
 		pv = PVManager
 				.read(channel(info.address(), info.type(), Object.class))

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerObservable.java
@@ -66,6 +66,10 @@ public class PVManagerObservable<R extends VType> extends ObservablePV<R> {
 		}
     };
 	
+    /**
+     * Create a new PV manager observable.
+     * @param info the parameters to create this PV with
+     */
 	public PVManagerObservable(PVInfo<R> info) {
 		super(info);
 		
@@ -76,12 +80,18 @@ public class PVManagerObservable<R extends VType> extends ObservablePV<R> {
                 .maxRate(ofHertz(UPDATE_FREQUENCY));
 	}	
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void close() {
         pv.close();
         super.close();
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public String toString() {
 		return "PVManagerObservable observing PV " + pv.getName() + " with current value: " + pv.getValue();

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerSettings.java
@@ -8,12 +8,12 @@ import uk.ac.stfc.isis.ibex.logger.IsisLog;
 /**
  * Applies settings to PV manager so that it knows where to find it's configuration.
  */
-public class PVManagerSettings {
+public final class PVManagerSettings {
     
     /**
      * Private constructor, this is a utility class.
      */
-    private PVManagerSettings() {}
+    private PVManagerSettings() { }
     
     /**
      * This is a system property that diirt uses internally to figure out where to find diirt config files.

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerSettings.java
@@ -5,27 +5,35 @@ import org.eclipse.core.runtime.FileLocator;
 
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 
+/**
+ * Applies settings to PV manager so that it knows where to find it's configuration.
+ */
 public class PVManagerSettings {
-	
-	/**
-	 * This is a system property that diirt uses internally to figure out where to find diirt config files.
-	 */
-	private static final String DIIRT_HOME_ENV_VAR = "diirt.home";
-	
-	/**
-	 * The path in the resources folder where diirt config files can be found.
-	 */
-	private static final String DIIRT_DIR = "/diirt/";
-	
-	/**
-	 * Tell PV manager to use our config files.
-	 */
-    public synchronized static void setUp() {
-		try {
-			System.setProperty(DIIRT_HOME_ENV_VAR, 
-	    		FileLocator.resolve(PVManagerSettings.class.getResource(DIIRT_DIR)).getPath());
-		} catch (IOException | RuntimeException err) {
-			IsisLog.getLogger(PVManagerSettings.class).error(err.getMessage(), err);
-		}
+    
+    /**
+     * Private constructor, this is a utility class.
+     */
+    private PVManagerSettings() {}
+    
+    /**
+     * This is a system property that diirt uses internally to figure out where to find diirt config files.
+     */
+    private static final String DIIRT_HOME_ENV_VAR = "diirt.home";
+    
+    /**
+     * The path in the resources folder where diirt config files can be found.
+     */
+    private static final String DIIRT_DIR = "/diirt/";
+    
+    /**
+     * Tell PV manager to use our config files.
+     */
+    public static synchronized void setUp() {
+        try {
+            System.setProperty(DIIRT_HOME_ENV_VAR, 
+                FileLocator.resolve(PVManagerSettings.class.getResource(DIIRT_DIR)).getPath());
+        } catch (IOException | RuntimeException err) {
+            IsisLog.getLogger(PVManagerSettings.class).error(err.getMessage(), err);
+        }
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerSettings.java
@@ -1,0 +1,31 @@
+package uk.ac.stfc.isis.ibex.epics.pvmanager;
+
+import java.io.IOException;
+import org.eclipse.core.runtime.FileLocator;
+
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+
+public class PVManagerSettings {
+	
+	/**
+	 * This is a system property that diirt uses internally to figure out where to find diirt config files.
+	 */
+	private static final String DIIRT_HOME_ENV_VAR = "diirt.home";
+	
+	/**
+	 * The path in the resources folder where diirt config files can be found.
+	 */
+	private static final String DIIRT_DIR = "/diirt/";
+	
+	/**
+	 * Tell PV manager to use our config files.
+	 */
+    public synchronized static void setUp() {
+		try {
+			System.setProperty(DIIRT_HOME_ENV_VAR, 
+	    		FileLocator.resolve(PVManagerSettings.class.getResource(DIIRT_DIR)).getPath());
+		} catch (IOException | RuntimeException err) {
+			IsisLog.getLogger(PVManagerSettings.class).error(err.getMessage(), err);
+		}
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/package-info.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of the ISIS IBEX application. Copyright (C) 2012-2017
+ * Science & Technology Facilities Council. All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful. This program
+ * and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution. EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM AND
+ * ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND. See the Eclipse Public License v1.0 for more
+ * details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0 along with
+ * this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * Classes to interact with PV manager.
+ */
+package uk.ac.stfc.isis.ibex.epics.pvmanager;


### PR DESCRIPTION
### Description of work

Removes need to have channel access config files in user area

To do this I've put them in a resources folder and then poked PV manager to use these files as opposed to it's default ones

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3311

### Acceptance criteria

- Delete `.diirt` folder from `C:\Users\<name>\`
- Check that if you build E4 via the IDE, you can still talk to PVs
- Check that if you build E4 via the batch script, you can still talk to PVs

### Unit tests

None - this is setting PV manager preferences / system environment variables, no testable logic

### System tests

Yes, they should work (even after we remove .diirt on the squish server).

### Documentation

When merged I will remove section in documentation that talks about how to set up channel access for E4.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

