### PR TITLE
Disallowed opening OPIs from synoptic preview.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/instrument/SynopticPreview.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/instrument/SynopticPreview.java
@@ -42,6 +42,14 @@ import uk.ac.stfc.isis.ibex.ui.synoptic.widgets.SynopticPanel;
 public class SynopticPreview extends Dialog {
 	private final SynopticModel model;
 
+	/**
+	 * The synoptic preview creator.
+	 * 
+	 * @param parent
+	 *             The shell in which the preview is created.
+	 * @param instrumentDescription
+	 *             A description of the devices present in the current synoptic on the instrument. 
+	 */
 	public SynopticPreview(Shell parent,
 			SynopticDescription instrumentDescription) {
 		super(parent);
@@ -59,7 +67,7 @@ public class SynopticPreview extends Dialog {
 		Composite container = (Composite) super.createDialogArea(parent);
 		container.setLayout(new FillLayout());
 		SynopticPanel instrument = new SynopticPanel(container,
-				SWT.NONE);
+				SWT.NONE, true);
 		instrument.setComponents(model.instrument().components(), model.instrument().showBeam());
 
 		return instrument;

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticPresenter.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticPresenter.java
@@ -100,12 +100,10 @@ public class SynopticPresenter extends ModelObject {
      */
 	public SynopticPresenter() {
 		model = Synoptic.getInstance().currentViewerModel();
-
 		navigator = new NavigationPresenter(model.instrumentGraph().head());
 		navigator.addPropertyChangeListener("currentTarget", navigationListener);
 
 		updateModel(); 
-		
 		// Must be done after the navigator is initialised otherwise updateModel could
 		// trigger a nullPointer exception.
 		
@@ -253,7 +251,6 @@ public class SynopticPresenter extends ModelObject {
 		if (currentTarget instanceof GroupedComponentTarget) {
             displayGroupTarget((GroupedComponentTarget) currentTarget);
 		}
-
 		if (currentTarget instanceof OpiTarget) {
             try {
                 SynopticOpiTargetView.displayOpi((OpiTarget) currentTarget);

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/beamline/BeamlineComposite.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/beamline/BeamlineComposite.java
@@ -41,6 +41,7 @@ public abstract class BeamlineComposite extends Composite  {
     protected CLabel nameLabel;
     private SynopticPresenter presenter = Activator.getDefault().presenter();
     private final Cursor handCursor = SWTResourceManager.getCursor(SWT.CURSOR_HAND);
+    private boolean isPreview;
 
     /**
      * The default constructor for the composite.
@@ -101,10 +102,22 @@ public abstract class BeamlineComposite extends Composite  {
             @Override
             public void handleEvent(Event event) {
                 if (presenter.isValidTarget(target)) {
-                    presenter.navigateTo(target);
+                    if (!isPreview) {
+                        presenter.navigateTo(target);
+                    }
                 }
             }
         });
+    }
+    
+    /**
+     * Sets whether or not the beamline composite is created in the synoptic preview menu.
+     * 
+     * @param isPreview
+     *                  True if the beamline composite is created in the synoptic preview menu
+     */
+    public void setIsPreview(boolean isPreview) {
+        this.isPreview = isPreview;
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/beamline/BeamlineCompositeContainer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/beamline/BeamlineCompositeContainer.java
@@ -36,14 +36,23 @@ public class BeamlineCompositeContainer extends BeamlineComposite {
 	private final GridLayout grid = new GridLayout(1, false);
 	
 	private int targetLineHeight;
+	private boolean isPreview;
 	
-	/*
-	 * Composite for storing beamline components. 
+	/**
+	 * Composite for storing beamline components.
+	 * 
+	 * @param parent
+	 *             The parent this composite belongs too.
+	 * @param style
+	 *             The SWT style display.
+	 * @param isPreview
+	 *             True if this composite was created in the synoptic preview.
 	 */
-	public BeamlineCompositeContainer(Composite parent, int style) {
+	public BeamlineCompositeContainer(Composite parent, int style, boolean isPreview) {
 		super(parent, style);
 		
 		super.setLayout(grid);
+		this.isPreview = isPreview;
 		grid.marginHeight = 0;
 		grid.verticalSpacing = 0;
 		setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
@@ -55,6 +64,7 @@ public class BeamlineCompositeContainer extends BeamlineComposite {
 	}
 
 	public void registerBeamlineTarget(BeamlineComposite target) {
+	    target.setIsPreview(isPreview);
 		targets.add(target);		
 		setTargetSize(target);
 		grid.numColumns = targets.size();

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/BasicComponent.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/BasicComponent.java
@@ -36,23 +36,27 @@ import uk.ac.stfc.isis.ibex.ui.synoptic.beamline.BeamlineComposite;
 
 
 /**
- * A basic beamline component that.
+ * A basic beam line component.
  */
 @SuppressWarnings("checkstyle:magicnumber")
 public class BasicComponent extends BeamlineComposite {
 
 	private Label image;
 	private Composite propertiesComposite;
+	private boolean isPreview;
 	
     /**
      * Constructor for this component.
      * 
      * @param parent
      *            The parent that holds the component.
+     * @param isPreview
+     *              If the component has been created by the synoptic preview.
      */
-	public BasicComponent(Composite parent) {
+	public BasicComponent(Composite parent, boolean isPreview) {
 		super(parent, SWT.NONE);
 		
+		this.isPreview = isPreview;
 		GridLayout gd = new GridLayout(1, false);
 		gd.marginHeight = 0;
 		gd.marginWidth = 0;
@@ -107,8 +111,7 @@ public class BasicComponent extends BeamlineComposite {
 		if (component.properties().isEmpty()) {
 			return;
 		}
-		
-		ComponentPropertiesView propertiesView = new ComponentPropertiesView(propertiesComposite, component);
+		ComponentPropertiesView propertiesView = new ComponentPropertiesView(propertiesComposite, component, isPreview);
 		
 		propertiesView.pack();
 		GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/ComponentPropertiesView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/ComponentPropertiesView.java
@@ -35,9 +35,20 @@ import uk.ac.stfc.isis.ibex.synoptic.model.WritableComponentProperty;
 
 @SuppressWarnings("checkstyle:magicnumber")
 public class ComponentPropertiesView extends Composite {
-		
-	public ComponentPropertiesView(Composite parent, Component component) {
+    
+    private boolean isPreview;
+	/**
+	 * The view for the component properties in the synoptic displays.
+	 * @param parent
+	 *             The parent this view belongs too.
+	 * @param component
+	 *             The component whose properties are to be displayed.
+	 * @param isPreview
+	 *             True if the synoptic display has been created in the synoptic preview.
+	 */
+	public ComponentPropertiesView(Composite parent, Component component, boolean isPreview) {
 		super(parent, SWT.BORDER);
+		this.isPreview = isPreview;
 		GridLayout gridLayout = new GridLayout(1, false);
 		gridLayout.verticalSpacing = 1;
 		gridLayout.marginWidth = 0;
@@ -96,7 +107,7 @@ public class ComponentPropertiesView extends Composite {
 	}
 
 	private void createWriter(WritableComponentProperty property, boolean displayPropertyName) {
-		WritableComponentView propertyView = new WritableComponentView(this, property, displayPropertyName);
+		WritableComponentView propertyView = new WritableComponentView(this, property, displayPropertyName, isPreview);
 		setViewSize(propertyView);
 	}		
 

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/ComponentView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/ComponentView.java
@@ -33,22 +33,22 @@ public final class ComponentView {
 	
 	private ComponentView() { }
 
-	public static BeamlineComposite create(BeamlineCompositeContainer parent, Component component) {
+	public static BeamlineComposite create(BeamlineCompositeContainer parent, Component component, boolean isPreview) {
 		BeamlineComposite target = component.components().isEmpty() 
-									? createBasicComponent(parent, component) 
-									: createGroupView(parent, component);
+									? createBasicComponent(parent, component, isPreview) 
+									: createGroupView(parent, component, isPreview);
 				
 		parent.registerBeamlineTarget(target);
 		
 		return target;
 	}
 
-	private static GroupView createGroupView(Composite parent, Component component) {
-		return new GroupView(parent, component);
+	private static GroupView createGroupView(Composite parent, Component component, boolean isPreview) {
+		return new GroupView(parent, component, isPreview);
 	}
 
-	private static BasicComponent createBasicComponent(Composite parent, Component component) {
-		BasicComponent componentView = new BasicComponent(parent);
+	private static BasicComponent createBasicComponent(Composite parent, Component component, boolean isPreview) {
+		BasicComponent componentView = new BasicComponent(parent, isPreview);
 		componentView.setName(component.name());
         componentView.setImage(ComponentIcons.iconForType(component.type()));
 		componentView.setProperties(component);

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/GroupView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/GroupView.java
@@ -38,13 +38,14 @@ public class GroupView extends BeamlineComposite {
 	private Composite groupPropertiesComposite;
 	private BeamlineCompositeContainer groupComponents;
 	private Component component;
+	private boolean isPreview;
 	
 	/**
      * @param parent
      *            The parent component
      */
 	public GroupView(Composite parent) {
-		this(parent, null);
+		this(parent, null, false);
 	}
 	
     /**
@@ -54,8 +55,11 @@ public class GroupView extends BeamlineComposite {
      *            The parent composite that this belongs to.
      * @param component
      *            The component that this view points to.
+     * @param isPreview
+     *              True if this view is created in the synoptic preview.
+     *      
      */
-	public GroupView(Composite parent, Component component) {
+	public GroupView(Composite parent, Component component, boolean isPreview) {
 		super(parent, SWT.NONE);
 		GridLayout gridLayout = new GridLayout(1, false);
 		gridLayout.verticalSpacing = 0;
@@ -77,7 +81,7 @@ public class GroupView extends BeamlineComposite {
         nameLabel.setAlignment(SWT.CENTER);
         nameLabel.setBackground(SWTResourceManager.getColor(111, 94, 230));
 		
-		groupComponents = new BeamlineCompositeContainer(this, SWT.NONE);
+		groupComponents = new BeamlineCompositeContainer(this, SWT.NONE, isPreview);
 		
 		if (component != null) {
             setName(component.name());
@@ -120,7 +124,7 @@ public class GroupView extends BeamlineComposite {
 	}
 
 	private void addPropertiesView(Component component) {
-		ComponentPropertiesView propertiesView = new ComponentPropertiesView(groupPropertiesComposite, component);
+		ComponentPropertiesView propertiesView = new ComponentPropertiesView(groupPropertiesComposite, component, isPreview);
 		
 		propertiesView.pack();
 		GridData gd = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
@@ -131,7 +135,7 @@ public class GroupView extends BeamlineComposite {
 
 	private void setComponents(Component component) {
 		for (Component child : component.components()) {
-			BeamlineComposite view = ComponentView.create(groupComponents, child);
+			BeamlineComposite view = ComponentView.create(groupComponents, child, isPreview);
 			groupComponents.registerBeamlineTarget(view);
 		}
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
@@ -54,13 +54,12 @@ public class WritableComponentView extends Composite {
 	private Text text;
 	private Composite composite;
 	
-	
 	private final WritableComponentProperty property;
 	
 	private final ModifyListener textModifyListener = new ModifyListener() {
 		@Override
 		public void modifyText(ModifyEvent e) {
-			
+		    
 		}
 	};
 	
@@ -71,7 +70,7 @@ public class WritableComponentView extends Composite {
      *            The property of the component that is writable
      */
 	public WritableComponentView(Composite parent, final WritableComponentProperty property) {
-		this(parent, property, true);
+		this(parent, property, true, true);
 	}
 	
 	/**
@@ -80,8 +79,9 @@ public class WritableComponentView extends Composite {
 	 * @param parent A widget which will be the parent of the new instance (cannot be null)
 	 * @param property The property of the component that is writable
 	 * @param displayName True if the property name should be displayed
+	 * @param isPreview False if the property text can be modified (ie if the view is created in a the synoptic preview).
 	 */
-	public WritableComponentView(Composite parent, final WritableComponentProperty property, boolean displayName) {
+	public WritableComponentView(Composite parent, final WritableComponentProperty property, boolean displayName, final boolean isPreview) {
 		super(parent, SWT.NONE);
 		setLayout(new FillLayout(SWT.VERTICAL));
 		
@@ -131,8 +131,9 @@ public class WritableComponentView extends Composite {
 			@Override
 			public void handleEvent(Event event) {
 				if (event.detail == SWT.TRAVERSE_RETURN) {
-					sendValue();
-					
+				    if (!isPreview) {
+				        sendValue();
+				    }
 				}
 			}
 		});

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
@@ -70,7 +70,7 @@ public class WritableComponentView extends Composite {
      *            The property of the component that is writable
      */
 	public WritableComponentView(Composite parent, final WritableComponentProperty property) {
-		this(parent, property, true, true);
+		this(parent, property, true, false);
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/views/SynopticView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/views/SynopticView.java
@@ -32,7 +32,7 @@ import uk.ac.stfc.isis.ibex.ui.synoptic.SynopticPresenter;
 import uk.ac.stfc.isis.ibex.ui.synoptic.widgets.SynopticPanel;
 
 /**
- * Provides the containing view for they synopitc.
+ * Provides the containing view for they synoptic.
  * 
  */
 public class SynopticView extends ViewPart {
@@ -50,7 +50,7 @@ public class SynopticView extends ViewPart {
 
 	@Override
 	public void createPartControl(Composite parent) {		
-        instrument = new SynopticPanel(parent, SWT.NONE);
+        instrument = new SynopticPanel(parent, SWT.NONE, false);
         instrument.setComponents(presenter.components(), presenter.showBeam());
 
         presenter.addPropertyChangeListener(COMPONENTS_CHANGE, new PropertyChangeListener() {

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/widgets/SynopticPanel.java
@@ -46,10 +46,12 @@ public class SynopticPanel extends Composite {
 	private BeamlineCompositeContainer instrumentComposite;
 	private LineDecoration beamline;
 	private ScrolledComposite scrolledComposite;
+	private boolean isPreview;
 	
-    public SynopticPanel(Composite parent, int style) {
+    public SynopticPanel(Composite parent, int style, boolean isPreview) {
 		super(parent, style);
 		setLayout(new FillLayout(SWT.VERTICAL));
+		this.isPreview = isPreview;
 
 		scrolledComposite = new ScrolledComposite(this, SWT.NONE | SWT.H_SCROLL | SWT.V_SCROLL);
 		scrolledComposite.setExpandHorizontal(true);
@@ -77,7 +79,7 @@ public class SynopticPanel extends Composite {
 
 	private void reset() {
 		clearInstrument();
-		instrumentComposite = new BeamlineCompositeContainer(scrolledComposite, SWT.NONE);
+		instrumentComposite = new BeamlineCompositeContainer(scrolledComposite, SWT.NONE, isPreview);
 		scrolledComposite.setContent(instrumentComposite);
 	}
 	
@@ -97,7 +99,7 @@ public class SynopticPanel extends Composite {
 		}
 		
 		for (Component component : components) {
-			ComponentView.create(instrumentComposite, component);
+			ComponentView.create(instrumentComposite, component, isPreview);
 		}
 		
 		if (showBeam) {


### PR DESCRIPTION
### Description of work

The OPIs now cannot be opened from the synoptic preview. Similarly, changing the value of a writable PV in the synoptic preview changes its value in the preview but doesn't write the value to the PV. This ticket involved passing a boolean from the point where the synoptic was created to where the OPIs could be opened or where the PVs could be modified.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2583

### Acceptance criteria

- [x] Clicking a component in the synoptic preview doesn't open an OPI.
- [x] Changing the value of a writable PV in the synoptic preview changes its value in the preview but doesn't write the value to the PV.
- [x] The above functionality still works in the synoptic and device screens perspectives.

N.B.: To write to a PV you must press `ENTER` after filling in the writable text box. 

### Unit tests

None required.

### System tests

None required.

### Documentation
None related.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

