### PR TITLE
Ticket3080 open logplotter properties

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -55,13 +55,16 @@
     </mainMenu>
     <sharedElements xsi:type="basic:Part" xmi:id="_RgW1RIjKEee8_tONW2Z5Qw" elementId="uk.ac.stfc.isis.ibex.e4.client.part.dashboard" containerData="40" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.dashboard/uk.ac.stfc.isis.ibex.ui.dashboard.views.DashboardView" label="Instrument status"/>
     <sharedElements xsi:type="basic:Part" xmi:id="_RgW1RojKEee8_tONW2Z5Qw" elementId="uk.ac.stfc.isis.ibex.e4.client.part.blocks" containerData="60" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.blocks/uk.ac.stfc.isis.ibex.ui.blocks.views.BlocksView" label="Blocks"/>
-    <sharedElements xsi:type="advanced:Area" xmi:id="_yi1esNadEeekLPLQ_9IvJQ" elementId="uk.ac.stfc.isis.ibex.e4.client.area.0" selectedElement="_ZX9AENacEeekLPLQ_9IvJQ" label="Log Plotter Area">
-      <children xsi:type="basic:PartStack" xmi:id="_ZX9AENacEeekLPLQ_9IvJQ" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.19" selectedElement="_KUbkENZ8EeekLPLQ_9IvJQ">
+    <sharedElements xsi:type="basic:PartSashContainer" xmi:id="_Z43_UIUFEeiCJ_qZ_3IIBQ" elementId="uk.ac.stfc.isis.ibex.e4.client.partsashcontainer.5" horizontal="true">
+      <children xsi:type="basic:PartStack" xmi:id="_ZX9AENacEeekLPLQ_9IvJQ" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.19" containerData="50" selectedElement="_KUbkENZ8EeekLPLQ_9IvJQ">
         <tags>newtablook</tags>
         <tags>org.eclipse.e4.primaryDataStack</tags>
         <tags>EditorStack</tags>
         <tags>NoAutoCollapse</tags>
         <children xsi:type="basic:Part" xmi:id="_KUbkENZ8EeekLPLQ_9IvJQ" elementId="uk.ac.stfc.isis.ibex.ui.logplotter.EmptyLogPlotterView" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Log Plotter"/>
+      </children>
+      <children xsi:type="basic:PartStack" xmi:id="_dPCC0IUFEeiCJ_qZ_3IIBQ" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.32" toBeRendered="false" containerData="50">
+        <children xsi:type="basic:Part" xmi:id="_doSQUIUFEeiCJ_qZ_3IIBQ" elementId="org.eclipse.ui.views.PropertySheet" toBeRendered="false" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" closeable="true"/>
       </children>
     </sharedElements>
     <trimBars xmi:id="_-fkTUGMWEeecC_eSNHqaWg" elementId="uk.ac.stfc.isis.ibex.e4.client.trimbar.0" side="Left">
@@ -331,7 +334,7 @@
         </children>
       </children>
       <children xsi:type="basic:PartSashContainer" xmi:id="_qNDzkKkLEeeMv9D6qSjWOQ" elementId="uk.ac.stfc.isis.ibex.client.e4.product.partsashcontainer.9" containerData="70" horizontal="true">
-        <children xsi:type="advanced:Placeholder" xmi:id="_W1z3wNUNEeeRPIKhqhrQWA" elementId="org.eclipse.ui.editorss" ref="_yi1esNadEeekLPLQ_9IvJQ"/>
+        <children xsi:type="advanced:Placeholder" xmi:id="_W1z3wNUNEeeRPIKhqhrQWA" elementId="org.eclipse.ui.editorss" ref="_Z43_UIUFEeiCJ_qZ_3IIBQ"/>
       </children>
     </children>
   </snippets>

--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -61,10 +61,19 @@
         <tags>org.eclipse.e4.primaryDataStack</tags>
         <tags>EditorStack</tags>
         <tags>NoAutoCollapse</tags>
-        <children xsi:type="basic:Part" xmi:id="_KUbkENZ8EeekLPLQ_9IvJQ" elementId="uk.ac.stfc.isis.ibex.ui.logplotter.EmptyLogPlotterView" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Log Plotter"/>
+        <children xsi:type="basic:Part" xmi:id="_KUbkENZ8EeekLPLQ_9IvJQ" elementId="uk.ac.stfc.isis.ibex.ui.logplotter.EmptyLogPlotterView" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Log Plotter">
+          <menus xmi:id="_GBWhoIUNEeiCJ_qZ_3IIBQ" elementId="uk.ac.stfc.isis.ibex.e4.client.menu.0">
+            <tags>ViewMenu</tags>
+            <children xsi:type="menu:HandledMenuItem" xmi:id="_HOx-EIUNEeiCJ_qZ_3IIBQ" elementId="uk.ac.stfc.isis.ibex.e4.client.handledmenuitem.fred" label="fred" iconURI="platform:/plugin/uk.ac.stfc.isis.ibex.ui.dae/icons/setup.png" command="_hj--kKkDEeeNUPQOsQF40g"/>
+          </menus>
+        </children>
       </children>
       <children xsi:type="basic:PartStack" xmi:id="_dPCC0IUFEeiCJ_qZ_3IIBQ" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.32" toBeRendered="false" containerData="50">
         <children xsi:type="basic:Part" xmi:id="_doSQUIUFEeiCJ_qZ_3IIBQ" elementId="org.eclipse.ui.views.PropertySheet" toBeRendered="false" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" closeable="true"/>
+        <children xsi:type="basic:Part" xmi:id="_TGckEIUXEeiCJ_qZ_3IIBQ" elementId="org.csstudio.trends.databrowser.archiveview.ArchiveView" toBeRendered="false" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" closeable="true"/>
+        <children xsi:type="basic:Part" xmi:id="_f1vhMIUXEeiCJ_qZ_3IIBQ" elementId="org.csstudio.trends.databrowser.sample_view" toBeRendered="false" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" closeable="true"/>
+        <children xsi:type="basic:Part" xmi:id="_f7OeIIUXEeiCJ_qZ_3IIBQ" elementId="org.csstudio.trends.databrowser.exportview.ExportView" toBeRendered="false" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" closeable="true"/>
+        <children xsi:type="basic:Part" xmi:id="_gYr2MIUXEeiCJ_qZ_3IIBQ" elementId="org.csstudio.trends.databrowser.waveformview.WaveformView" toBeRendered="false" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" closeable="true"/>
       </children>
     </sharedElements>
     <trimBars xmi:id="_-fkTUGMWEeecC_eSNHqaWg" elementId="uk.ac.stfc.isis.ibex.e4.client.trimbar.0" side="Left">

--- a/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
@@ -46,7 +46,7 @@ uk.ac.stfc.isis.ibex.preferences/instrument_scientist_password=reliablebeam
 ## Data Browser
 ## NOTE: this preference will get the currently selected instrument appened to it by the Client
 org.csstudio.trends.databrowser2/urls=jdbc:mysql://localhost/archive*jdbc:mysql://130.246.39.152/archive
-org.csstudio.trends.databrowser2/use_auto_scale=true
+org.csstudio.trends.databrowser2/use_auto_scale=false
 
 # Default data sources for newly added channels
 # Format:  <name>|<key>|<url>

--- a/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
@@ -15,6 +15,11 @@ org.csstudio.platform.libs.epics/conn_tmo=30.0
 
 # OPI Builder
 org.csstudio.opibuilder/pv_connection_layer=pvmanager
+org.csstudio.opibuilder/switch_to_opi_editor_perspective=false
+org.csstudio.opibuilder/no_edit=true
+org.csstudio.opibuilder/show_compact_mode_dialog=false
+org.csstudio.opibuilder/show_fullscreen_dialog=false
+org.csstudio.opibuilder/popup_console=NO_POP
 
 org.csstudio.utility.pvmanager.loc/zero_initialization=true
 
@@ -39,11 +44,6 @@ uk.ac.stfc.isis.ibex.preferences/instrument_scientist_password=reliablebeam
 
 
 ## Data Browser
-# Removal of these settings results in empty defaults
-# URLs to suggest in the "Archives" view
-# SNS 'Office' users use CMAN
-#org.csstudio.trends.databrowser2/urls=jdbc:mysql://172.23.244.65/archive*xnds://ics-srv-testf1.sns.ornl.gov/archive/cgi/ArchiveDataServer.cgi
-#org.csstudio.trends.databrowser2/urls=jdbc:mysql://localhost/archive*jdbc:mysql://130.246.55.141/archive
 ## NOTE: this preference will get the currently selected instrument appened to it by the Client
 org.csstudio.trends.databrowser2/urls=jdbc:mysql://localhost/archive*jdbc:mysql://130.246.39.152/archive
 org.csstudio.trends.databrowser2/use_auto_scale=true

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.ui,
  org.csstudio.ui.util,
  org.csstudio.trends.databrowser2;bundle-version="4.2.4",
  org.diirt.datasource;bundle-version="3.1.7",
- org.diirt.vtype;bundle-version="3.1.7"
+ org.diirt.vtype;bundle-version="3.1.7",
+ org.eclipse.ui.workbench
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.ui.logplotter

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/plugin.xml
@@ -2,14 +2,6 @@
 <?eclipse version="3.4"?>
 <plugin>
    <extension
-         point="org.eclipse.ui.perspectives">
-      <perspective
-            class="uk.ac.stfc.isis.ibex.ui.logplotter.Perspective"
-            id="uk.ac.stfc.isis.ibex.ui.logplotter.perspective"
-            name="Log Plotter">
-      </perspective>
-   </extension>
-   <extension
          point="uk.ac.stfc.isis.ibex.ui.blocks.presentation">
       <PVHistoryPresenter
             class="uk.ac.stfc.isis.ibex.ui.logplotter.LogPlotterHistoryPresenter">

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/plugin.xml
@@ -10,9 +10,6 @@
       </perspective>
    </extension>
    <extension
-         point="org.eclipse.ui.perspectiveExtensions">
-   </extension>
-   <extension
          point="uk.ac.stfc.isis.ibex.ui.blocks.presentation">
       <PVHistoryPresenter
             class="uk.ac.stfc.isis.ibex.ui.logplotter.LogPlotterHistoryPresenter">
@@ -37,7 +34,7 @@
       <command
             defaultHandler="uk.ac.stfc.isis.ibex.ui.logplotter.OpenLogPlotterPopup"
             id="uk.ac.stfc.isis.ibex.ui.logplotter.OpenLogPlotterPopup"
-            name="%LogPlotter">
+            name="%Databrowser">
       </command>
    </extension>
    <extension

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/EmptyLogPlotterView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/EmptyLogPlotterView.java
@@ -22,6 +22,9 @@ public class EmptyLogPlotterView extends ViewPart {
      */
     public static final String ID = "uk.ac.stfc.isis.ibex.ui.logplotter.EmptyLogPlotterView";
 	
+    /**
+     * {@inheritDoc}
+     */
 	@Override
 	public void createPartControl(Composite parent) {
 		parent.setLayout(new GridLayout(1, false));
@@ -37,9 +40,12 @@ public class EmptyLogPlotterView extends ViewPart {
 		
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void setFocus() {
-		
+		// no action required
 	}
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterHistoryPresenter.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterHistoryPresenter.java
@@ -72,14 +72,14 @@ public class LogPlotterHistoryPresenter implements PVHistoryPresenter {
 	    }
 		Model model = editor.getModel();
 		model.setSaveChanges(false);
-		model.setArchiveRescale(ArchiveRescale.STAGGER);
+		model.setArchiveRescale(ArchiveRescale.NONE);
 		
 		// Add received items
 	    final double period = Preferences.getScanPeriod();
 	    try {
 	    	// Create axis
 			AxisConfig axis = new AxisConfig(displayName);
-			axis.setAutoScale(true);
+			axis.setAutoScale(false);
 			model.addAxis(axis);
 	    	
 			// Create trace

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterHistoryPresenter.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterHistoryPresenter.java
@@ -39,7 +39,6 @@ import org.eclipse.osgi.util.NLS;
 import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.PlatformUI;
 
-import uk.ac.stfc.isis.ibex.ui.UI;
 import uk.ac.stfc.isis.ibex.ui.blocks.presentation.PVHistoryPresenter;
 
 /**
@@ -58,6 +57,9 @@ public class LogPlotterHistoryPresenter implements PVHistoryPresenter {
 						 .map(e -> (DataBrowserEditor) e);
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public ArrayList<String> getCurrentDisplays() {
 		return getCurrentDataBrowsers().map(e -> e.getTitle())
@@ -95,6 +97,9 @@ public class LogPlotterHistoryPresenter implements PVHistoryPresenter {
 	    }
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void newDisplay(String pvAddress, final String displayName) {		
 	    // Create new editor
@@ -108,6 +113,9 @@ public class LogPlotterHistoryPresenter implements PVHistoryPresenter {
 	    addPVToEditor(pvAddress, displayName, editor);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void addToDisplay(String pvAddress, String display, String presenterName) {
 		List<DataBrowserEditor> editors = getCurrentDataBrowsers().filter(e -> e.getTitle().equals(presenterName))

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
@@ -1,0 +1,33 @@
+/*
+* This file is part of the ISIS IBEX application.
+* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* All rights reserved.
+*
+* This program is distributed in the hope that it will be useful.
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v1.0 which accompanies this distribution.
+* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+*
+* You should have received a copy of the Eclipse Public License v1.0
+* along with this program; if not, you can obtain a copy from
+* https://www.eclipse.org/org/documents/epl-v10.php or 
+* http://opensource.org/licenses/eclipse-1.0.php
+*/
+
+package uk.ac.stfc.isis.ibex.ui.logplotter;
+
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+
+/**
+ * This class is needed to display OPI PVs in the databrowser.
+ */
+public class OpenLogPlotterPopup extends org.csstudio.trends.databrowser2.OpenDataBrowserPopup {
+
+	@Override
+    public Object execute(final ExecutionEvent event) throws ExecutionException {       
+		return super.execute(event);
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
@@ -20,14 +20,44 @@ package uk.ac.stfc.isis.ibex.ui.logplotter;
 
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.IPerspectiveRegistry;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
 
 /**
  * This class is needed to display OPI PVs in the databrowser.
  */
 public class OpenLogPlotterPopup extends org.csstudio.trends.databrowser2.OpenDataBrowserPopup {
+	
+	private static final String LOG_PLOTTER_PERSPECTIVE_ID = "uk.ac.stfc.isis.ibex.client.e4.product.perspective.logplotter";
 
+	/**
+	 * Override CSStudio command to switch to log plotter perspective first, before adding items to databrowser.
+	 */
 	@Override
-    public Object execute(final ExecutionEvent event) throws ExecutionException {       
-		return super.execute(event);
+    public Object execute(final ExecutionEvent event) {       
+		try {
+			switchToLogPlotter();
+			return super.execute(event);
+		} catch (ExecutionException | RuntimeException e) {
+			IsisLog.getLogger(getClass()).error(e.getMessage(), e);
+			return null;
+		}
     }
+	
+	/**
+	 * This is a bit of a hack to switch perspectives in a way that is compatible with both E4 and the E3 compatibility layer.
+	 * 
+	 * Can't use our normal perspective provider as that requires dependency injection, which we can't use with E3-style extension
+	 * points. Can't move away from E3 extension points as this is what the CSStudio view uses.
+	 */
+	private static void switchToLogPlotter() {
+		final IWorkbench workbench = PlatformUI.getWorkbench();
+        final IPerspectiveRegistry registry = workbench.getPerspectiveRegistry();
+        final IWorkbenchPage page = workbench.getActiveWorkbenchWindow().getActivePage();
+        page.setPerspective(registry.findPerspectiveWithId(LOG_PLOTTER_PERSPECTIVE_ID));
+	}
 }


### PR DESCRIPTION
### Description of work

I had a look at adding an extra tool item to open the properties pane - this is not easy, the code is buried in an "internal" CSS class (see [here](https://github.com/ControlSystemStudio/cs-studio/blob/master/applications/appunorganized/appunorganized-plugins/org.csstudio.rap.rtplot/src/org/csstudio/swt/rtplot/internal/ToolbarHandler.java)).

However, I have made the properties screen open in a sensible way from the right click context menu. at the same time I also made all the other items in that context menu open in sensible places. The only one I was unable to "fix" was "Open data browser perspective", which is hard-wired to CSS's data browser perspective. Luckily it is easy for our users to get back out of this state - clicking on any IBEX perspective will take them back to a known view.

https://github.com/ISISComputingGroup/IBEX/issues/3080

### Acceptance criteria

- Open the log plotter properties in a sensible place
- For each item in the right click context menu on a log plotter graph, check that it opens in a sensible place
  * exception: "Data browser perspective" will still open a CSS perspective. This option is hard to remove. However, check that it is easy for a user to get out of this state.
- Right clicking on a block to send it to the log plotter works and creates graphs in sensible places
- Right clicking on a PV in an OPI works and creates graphs in sensible places

### Unit tests

None. This change is in the layer that interacts heavily with CSS/Eclipse. This makes it hard to unit test.


### Documentation

Once this is merged, I will update the user manual (there are reasonably significant user-interface changes to the log plotter, we should make these very clear)

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

