### PR TITLE
The drop down menu now displays default synoptic when editing configs.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
@@ -51,15 +51,15 @@ import uk.ac.stfc.isis.ibex.validators.SummaryDescriptionValidator;
  */
 @SuppressWarnings("checkstyle:magicnumber")
 public class SummaryPanel extends Composite {
-	private Text txtName;
-	private Text txtDescription;
+    private Text txtName;
+    private Text txtDescription;
     private Label lblDateCreated;
-	private Label lblDateCreatedField;
+    private Label lblDateCreatedField;
     private Label lblDateModified;
-	private Label lblDateModifiedField;
+    private Label lblDateModifiedField;
     private Label lblSynoptic;
-	private ComboViewer cmboSynoptic;
-	private EditableConfiguration config;
+    private ComboViewer cmboSynoptic;
+    private EditableConfiguration config;
     private final MessageDisplayer messageDisplayer;
 
     /**
@@ -73,171 +73,177 @@ public class SummaryPanel extends Composite {
      *            The message displayer used to show error messages to the user.
      */
     public SummaryPanel(Composite parent, int style, MessageDisplayer dialog) {
-		super(parent, style);
+        super(parent, style);
 
         messageDisplayer = dialog;
-		setLayout(new FillLayout(SWT.HORIZONTAL));
-		
+        setLayout(new FillLayout(SWT.HORIZONTAL));
+
         Composite cmpSummary = new Composite(this, SWT.NONE);
         cmpSummary.setLayout(new GridLayout(2, false));
 
         Label lblName = new Label(cmpSummary, SWT.NONE);
-		lblName.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-		lblName.setText("Name:");
-		
+        lblName.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblName.setText("Name:");
+
         txtName = new Text(cmpSummary, SWT.BORDER);
-		txtName.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		
+        txtName.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+
         Label lblDescription = new Label(cmpSummary, SWT.NONE);
-		lblDescription.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-		lblDescription.setText("Description:");
-		
+        lblDescription.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblDescription.setText("Description:");
+
         txtDescription = new Text(cmpSummary, SWT.BORDER);
-		txtDescription.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		txtDescription.setTextLimit(39);
-		
+        txtDescription.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+        txtDescription.setTextLimit(39);
+
         lblSynoptic = new Label(cmpSummary, SWT.NONE);
-		lblSynoptic.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-		lblSynoptic.setText("Synoptic:");
-		
+        lblSynoptic.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblSynoptic.setText("Synoptic:");
+
         cmboSynoptic = new ComboViewer(cmpSummary, SWT.READ_ONLY);
-		cmboSynoptic.getCombo().setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
-		cmboSynoptic.setContentProvider(new ArrayContentProvider());
-		
+        cmboSynoptic.getCombo().setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+        cmboSynoptic.setContentProvider(new ArrayContentProvider());
+
         lblDateCreated = new Label(cmpSummary, SWT.NONE);
-		lblDateCreated.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-		lblDateCreated.setText("Date Created:");
-		
+        lblDateCreated.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblDateCreated.setText("Date Created:");
+
         lblDateCreatedField = new Label(cmpSummary, SWT.NONE);
-				
+
         lblDateModified = new Label(cmpSummary, SWT.NONE);
-		lblDateModified.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-		lblDateModified.setText("Date Modified:");
-		
+        lblDateModified.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+        lblDateModified.setText("Date Modified:");
+
         lblDateModifiedField = new Label(cmpSummary, SWT.NONE);
-	}
-	
+    }
+
     /**
      * Sets the configuration that the panel information relates to.
      * 
      * @param config
      *            The configuration that the panel relates to.
      */
-	public void setConfig(EditableConfiguration config) {
-		this.config = config;
-		setBindings();
-	}
+    public void setConfig(EditableConfiguration config) {
+        this.config = config;
+        setBindings();
+    }
 
-	private void setBindings() {
+    private void setBindings() {
         DataBindingContext bindingContext = new DataBindingContext();
-		
-		UpdateValueStrategy descValidator = new UpdateValueStrategy();
+
+        UpdateValueStrategy descValidator = new UpdateValueStrategy();
         // Set validator if not saving a new config
         if (!config.getIsNew()) {
-            BlockServerNameValidator configDescriptionRules =
-                Configurations.getInstance().variables().configDescriptionRules.getValue();
+            BlockServerNameValidator configDescriptionRules = Configurations.getInstance()
+                    .variables().configDescriptionRules.getValue();
             descValidator
                     .setBeforeSetValidator(new SummaryDescriptionValidator(messageDisplayer, configDescriptionRules));
         }
-		
+
         UpdateValueStrategy notConverter = new UpdateValueStrategy() {
             @Override
             public Object convert(Object value) {
                 return !(Boolean) value;
             }
         };
-        
+
         bindSynopticList();
-        
+
         bindingContext.bindValue(WidgetProperties.enabled().observe(txtName),
                 BeanProperties.value("isNew").observe(config));
-		bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtName), BeanProperties.value("name").observe(config));
+        bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtName),
+                BeanProperties.value("name").observe(config));
         bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtDescription),
                 BeanProperties.value("description").observe(config), descValidator, null);
-		bindingContext.bindValue(WidgetProperties.selection().observe(cmboSynoptic.getCombo()), 
-		        BeanProperties.value("synoptic").observe(config));		
+        bindingContext.bindValue(WidgetProperties.selection().observe(cmboSynoptic.getCombo()),
+                BeanProperties.value("synoptic").observe(config));
         bindingContext.bindValue(WidgetProperties.visible().observe(lblDateCreated),
                 BeanProperties.value("isNew").observe(config), null, notConverter);
         bindingContext.bindValue(WidgetProperties.visible().observe(lblDateModified),
                 BeanProperties.value("isNew").observe(config), null, notConverter);
-		bindingContext.bindValue(WidgetProperties.text().observe(lblDateCreatedField), BeanProperties.value("dateCreated").observe(config));
-		bindingContext.bindValue(WidgetProperties.text().observe(lblDateModifiedField), BeanProperties.value("dateModified").observe(config));
+        bindingContext.bindValue(WidgetProperties.text().observe(lblDateCreatedField),
+                BeanProperties.value("dateCreated").observe(config));
+        bindingContext.bindValue(WidgetProperties.text().observe(lblDateModifiedField),
+                BeanProperties.value("dateModified").observe(config));
 
         bindingContext.bindValue(WidgetProperties.visible().observe(lblSynoptic),
                 BeanProperties.value("isComponent").observe(config), null, notConverter);
         bindingContext.bindValue(WidgetProperties.visible().observe(cmboSynoptic.getCombo()),
                 BeanProperties.value("isComponent").observe(config), null, notConverter);
-                
-	}
-	
-	/**
-	 * Bind the default synoptic list to the synoptic names from the list.
-	 * 
-	 * This means as the list is updated new values will become available to the synoptic list
-	 * This behaviour is incorrect because it also select the default synoptic for the current config. There is a
-	 * ticket to fix this #2527.
-	 */
-	private void bindSynopticList() {
-		Synoptic.getInstance().availableSynopticsInfo().addObserver(new Observer<Collection<SynopticInfo>>() {
-			
-			@Override
-			public void update(final Collection<SynopticInfo> value, Exception error, boolean isConnected) {
-				updateSynopticNamesInComboBox(value);				
-			}
-			
-			@Override
-			public void onValue(Collection<SynopticInfo> value) {
-				updateSynopticNamesInComboBox(value);
 
-			}
-            
-			/**
-			 * Get the new list of synoptics and the current default and update the combo box.
-			 * 
-			 * @param value the new value of the synoptics list
-			 */
-			private void updateSynopticNamesInComboBox(Collection<SynopticInfo> value) {
-				final String[] names = SynopticInfo.names(value).toArray(new String[0]);
-				Arrays.sort(names);
-				
-				final String selected = getDefaultSelection(value);
-				if (!cmboSynoptic.getControl().isDisposed()) {
-				    cmboSynoptic.setInput(names);
-				    if (selected != null) {
-	                    config.setSynoptic(selected);
-	                }
-				}
-			}
+    }
 
-			/**
-			 * Based on the synoptics list get the current default.
-			 * 
-			 * @param value the synoptics list
-			 * @return the label; empty if there is no default
-			 */
-			private String getDefaultSelection(Collection<SynopticInfo> value) {
-				if (value == null) {
-					return null;
-				}
-				for (SynopticInfo info : value) {
-					if (info.isDefault()) {
-						return info.name();
-					}
-				}
-				return null;
-			}
-			
-			@Override
-			public void onError(Exception e) {
-				// keep list as is
-				
-			}
-			
-			@Override
-			public void onConnectionStatus(boolean isConnected) {
-				// keep list as is				
-			}
-		});
-	}
+    /**
+     * Bind the default synoptic list to the synoptic names from the list.
+     * 
+     * This means as the list is updated new values will become available to the
+     * synoptic list This behaviour is incorrect because it also select the
+     * default synoptic for the current config. There is a ticket to fix this
+     * #2527.
+     */
+    private void bindSynopticList() {
+        Synoptic.getInstance().availableSynopticsInfo().addObserver(new Observer<Collection<SynopticInfo>>() {
 
+            @Override
+            public void update(final Collection<SynopticInfo> value, Exception error, boolean isConnected) {
+                updateSynopticNamesInComboBox(value);
+            }
+
+            @Override
+            public void onValue(Collection<SynopticInfo> value) {
+                updateSynopticNamesInComboBox(value);
+
+            }
+
+            /**
+             * Get the new list of synoptics and the current default and update
+             * the combo box.
+             * 
+             * @param value
+             *            the new value of the synoptics list
+             */
+            private void updateSynopticNamesInComboBox(Collection<SynopticInfo> value) {
+                final String[] names = SynopticInfo.names(value).toArray(new String[0]);
+                Arrays.sort(names);
+
+                final String selected = getDefaultSelection(value);
+                if (!cmboSynoptic.getControl().isDisposed()) {
+                    cmboSynoptic.setInput(names);
+                    if (selected != null) {
+                        config.setSynoptic(selected);
+                    }
+                }
+            }
+
+            /**
+             * Based on the synoptics list get the current default.
+             * 
+             * @param value
+             *            the synoptics list
+             * @return the label; empty if there is no default
+             */
+            private String getDefaultSelection(Collection<SynopticInfo> value) {
+                if (value == null) {
+                    return null;
+                }
+                for (SynopticInfo info : value) {
+                    if (info.isDefault()) {
+                        return info.name();
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public void onError(Exception e) {
+                // keep list as is
+
+            }
+
+            @Override
+            public void onConnectionStatus(boolean isConnected) {
+                // keep list as is
+            }
+        });
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
@@ -154,7 +154,8 @@ public class SummaryPanel extends Composite {
 		bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtName), BeanProperties.value("name").observe(config));
         bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtDescription),
                 BeanProperties.value("description").observe(config), descValidator, null);
-		bindingContext.bindValue(WidgetProperties.selection().observe(cmboSynoptic.getCombo()), BeanProperties.value("synoptic").observe(config));		
+		bindingContext.bindValue(WidgetProperties.selection().observe(cmboSynoptic.getCombo()), 
+		        BeanProperties.value("synoptic").observe(config));		
         bindingContext.bindValue(WidgetProperties.visible().observe(lblDateCreated),
                 BeanProperties.value("isNew").observe(config), null, notConverter);
         bindingContext.bindValue(WidgetProperties.visible().observe(lblDateModified),
@@ -189,7 +190,7 @@ public class SummaryPanel extends Composite {
 				updateSynopticNamesInComboBox(value);
 
 			}
-
+            
 			/**
 			 * Get the new list of synoptics and the current default and update the combo box.
 			 * 
@@ -200,20 +201,12 @@ public class SummaryPanel extends Composite {
 				Arrays.sort(names);
 				
 				final String selected = getDefaultSelection(value);
-				
-				
-				Display.getDefault().asyncExec(new Runnable() {
-					
-					@Override
-					public void run() {
-						if (!cmboSynoptic.getControl().isDisposed()) {
-							cmboSynoptic.setInput(names);
-							if (selected != null) {
-								config.setSynoptic(selected);
-							}
-						}
-					}
-				});
+				if (!cmboSynoptic.getControl().isDisposed()) {
+				    cmboSynoptic.setInput(names);
+				    if (selected != null) {
+	                    config.setSynoptic(selected);
+	                }
+				}
 			}
 
 			/**
@@ -246,4 +239,5 @@ public class SummaryPanel extends Composite {
 			}
 		});
 	}
+
 }


### PR DESCRIPTION
### Description of work

The `synoptic` drop down menu now displays the default synoptic when opening the configuration editing dialog. 

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2883

### Acceptance criteria

- When editing a configuration, the "default synoptic" the drop down menu displays the default synoptic. 
- This does not stop the user from setting a default config, and doesn't break the default config button in the synoptic perspective.

### Unit tests

None needed.

### System tests

None needed.

### Documentation
None related.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

