### PR TITLE
Ticket 2230: Add a live view OPI

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/live_view.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/live_view.opi
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display typeId="org.csstudio.opibuilder.Display" version="1.0">
+  <show_close_button>true</show_close_button>
+  <rules />
+  <wuid>-5a680863:164a30e14bc:-7ffa</wuid>
+  <show_grid>true</show_grid>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <scripts />
+  <height>600</height>
+  <macros>
+    <include_parent_macros>true</include_parent_macros>
+    <DAE>$(P)DAE</DAE>
+  </macros>
+  <boy_version>3.1.4.201301231545</boy_version>
+  <show_edit_range>true</show_edit_range>
+  <widget_type>Display</widget_type>
+  <auto_scale_widgets>
+    <auto_scale_widgets>false</auto_scale_widgets>
+    <min_width>-1</min_width>
+    <min_height>-1</min_height>
+  </auto_scale_widgets>
+  <background_color>
+    <color red="240" green="240" blue="240" />
+  </background_color>
+  <width>800</width>
+  <x>-1</x>
+  <name></name>
+  <grid_space>6</grid_space>
+  <show_ruler>true</show_ruler>
+  <y>-1</y>
+  <snap_to_geometry>true</snap_to_geometry>
+  <foreground_color>
+    <color red="192" green="192" blue="192" />
+  </foreground_color>
+  <actions hook="false" hook_all="false" />
+  <widget typeId="org.csstudio.opibuilder.widgets.intensityGraph" version="1.0">
+    <vertial_profile_y_pv_value />
+    <y_axis_show_minor_ticks>true</y_axis_show_minor_ticks>
+    <tooltip>$(pv_name)</tooltip>
+    <rules>
+      <rule name="Set data_width" prop_id="data_width" out_exp="true">
+        <exp bool_exp="true">
+          <value>pv0</value>
+        </exp>
+        <pv trig="true">$(DAE):image1:ArraySize0_RBV</pv>
+      </rule>
+      <rule name="Set data_height" prop_id="data_height" out_exp="true">
+        <exp bool_exp="true">
+          <value>pv0</value>
+        </exp>
+        <pv trig="true">$(DAE):image1:ArraySize1_RBV</pv>
+      </rule>
+      <rule name="Set x_max" prop_id="x_axis_maximum" out_exp="true">
+        <exp bool_exp="true">
+          <value>pv0</value>
+        </exp>
+        <pv trig="true">$(DAE):image1:ArraySize0_RBV</pv>
+      </rule>
+      <rule name="Set y_max" prop_id="y_axis_maximum" out_exp="true">
+        <exp bool_exp="true">
+          <value>pv0</value>
+        </exp>
+        <pv trig="true">$(DAE):image1:ArraySize1_RBV</pv>
+      </rule>
+    </rules>
+    <horizon_profile_y_pv_value />
+    <x_axis_show_minor_ticks>true</x_axis_show_minor_ticks>
+    <pv_value />
+    <color_map>
+      <interpolate>true</interpolate>
+      <autoscale>true</autoscale>
+      <map>2</map>
+    </color_map>
+    <show_ramp>true</show_ramp>
+    <horizon_profile_x_pv_name></horizon_profile_x_pv_name>
+    <y_axis_axis_title>Y Axis</y_axis_axis_title>
+    <height>600</height>
+    <horizon_profile_y_pv_name></horizon_profile_y_pv_name>
+    <border_width>1</border_width>
+    <single_line_profiling>false</single_line_profiling>
+    <y_axis_minimum>0.0</y_axis_minimum>
+    <visible>true</visible>
+    <graph_area_width>705</graph_area_width>
+    <vertical_profile_y_pv_name></vertical_profile_y_pv_name>
+    <x_axis_major_tick_step_hint>50</x_axis_major_tick_step_hint>
+    <y_axis_scale_font>
+      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+    </y_axis_scale_font>
+    <pv_name>$(DAE):image1:ArrayData</pv_name>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <widget_type>Intensity Graph</widget_type>
+    <x_axis_minimum>0.0</x_axis_minimum>
+    <y_axis_maximum>100.0</y_axis_maximum>
+    <x_axis_maximum>100.0</x_axis_maximum>
+    <name>Intensity Graph</name>
+    <vertial_profile_x_pv_value />
+    <y_axis_axis_color>
+      <color red="0" green="0" blue="0" />
+    </y_axis_axis_color>
+    <actions hook="false" hook_all="false" />
+    <border_style>0</border_style>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <rgb_mode>false</rgb_mode>
+    <crop_left>0</crop_left>
+    <x_axis_scale_font>
+      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+    </x_axis_scale_font>
+    <data_width>1024</data_width>
+    <enabled>true</enabled>
+    <wuid>-5a680863:164a30e14bc:-7ff5</wuid>
+    <y_axis_major_tick_step_hint>50</y_axis_major_tick_step_hint>
+    <y_axis_title_font>
+      <fontdata fontName="Arial" height="9" style="1" />
+    </y_axis_title_font>
+    <scripts />
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <graph_area_height>554</graph_area_height>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>true</keep_wh_ratio>
+    </scale_options>
+    <x_axis_visible>true</x_axis_visible>
+    <x_axis_title_font>
+      <fontdata fontName="Arial" height="9" style="1" />
+    </x_axis_title_font>
+    <vertical_profile_x_pv_name></vertical_profile_x_pv_name>
+    <crop_bottom>0</crop_bottom>
+    <x_axis_axis_color>
+      <color red="0" green="0" blue="0" />
+    </x_axis_axis_color>
+    <y_axis_visible>true</y_axis_visible>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <horizon_profile_x_pv_value />
+    <background_color>
+      <color red="240" green="240" blue="240" />
+    </background_color>
+    <x_axis_axis_title>X Axis</x_axis_axis_title>
+    <width>800</width>
+    <x>0</x>
+    <y>0</y>
+    <maximum>255.0</maximum>
+    <color_depth>0</color_depth>
+    <data_height>1024</data_height>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <minimum>0.0</minimum>
+    <crop_right>0</crop_right>
+    <crop_top>0</crop_top>
+    <roi_color>
+      <color red="0" green="255" blue="255" />
+    </roi_color>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+    </font>
+  </widget>
+</display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -1438,5 +1438,16 @@
         </macros>
       </value>
     </entry>
+    <entry>        
+      <key>Live View</key>
+      <value>
+        <categories>
+          <category>Monitors</category>
+        </categories>
+        <type>DAE</type>
+        <path>live_view.opi</path>
+        <description>The OPI for a live view of the detector</description>
+      </value>
+    </entry>
 	</opis>
 </descriptions>


### PR DESCRIPTION
### Description of work

This ticket adds a live view OPI.

### Ticket

See https://github.com/ISISComputingGroup/IBEX/issues/2230

### Acceptance criteria

To test:
* Get changes from https://github.com/ISISComputingGroup/EPICS-areaDetector/pull/7
* Follow instructions on https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/DAE-Live-View for running a simulated live view
* Run the live view via a device screen
* Change the X and Y of the detector in ADSimDetector/iocs/simDetectorIOC/iocBoot/iocSimDetector/st_base.cmd
* Restart the IOC, confirm the OPI updates appropriately.

Note:
* The default update time of the simulator is 0.001 secs, which is pushing the OPI much more than the 1 sec the DAE will run at. I saw some rendering issues at this speed in E3 but not in E4, if you do have issues try lowering this value as specified in the docs.
* I have run this overnight and seen no memory leaks in the GUI, feel free to run again though


### Documentation
Some documentation at https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/DAE-Live-View

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

