### PR TITLE
Fix memory leak

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
+++ b/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
@@ -96,7 +96,7 @@ public abstract class MessageParser<T extends IMessage> implements Runnable {
          * Hence, set it to null here.
          * 
          * Failure to do this will result in the thread going CPU-bound
-         * and eventually leaking memory while it tries repeatedly to
+         * and eventually leaking memory while it tries repeatedly to connect
          * 
          */
         jmsConsumer = null;

--- a/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
+++ b/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
@@ -62,6 +62,9 @@ public abstract class MessageParser<T extends IMessage> implements Runnable {
      *            true to start, false to stop
      */
     public void setRunning(boolean run) {
+    	if (run && jmsConsumer == null) {
+    		throw new IllegalStateException("Cannot start running without a consumer");
+    	}
         running = run;
     }
     
@@ -83,6 +86,21 @@ public abstract class MessageParser<T extends IMessage> implements Runnable {
      */
     public void closeJMSConsumer() throws JMSException {
         jmsConsumer.close();
+        
+        /**
+         * Once the consumer is closed, we can't do anything with it
+         * and it can never be reopened. Additionally there is no
+         * isClosed() on a consumer so we can't tell that it's closed
+         * after the fact.
+         * 
+         * Hence, set it to null here.
+         * 
+         * Failure to do this will result in the thread going CPU-bound
+         * and eventually leaking memory while it tries repeatedly to
+         * 
+         */
+        jmsConsumer = null;
+        setRunning(false);
     }
 
     /**


### PR DESCRIPTION
### Description of work

Fix a thread going CPU bound and leaking memory in the GUI.

**NOTE: in E3, there is a (different) issue with a memory leak when switching instruments. This leak does not appear in E4. Since everyone is going to be on E4 soon I have not put any effort into fixing that leak. It also only occurs when switching instruments so is unlikely to be an issue on the instruments.**

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3330

### Acceptance criteria

- Memory leak / going CPU bound issue is fixed

### Unit tests

- None added - this is hard as it's to do with the threading.

### Documentation

Added documentation to the relevant area of the code.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

