### PR TITLE
Underlined the relevant letters.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlocksTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/BlocksTest.java
@@ -22,6 +22,7 @@ package uk.ac.stfc.isis.ibex.configserver.tests.editing;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.Test;
@@ -113,7 +114,7 @@ public class BlocksTest extends EditableConfigurationTest {
 		
 		// Act
 		EditableBlock gapx = getFirst(edited.getAllBlocks());
-		edited.removeBlock(gapx);
+		edited.removeBlocks(Arrays.asList(gapx));
 		
 		// Assert
 		assertEmpty(edited.asConfiguration().getBlocks());

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Block.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Block.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.configserver.configuration;
 
 import com.google.common.base.Strings;
 
+import uk.ac.stfc.isis.ibex.epics.observing.INamed;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
 /**
@@ -31,7 +32,7 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
  * JSON.
  */
 @SuppressWarnings("checkstyle:membername")
-public class Block extends ModelObject {
+public class Block extends ModelObject implements INamed {
 
     /**
      * Default value to give to periodic scan.

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/BlockFactory.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/BlockFactory.java
@@ -22,9 +22,9 @@
  */
 package uk.ac.stfc.isis.ibex.configserver.editing;
 
-import java.util.ArrayList;
+
 import java.util.Collection;
-import java.util.List;
+import java.util.stream.Collectors;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
 
@@ -58,12 +58,9 @@ public class BlockFactory {
         return block;
     }
 
-    private Collection<String> blockNames() {
-        List<String> names = new ArrayList<>();
-        for (Block block : config.transformBlocks()) {
-            names.add(block.getName());
-        }
-
-        return names;
+    private Collection<String> blockNames() {    
+        return config.transformBlocks().stream()
+    			.map(b -> b.getName())
+    			.collect(Collectors.toList());
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -542,16 +542,6 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
     }
 
     /**
-     * Remove a block from the configuration.
-     * 
-     * @param block
-     *            the block to remove
-     */
-    public void removeBlock(EditableBlock block) {
-    	removeBlocks(Arrays.asList(block));
-    }
-
-    /**
      * Remove multiple blocks from the configuration.
      * 
      * @param blocks

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
@@ -20,6 +20,8 @@
 package uk.ac.stfc.isis.ibex.ui.configserver.editing;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -80,6 +82,20 @@ public class ConfigEditorPanel extends Composite {
 		
         editorTabs = new TabFolder(this, SWT.NONE);
 		editorTabs.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+		
+		editorTabs.addSelectionListener(new SelectionListener(){
+
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                if (editorTabs.getSelection()[0].equals(blocksTab)){
+                    blocks.showMnemonics();
+                }
+            }
+
+            @Override
+            public void widgetDefaultSelected(SelectionEvent e) {
+            }
+        });
 
         if (config.getIsComponent()) {
             components = null;

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
@@ -20,8 +20,8 @@
 package uk.ac.stfc.isis.ibex.ui.configserver.editing;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
@@ -83,17 +83,12 @@ public class ConfigEditorPanel extends Composite {
         editorTabs = new TabFolder(this, SWT.NONE);
 		editorTabs.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 		
-		editorTabs.addSelectionListener(new SelectionListener(){
-
+		editorTabs.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
                 if (editorTabs.getSelection()[0].equals(blocksTab)){
                     blocks.showMnemonics();
                 }
-            }
-
-            @Override
-            public void widgetDefaultSelected(SelectionEvent e) {
             }
         });
 

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/DeleteTableItemHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/DeleteTableItemHelper.java
@@ -1,0 +1,45 @@
+package uk.ac.stfc.isis.ibex.ui.configserver.editing;
+
+import java.util.List;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+
+import uk.ac.stfc.isis.ibex.epics.observing.INamed;
+
+public class DeleteTableItemHelper<T extends INamed> {
+	Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+	
+    public int createDeleteDialog(String itemType, List<T> toRemove) {
+        String dialogTitle = "Delete " + itemType;
+        String dialogText = "Do you really want to delete the " + itemType;
+        
+        if (toRemove.size() == 1) {
+            dialogText += " " + toRemove.get(0).getName() + "?";
+        } else {
+            dialogTitle = "Delete " + itemType + "s";
+            dialogText += "s " + itemNamesToString(toRemove) + "?";
+        }
+                
+        MessageBox dialog = new MessageBox(shell, SWT.ICON_WARNING | SWT.OK | SWT.CANCEL);
+        dialog.setText(dialogTitle);
+        dialog.setMessage(dialogText);
+        return dialog.open();
+    }
+	
+	private String itemNamesToString(List<T> items) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < items.size(); i++) {
+            INamed item = items.get(i);
+            sb.append(item.getName());
+            if (i == items.size() - 2) {
+                sb.append(" and ");
+            } else if (i != items.size() - 1) {
+                sb.append(", ");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -231,7 +231,6 @@ public class BlocksEditorPanel extends Composite {
 	                    MessageDialog.ERROR, new String[] {"OK"}, 0);
 	            error.open();
 	        }
-	        viewModel.setSelectedBlocks(Arrays.asList(added));
 	        table.setSelected(added);
 	    }
 	}
@@ -241,7 +240,6 @@ public class BlocksEditorPanel extends Composite {
         EditableBlock added = blockFactory.createNewBlock();
         EditBlockDialog dialog = new EditBlockDialog(getShell(), added, config);
         dialog.open();
-        viewModel.setSelectedBlocks(Arrays.asList(added));
         table.setSelected(added);
 	}
 	
@@ -270,11 +268,11 @@ public class BlocksEditorPanel extends Composite {
 		if (returnCode == SWT.OK) {
 			int index = table.getSelectionIndex();
 			config.removeBlocks(toRemove);
-		
+			
+			
 			// Update new selection
 			int newIndex = index > 0 ? index - 1 : index;
 			table.setSelectionIndex(newIndex);
-			viewModel.setSelectedBlocks(table.selectedRows());
 		}
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -89,16 +89,22 @@ public class BlocksEditorPanel extends Composite {
             @Override
             public void keyPressed(KeyEvent e) {
                 if (e.keyCode == SWT.DEL) {
-                    deleteSelected();
+                    if (!table.selectedRows().isEmpty()) {
+                        deleteSelected();
+                    }
                 //copies selected blocks if press "Ctrl + D".
                 } else if (e.character == 0x4) {
-                    copySelected();
+                    if (!table.selectedRows().isEmpty()) {
+                        copySelected();
+                    }
                 //adds new block if press "Ctrl + A".
                 } else if (e.character == 0x01) {
                     addNew();
                 //edits first selected block if press "Ctrl +E".
                 } else if (e.character == 0x5 && editEnabled(Arrays.asList(table.firstSelectedRow()))) {
-                    openEditBlockDialog(table.firstSelectedRow());
+                    if (!table.selectedRows().isEmpty()) {
+                        openEditBlockDialog(table.firstSelectedRow());
+                    }
                 }
             }
         });
@@ -196,24 +202,22 @@ public class BlocksEditorPanel extends Composite {
 	}
 	
 	private void copySelected() {
-	    if (!table.selectedRows().isEmpty()) {
-    	    for (Block block : table.selectedRows()) {
-                EditableBlock added = new EditableBlock(block);
-                added.setName(viewModel.getUniqueName(added.getName()));
+	    for (Block block : table.selectedRows()) {
+	        EditableBlock added = new EditableBlock(block);
+	        added.setName(viewModel.getUniqueName(added.getName()));
                 
-                try {
-                    config.addNewBlock(added);
-                } catch (DuplicateBlockNameException e1) {
-                    MessageDialog error = new MessageDialog(this.getShell(), "Error", null,
-                            "Failed to add block " + added.getName() + ":\nBlock with this name already exists.",
-                            MessageDialog.ERROR, new String[] {"OK"}, 0);
-                    error.open();
-                }
-                setBlocks(config);
-                setSelectedBlocks(new ArrayList<EditableBlock>(Arrays.asList(added)));
-                table.setSelected(added);
-    	    }
-	    } 
+	        try {
+	            config.addNewBlock(added);
+	        } catch (DuplicateBlockNameException e1) {
+	            MessageDialog error = new MessageDialog(this.getShell(), "Error", null,
+	                    "Failed to add block " + added.getName() + ":\nBlock with this name already exists.",
+	                    MessageDialog.ERROR, new String[] {"OK"}, 0);
+	            error.open();
+	        }
+	        setBlocks(config);
+	        setSelectedBlocks(new ArrayList<EditableBlock>(Arrays.asList(added)));
+	        table.setSelected(added);
+	    }
 	}
 
 	private void addNew() {
@@ -275,6 +279,12 @@ public class BlocksEditorPanel extends Composite {
 			int newIndex = index > 0 ? index - 1 : index;
 			table.setSelectionIndex(newIndex);
 			setSelectedBlocks(table.selectedRows());
+		}
+		
+		if (table.isEmpty()){
+		    edit.setEnabled(false);
+		    remove.setEnabled(false);
+	        copy.setEnabled(false);
 		}
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -38,6 +38,8 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.MessageBox;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
@@ -114,20 +116,20 @@ public class BlocksEditorPanel extends Composite {
 		gd_add.widthHint = 110;
 		
 		add.setLayoutData(gd_add);
-		add.setText("Add Block");	
+		add.setText("&Add Block");
 		add.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
                 addNew();
 			}
 		});
-
+		
         copy = new Button(composite, SWT.NONE);
         GridData gd_copy = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
         gd_copy.widthHint = 110;
         
         copy.setLayoutData(gd_copy);
-        copy.setText("Copy Block");
+        copy.setText("&Duplicate Block");
         copy.setEnabled(false);
         copy.addSelectionListener(new SelectionAdapter() {
             @Override
@@ -135,7 +137,7 @@ public class BlocksEditorPanel extends Composite {
                 copySelected();
             }
         });
-
+        
 		edit = new Button(composite, SWT.NONE);
 		GridData gd_edit = new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1);
 		gd_edit.widthHint = 110;
@@ -146,7 +148,7 @@ public class BlocksEditorPanel extends Composite {
                 openEditBlockDialog(table.firstSelectedRow());
 			}
 		});
-		edit.setText("Edit Block");
+		edit.setText("&Edit Block");
 		edit.setEnabled(false);
 		
 		remove = new Button(composite, SWT.NONE);
@@ -161,7 +163,6 @@ public class BlocksEditorPanel extends Composite {
 				deleteSelected();
 			}
 		});
-		
 		table.addSelectionChangedListener(new ISelectionChangedListener() {
 			@Override
 			public void selectionChanged(SelectionChangedEvent arg0) {
@@ -169,7 +170,6 @@ public class BlocksEditorPanel extends Composite {
 				setSelectedBlocks(selected);
 			}
 		});
-
         table.addMouseListener(new MouseAdapter() {
             @Override
             public void mouseDoubleClick(MouseEvent e) {
@@ -181,7 +181,6 @@ public class BlocksEditorPanel extends Composite {
                 }
             }
         });
-        
 	}
 	
 	/**
@@ -296,5 +295,15 @@ public class BlocksEditorPanel extends Composite {
     private void openEditBlockDialog(EditableBlock toEdit) {
         EditBlockDialog dialog = new EditBlockDialog(getShell(), toEdit, config);
         dialog.open();
+    }
+
+    public void showMnemonics() {
+        Event event = new Event();
+        event.keyCode = SWT.ALT;
+        event.type = SWT.KeyDown;
+        Display.getCurrent().post(event);
+        event.type = SWT.KeyUp;
+        Display.getCurrent().post(event);
+
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorPanel.java
@@ -22,7 +22,6 @@ package uk.ac.stfc.isis.ibex.ui.configserver.editing.blocks;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.databinding.DataBindingContext;
@@ -45,13 +44,13 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.MessageBox;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
 import uk.ac.stfc.isis.ibex.configserver.editing.BlockFactory;
 import uk.ac.stfc.isis.ibex.configserver.editing.DuplicateBlockNameException;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableBlock;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
+import uk.ac.stfc.isis.ibex.ui.configserver.editing.DeleteTableItemHelper;
 
 /**
  * The class responsible for creating the block editor panel.
@@ -249,45 +248,19 @@ public class BlocksEditorPanel extends Composite {
 	}
 
 	private void deleteSelected() {
-		List<EditableBlock> toRemove = table.selectedRows();
-		String dialogTitle = "Delete Block";
-		String dialogText = "Do you really want to delete the block";
-		
-		if (toRemove.size() == 1) {
-			dialogText += " " + toRemove.get(0).getName() + "?";
-		} else {
-			dialogTitle = "Delete Blocks";
-			dialogText += "s " + blockNamesToString(toRemove) + "?";
-		}
-				
-		MessageBox dialog = new MessageBox(getShell(), SWT.ICON_WARNING | SWT.OK | SWT.CANCEL);
-		dialog.setText(dialogTitle);
-		dialog.setMessage(dialogText);
-		int returnCode = dialog.open();
+    	List<EditableBlock> toRemove = table.selectedRows();
+    	
+    	DeleteTableItemHelper<EditableBlock> helper = new DeleteTableItemHelper<>();
+        int returnCode = helper.createDeleteDialog("Block", toRemove);
 		
 		if (returnCode == SWT.OK) {
 			int index = table.getSelectionIndex();
 			config.removeBlocks(toRemove);
 			
-			
 			// Update new selection
 			int newIndex = index > 0 ? index - 1 : index;
 			table.setSelectionIndex(newIndex);
 		}
-	}
-
-	private String blockNamesToString(List<EditableBlock> blocks) {
-		StringBuilder sb = new StringBuilder();
-		for (int i = 0; i < blocks.size(); i++) {
-			EditableBlock block = blocks.get(i);
-			sb.append(block.getName());
-			if (i == blocks.size() - 2) {
-				sb.append(" and ");
-			} else if (i != blocks.size() - 1) {
-				sb.append(", ");
-			}
-		}
-		return sb.toString();
 	}
 
     private void openEditBlockDialog(EditableBlock toEdit) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorViewModel.java
@@ -3,6 +3,8 @@ package uk.ac.stfc.isis.ibex.ui.configserver.editing.blocks;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
 import uk.ac.stfc.isis.ibex.configserver.editing.DefaultName;
@@ -39,12 +41,12 @@ public class BlocksEditorViewModel extends ModelObject {
      *          The new unique name for the block.
      */
     public String getUniqueName(String blockName) {
-        Collection<String> allBlocksInConfigNames = new ArrayList<String>();
-        for (Block blockInConfig : config.getAllBlocks()) {
-            allBlocksInConfigNames.add(blockInConfig.getName());
-        }
+    	List<String> blockNames = config.getAllBlocks().stream()
+    			.map(b -> b.getName())
+    			.collect(Collectors.toList());
+    	
         DefaultName namer = new DefaultName(blockName);
-        return namer.getUnique(allBlocksInConfigNames);
+        return namer.getUnique(blockNames);
     }
     
 	public boolean editEnabled(List<EditableBlock> blocks) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksEditorViewModel.java
@@ -2,9 +2,11 @@ package uk.ac.stfc.isis.ibex.ui.configserver.editing.blocks;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
 import uk.ac.stfc.isis.ibex.configserver.editing.DefaultName;
+import uk.ac.stfc.isis.ibex.configserver.editing.EditableBlock;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 
@@ -14,6 +16,9 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
  */
 public class BlocksEditorViewModel extends ModelObject {
     EditableConfiguration config;
+    
+    private boolean editEnabled;
+    private boolean copyDeleteEnabled;
     
     /**
      * Constructor for the block editor panel view model.
@@ -41,5 +46,39 @@ public class BlocksEditorViewModel extends ModelObject {
         DefaultName namer = new DefaultName(blockName);
         return namer.getUnique(allBlocksInConfigNames);
     }
+    
+	public boolean editEnabled(List<EditableBlock> blocks) {
+		boolean enabled = !blocks.isEmpty();
+		
+		for (EditableBlock block : blocks) {
+			enabled &= block != null && block.isEditable();
+		}
+		return enabled;
+	}
+    
+	public boolean getEditEnabled() {
+		return editEnabled;
+	}
+	
+	public void setEditEnabled(boolean editEnabled) {
+		firePropertyChange("editEnabled", this.editEnabled, this.editEnabled = editEnabled);
+	}
+	
+	public boolean getCopyDeleteEnabled() {
+		return copyDeleteEnabled;
+	}
+	
+	public void setCopyDeleteEnabled(boolean copyDeleteEnabled) {
+		firePropertyChange("copyDeleteEnabled", this.copyDeleteEnabled, this.copyDeleteEnabled = copyDeleteEnabled);
+	}
+	
+	public void setSelectedBlocks(List<EditableBlock> selected) {
+		if (selected.size() > 1) {
+			setEditEnabled(false);
+		} else {
+			setEditEnabled(editEnabled(selected));
+		}
+		setCopyDeleteEnabled(editEnabled(selected));
+	}
 }
 

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksTable.java
@@ -139,4 +139,17 @@ public class BlocksTable extends DataboundTable<EditableBlock> {
 		search.setSearchText(searchText);
 		this.viewer().refresh();
 	}
+
+	/**
+     * Checks if the table is empty
+     * @return True if the table is empty.
+     */
+    public boolean isEmpty() {
+        int nbOfTableItems = table().getItemCount();
+        if (nbOfTableItems == 0) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksTable.java
@@ -139,17 +139,4 @@ public class BlocksTable extends DataboundTable<EditableBlock> {
 		search.setSearchText(searchText);
 		this.viewer().refresh();
 	}
-
-	/**
-     * Checks if the table is empty
-     * @return True if the table is empty.
-     */
-    public boolean isEmpty() {
-        int nbOfTableItems = table().getItemCount();
-        if (nbOfTableItems == 0) {
-            return true;
-        } else {
-            return false;
-        }
-    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocOverviewPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/IocOverviewPanel.java
@@ -38,11 +38,11 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Text;
 
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
+import uk.ac.stfc.isis.ibex.ui.configserver.editing.DeleteTableItemHelper;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs.dialog.AddIocDialog;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs.dialog.IocDialog;
 import uk.ac.stfc.isis.ibex.validators.MessageDisplayer;
@@ -246,22 +246,10 @@ public class IocOverviewPanel extends Composite {
     }
     
     private void deleteSelected() {
-
-        List<EditableIoc> toRemove = table.selectedRows();
-        String dialogTitle = "Delete IOC";
-        String dialogText = "Do you really want to delete the IOC";
-        
-        if (toRemove.size() == 1) {
-            dialogText += " " + toRemove.get(0).getName() + "?";
-        } else {
-            dialogTitle = "Delete IOCs";
-            dialogText += "s " + iocNamesToString(toRemove) + "?";
-        }
-                
-        MessageBox dialog = new MessageBox(getShell(), SWT.ICON_WARNING | SWT.OK | SWT.CANCEL);
-        dialog.setText(dialogTitle);
-        dialog.setMessage(dialogText);
-        int returnCode = dialog.open();
+    	List<EditableIoc> toRemove = table.selectedRows();
+    	
+    	DeleteTableItemHelper<EditableIoc> helper = new DeleteTableItemHelper<>();
+        int returnCode = helper.createDeleteDialog("IOC", toRemove);
         
         if (returnCode == SWT.OK) {
             int index = table.getSelectionIndex();
@@ -275,19 +263,4 @@ public class IocOverviewPanel extends Composite {
             setSelectedIocs(table.selectedRows());
         }
     }
-
-    private String iocNamesToString(List<EditableIoc> iocs) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < iocs.size(); i++) {
-            EditableIoc ioc = iocs.get(i);
-            sb.append(ioc.getName());
-            if (i == iocs.size() - 2) {
-                sb.append(" and ");
-            } else if (i != iocs.size() - 1) {
-                sb.append(", ");
-            }
-        }
-        return sb.toString();
-    }
-
 }

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
@@ -158,7 +158,10 @@ public abstract class DataboundTable<TRow> extends Composite {
      * @param index the new selection index
      */
 	public void setSelectionIndex(int index) {
-		table.setSelection(index);
+		table.select(index);
+		// Forces the viewer to refresh the selection and call events
+		IStructuredSelection selected = viewer.getStructuredSelection();
+		viewer.setSelection(selected);
 	}
 	
     /**


### PR DESCRIPTION
### Description of work

I changed the buttons in block editor to be ``Add Block``, ``Duplicate Block``, ``Edit Block`` and ``Delete Block``. I also added a feature to underline the first letter of each (except for ``Delete Block``) as these letters are used for the keyboard shortcuts. I didn't underline the delete block as I'm guessing using the ``DEL`` key is fairly instinctive and because I couldn't get more than one letter per word to be underlined. This is because I used the mnemonic tool, by setting and ``&`` before each letter corresponding to a keyboard shortcut and simulated a key event where the alt key would be pressed. This is a slightly dodgy way of doing this, but after struggling for a while I did not manage to set the button to only have one underlined character (because you can only underline using a font, a single font is capable of only underlining part of a string and you can only set one font per widget such that you can only underline everything or nothing).

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3418

### Acceptance criteria

- The buttons in block editor are Add Block, Duplicate Block, Edit Block and Delete Block.
- The letter relevant to each keyboard shortcut is underlined.

### Unit tests

None required.

### System tests

None required.

### Documentation
Changed [documentation](https://github.com/ISISComputingGroup/ibex_user_manual/wiki/CreateandManageConfigurations) to reflect the change in name of the ``Duplicate Block`` button.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

