### PR TITLE
Created shortcut to reset layout.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -105,7 +105,8 @@
   <handlers xmi:id="_Q7_cIKkEEeeNUPQOsQF40g" elementId="uk.ac.stfc.isis.ibex.e4.client.handler.about" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.help/uk.ac.stfc.isis.ibex.ui.help.AboutHandler" command="_hj--kKkDEeeNUPQOsQF40g"/>
   <handlers xmi:id="_v5ccsKkNEeeEH_5MGE7mgA" elementId="uk.ac.stfc.isis.ibex.e4.client.handler.usermanual" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.help/uk.ac.stfc.isis.ibex.ui.help.ManualHandler" command="_w0psQKkDEeeNUPQOsQF40g"/>
   <handlers xmi:id="_37kgEKkNEeeEH_5MGE7mgA" elementId="uk.ac.stfc.isis.ibex.e4.client.handler.consolelogdialog" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.logger/uk.ac.stfc.isis.ibex.ui.logger.ConsoleLogHandler" command="_5pQ8gKkDEeeNUPQOsQF40g"/>
-  <handlers xmi:id="_hPKD8IOSEeizju06Crxm-g" elementId="uk.ac.stfc.isis.ibex.e4.client.handler.0" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher.commands.SwitchPerspective" command="_UJcx8IOSEeizju06Crxm-g"/>
+  <handlers xmi:id="_JRFiEJlbEeiJWOfXjwtf9A" elementId="uk.ac.stfc.isis.ibex.e4.client.handler.0" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher.commands.SwitchPerspective" command="_UJcx8IOSEeizju06Crxm-g"/>
+  <handlers xmi:id="_7P65YJZlEeilnu5vNzjU3w" elementId="uk.ac.stfc.isis.ibex.e4.client.handler.resetperspectives" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher.commands.ResetPerspective" command="_NufGcJZmEeilnu5vNzjU3w"/>
   <bindingTables xmi:id="_5WjMoIOQEeizju06Crxm-g" elementId="IBEX_key_scheme" bindingContext="_no3QoIOVEeizju06Crxm-g">
     <tags>type:user</tags>
     <bindings xmi:id="_5zdyIIOQEeizju06Crxm-g" elementId="uk.ac.stfc.isis.ibex.e4.client.keybindings" keySequence="M2+M3+A" command="_UJcx8IOSEeizju06Crxm-g">
@@ -191,6 +192,9 @@
       <parameters xmi:id="_w_S0QYQ0Eeizju06Crxm-g" elementId="uk.ac.stfc.isis.ibex.e4.client.parameter.0" name="uk.ac.stfc.isis.ibex.e4.client.switchperspectives.perspectiveid" value="uk.ac.stfc.isis.ibex.e4.client.perspective.devicescreens">
         <tags>type:user</tags>
       </parameters>
+    </bindings>
+    <bindings xmi:id="_fq1XQJZmEeilnu5vNzjU3w" elementId="uk.ac.stfc.isis.ibex.e4.client.keybindings" keySequence="M2+M3+O" command="_NufGcJZmEeilnu5vNzjU3w">
+      <tags>type:user</tags>
     </bindings>
   </bindingTables>
   <rootContext xmi:id="_no3QoIOVEeizju06Crxm-g" elementId="org.eclipse.ui.contexts.dialogAndWindow" name="dialog and window" description="default binding context">
@@ -580,6 +584,9 @@
   <commands xmi:id="_UJcx8IOSEeizju06Crxm-g" elementId="uk.ac.stfc.isis.ibex.e4.client.command.switchperspetives" commandName="Switch Perspetives" description="Switch Perspetives">
     <tags>type:user</tags>
     <parameters xmi:id="_cauroIOSEeizju06Crxm-g" elementId="uk.ac.stfc.isis.ibex.e4.client.switchperspectives.perspectiveid" name="perspectiveid" optional="false"/>
+  </commands>
+  <commands xmi:id="_NufGcJZmEeilnu5vNzjU3w" elementId="uk.ac.stfc.isis.ibex.e4.client.command.resetperspectives" commandName="Reset Perspectives" description="Reset Perspectives">
+    <tags>type:user</tags>
   </commands>
   <addons xmi:id="_2jV5MWGNEeeR5ozUwT3tEw" elementId="org.eclipse.e4.core.commands.service" contributionURI="bundleclass://org.eclipse.e4.core.commands/org.eclipse.e4.core.commands.CommandServiceAddon"/>
   <addons xmi:id="_2jV5MmGNEeeR5ozUwT3tEw" elementId="org.eclipse.e4.ui.contexts.service" contributionURI="bundleclass://org.eclipse.e4.ui.services/org.eclipse.e4.ui.services.ContextServiceAddon"/>

--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -193,7 +193,7 @@
         <tags>type:user</tags>
       </parameters>
     </bindings>
-    <bindings xmi:id="_fq1XQJZmEeilnu5vNzjU3w" elementId="uk.ac.stfc.isis.ibex.e4.client.keybindings" keySequence="M2+M3+O" command="_NufGcJZmEeilnu5vNzjU3w">
+    <bindings xmi:id="_fq1XQJZmEeilnu5vNzjU3w" elementId="uk.ac.stfc.isis.ibex.e4.client.keybindings" keySequence="M2+M3+Z" command="_NufGcJZmEeilnu5vNzjU3w">
       <tags>type:user</tags>
     </bindings>
   </bindingTables>

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/PerspectiveResetAdapter.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/PerspectiveResetAdapter.java
@@ -10,30 +10,30 @@ import org.eclipse.ui.PlatformUI;
  */
 public class PerspectiveResetAdapter extends SelectionAdapter {
 
-	private final PerspectivesProvider provider;
+    private final PerspectivesProvider provider;
 
-	/**
-	 * Constructor.
-	 * 
-	 * @param provider
-	 *            PerspectivesProvider
-	 */
-	public PerspectiveResetAdapter(PerspectivesProvider provider) {
-		this.provider = provider;
-	}
+    /**
+     * Constructor.
+     * 
+     * @param provider
+     *            PerspectivesProvider
+     */
+    public PerspectiveResetAdapter(PerspectivesProvider provider) {
+        this.provider = provider;
+    }
 
-	@Override
-	public void widgetSelected(SelectionEvent event) {
-		resetPerspective();
-	}
+    @Override
+    public void widgetSelected(SelectionEvent event) {
+        resetPerspective();
+    }
 
-	/**
-	 * Method that resets the current perspective.
-	 */
-	public void resetPerspective(){
-	    MPerspectiveStack perspectiveStack = provider.getTopLevelStack();
+    /**
+     * Method that resets the current perspective.
+     */
+    public void resetPerspective() {
+        MPerspectiveStack perspectiveStack = provider.getTopLevelStack();
         PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().resetPerspective();
         perspectiveStack.getSelectedElement().setVisible(true);
         perspectiveStack.setVisible(true);
-	}
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/PerspectiveResetAdapter.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/PerspectiveResetAdapter.java
@@ -24,9 +24,16 @@ public class PerspectiveResetAdapter extends SelectionAdapter {
 
 	@Override
 	public void widgetSelected(SelectionEvent event) {
-		MPerspectiveStack perspectiveStack = provider.getTopLevelStack();
-		PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().resetPerspective();
-		perspectiveStack.getSelectedElement().setVisible(true);
-		perspectiveStack.setVisible(true);
+		resetPerspective();
+	}
+
+	/**
+	 * Method that resets the current perspective.
+	 */
+	public void resetPerspective(){
+	    MPerspectiveStack perspectiveStack = provider.getTopLevelStack();
+        PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().resetPerspective();
+        perspectiveStack.getSelectedElement().setVisible(true);
+        perspectiveStack.setVisible(true);
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/commands/ResetPerspective.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/commands/ResetPerspective.java
@@ -14,22 +14,25 @@ import uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher.PerspectivesProvider;
  * Class containing the eclipse command to reset perspectives.
  */
 public class ResetPerspective {
-    
+
     /**
      * The application (injected by eclipse framework).
      */
-    @Inject public MApplication app;
-    
+    @Inject
+    public MApplication app;
+
     /**
      * The part service (injected by eclipse framework).
      */
-    @Inject public EPartService partService;
-    
+    @Inject
+    public EPartService partService;
+
     /**
      * The model service (injected by eclipse framework).
      */
-    @Inject public EModelService modelService;
-    
+    @Inject
+    public EModelService modelService;
+
     /**
      * Eclipse command to rest perspectives.
      */

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/commands/ResetPerspective.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/commands/ResetPerspective.java
@@ -1,0 +1,42 @@
+package uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher.commands;
+
+import javax.inject.Inject;
+
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.e4.ui.model.application.MApplication;
+import org.eclipse.e4.ui.workbench.modeling.EModelService;
+import org.eclipse.e4.ui.workbench.modeling.EPartService;
+
+import uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher.PerspectiveResetAdapter;
+import uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher.PerspectivesProvider;
+
+/**
+ * Class containing the eclipse command to reset perspectives.
+ */
+public class ResetPerspective {
+    
+    /**
+     * The application (injected by eclipse framework).
+     */
+    @Inject public MApplication app;
+    
+    /**
+     * The part service (injected by eclipse framework).
+     */
+    @Inject public EPartService partService;
+    
+    /**
+     * The model service (injected by eclipse framework).
+     */
+    @Inject public EModelService modelService;
+    
+    /**
+     * Eclipse command to rest perspectives.
+     */
+    @Execute
+    public void execute() {
+        PerspectivesProvider provider = new PerspectivesProvider(app, partService, modelService);
+        PerspectiveResetAdapter resetAdapter = new PerspectiveResetAdapter(provider);
+        resetAdapter.resetPerspective();
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/commands/SwitchPerspective.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/commands/SwitchPerspective.java
@@ -14,29 +14,34 @@ import uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher.PerspectivesProvider;
  * Class containing the eclipse command to switch perspectives.
  */
 public class SwitchPerspective {
-	
-	/**
-	 * The application (injected by eclipse framework).
-	 */
-	@Inject public MApplication app;
-	
-	/**
-	 * The part service (injected by eclipse framework).
-	 */
-	@Inject public EPartService partService;
-	
-	/**
-	 * The model service (injected by eclipse framework).
-	 */
-	@Inject public EModelService modelService;
-	
-	/**
-	 * Eclipse command to switch perspectives.
-	 * @param id the id of the perspective to switch to
-	 */
-	@Execute
-	public void execute(@Named("uk.ac.stfc.isis.ibex.e4.client.switchperspectives.perspectiveid") String id) {
-		PerspectivesProvider provider = new PerspectivesProvider(app, partService, modelService);
-	    provider.switchPerspective(id);
-	}
+
+    /**
+     * The application (injected by eclipse framework).
+     */
+    @Inject
+    public MApplication app;
+
+    /**
+     * The part service (injected by eclipse framework).
+     */
+    @Inject
+    public EPartService partService;
+
+    /**
+     * The model service (injected by eclipse framework).
+     */
+    @Inject
+    public EModelService modelService;
+
+    /**
+     * Eclipse command to switch perspectives.
+     * 
+     * @param id
+     *            the id of the perspective to switch to
+     */
+    @Execute
+    public void execute(@Named("uk.ac.stfc.isis.ibex.e4.client.switchperspectives.perspectiveid") String id) {
+        PerspectivesProvider provider = new PerspectivesProvider(app, partService, modelService);
+        provider.switchPerspective(id);
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/views/PerspectiveSwitcherView.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/views/PerspectiveSwitcherView.java
@@ -1,7 +1,6 @@
 package uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher.views;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import javax.annotation.PostConstruct;


### PR DESCRIPTION
### Description of work

I added a shortcut to reset a perspective's layout. The shortcut is "Alt+Shift+O". This is a bit awkward, "O" isn't the first letter that pops to mind when thinking of "Reset Layout" but  "Alt+Shift+R", "Alt+Shift+E", "Alt+Shift+A", "Alt+Shift+L", "Alt+Shift+Y" are already taken. "Alt+Shift+Z" could maybe be better as it is close to "Ctrl+Z" that is often used to undo the last change?

**Note: it has been implemented as Alt+Shift+Z**

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3421

### Acceptance criteria

- "Alt+Shift+O" resets the current perspective's layout.
- "Alt+Shift+O" is a suitable keybinding.

### Unit tests

None required.

### System tests

None required.

### Documentation
None found.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

