### PR TITLE
Ticket3397

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerWritable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerWritable.java
@@ -42,25 +42,32 @@ public class PVManagerWritable<T> extends WritablePV<T> {
 	private final WriteExpressionImpl<T> writeExpression;
 	private final PVWriter<T> pv;
 	
+	private final Object pvLock = new Object();
+	
 	private final PVWriterListener<T> observingListener = new PVWriterListener<T>() {
+		/**
+		 * Implementation note: MUST be thread-safe!
+		 */
 		@Override
 		public void pvChanged(PVWriterEvent<T> evt) {
-			if (pv == null) {
-				return;
-			}
-			
-			if (evt.isConnectionChanged()) {
-				LoggerUtils.logIfExtraDebug(IsisLog.getLogger(getClass()),
-						"(Ticket 3001) PV canWrite changed to " + pv.isWriteConnected() + ". This PV is " + details().address());
-				canWriteChanged(pv.isWriteConnected());
-			}
-			
-			if (evt.isExceptionChanged()) {
-				error(pv.lastWriteException());
-			}
-			
-			if (evt.isWriteFailed()) {
-				error(new WriteException("Write failed"));
+			synchronized (pvLock) {
+				if (pv == null) {
+					return;
+				}
+				
+				if (evt.isConnectionChanged()) {
+					LoggerUtils.logIfExtraDebug(IsisLog.getLogger(getClass()),
+							"(Ticket 3001) PV canWrite changed to " + pv.isWriteConnected() + ". This PV is " + details().address());
+					canWriteChanged(pv.isWriteConnected());
+				}
+				
+				if (evt.isExceptionChanged()) {
+					error(pv.lastWriteException());
+				}
+				
+				if (evt.isWriteFailed()) {
+					error(new WriteException("Write failed"));
+				}
 			}
 		}
 	};
@@ -76,23 +83,26 @@ public class PVManagerWritable<T> extends WritablePV<T> {
 	
 	@Override
 	public void write(T value) throws IOException {
-	    
-	    if (!canWrite()) {
-	        String message = "Can't write to PV '" + writeExpression.getName() + "'.";
-	        
-	        if (pv.lastWriteException() != null) {
-	            message += " Caused by: " + pv.lastWriteException().toString();
-	            throw new IOException(message, pv.lastWriteException());
-	        } else {
-	            throw new IOException(message);
-	        }
+	    synchronized (pvLock) {
+		    if (!canWrite()) {
+		        String message = "Can't write to PV '" + writeExpression.getName() + "'.";
+		        
+		        if (pv.lastWriteException() != null) {
+		            message += " Caused by: " + pv.lastWriteException().toString();
+		            throw new IOException(message, pv.lastWriteException());
+		        } else {
+		            throw new IOException(message);
+		        }
+		    }
+		    
+			pv.write(value);
 	    }
-	    
-		pv.write(value);
 	}
 
 	@Override
 	public void close() {
-		pv.close();
+		synchronized (pvLock) {
+			pv.close();
+		}
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/writing/ForwardingWritable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/writing/ForwardingWritable.java
@@ -44,7 +44,7 @@ public class ForwardingWritable<TIn, TOut> extends BaseWritable<TIn> {
 		public void write(TIn value) throws IOException {
             TOut tranformedValue = transform(value);
             if (tranformedValue != null) {
-                writeToWritables(tranformedValue);
+            	writeToWritables(tranformedValue);
             }
 		}
 		

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/ConfigHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/ConfigHandler.java
@@ -51,17 +51,13 @@ public abstract class ConfigHandler<T> {
 	protected static final Editing EDITING = Configurations.getInstance().edit();
 	/** can execute the handler */
 	private boolean canExecute;
-	
-	private static final Object LOCK = new Object();
 
 	/**
 	 * The Handler can be executed.
 	 * @param canExecute true if it can be executed; false otherwise
 	 */
 	protected void setCanExecute(boolean canExecute) {
-		synchronized (LOCK) {
-			this.canExecute = canExecute;
-		}
+		this.canExecute = canExecute;
 	}
 	
 	/**
@@ -70,9 +66,7 @@ public abstract class ConfigHandler<T> {
 	 */
 	@CanExecute
 	public boolean canExecute() {
-		synchronized (LOCK) {
-			return this.canExecute;
-		}
+		return this.canExecute;
 	}
 	
 	/**
@@ -86,8 +80,6 @@ public abstract class ConfigHandler<T> {
 				canWriteChanged(canWrite);
 			}
 		};
-		
-		
 	};
 	
 	/**
@@ -119,13 +111,11 @@ public abstract class ConfigHandler<T> {
      */
     @Execute
     public final void execute(Shell shell) {
-    	synchronized (LOCK) {
-	        try {
-	            safeExecute(shell);
-	        } catch (RuntimeException e) {
-	            onError(e);
-	        }
-    	}
+        try {
+            safeExecute(shell);
+        } catch (RuntimeException e) {
+            onError(e);
+        }
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/EditCurrentConfigHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/EditCurrentConfigHandler.java
@@ -40,7 +40,7 @@ import uk.ac.stfc.isis.ibex.ui.configserver.commands.helpers.ViewConfigHelper;
  * 
  * It sets the menu labels, and opens the dialogue for editing or viewing a configuration.
  */
-public class EditCurrentConfigHandler extends DisablingConfigHandler<Configuration> {
+public class EditCurrentConfigHandler extends ConfigHandler<Configuration> {
 
     private static final String EDIT_MENU_TEXT = "Edit Current Configuration...";
     private static final String READ_ONLY_TEXT = "View Current Configuration...";

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/EditCurrentConfigHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/EditCurrentConfigHandler.java
@@ -40,7 +40,7 @@ import uk.ac.stfc.isis.ibex.ui.configserver.commands.helpers.ViewConfigHelper;
  * 
  * It sets the menu labels, and opens the dialogue for editing or viewing a configuration.
  */
-public class EditCurrentConfigHandler extends ConfigHandler<Configuration> {
+public class EditCurrentConfigHandler extends DisablingConfigHandler<Configuration> {
 
     private static final String EDIT_MENU_TEXT = "Edit Current Configuration...";
     private static final String READ_ONLY_TEXT = "View Current Configuration...";


### PR DESCRIPTION
### Description of work

Fixes some concurrency issues in some writable / writer layers which were causing items in the configuration menus to be greyed out erroneously.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3397

### Acceptance criteria

With the master branch:
- Open the GUI 10 times pointing at an instrument with a running blockserver
- Confirm that sometimes, some of the items in the configuration menus are greyed out when they shouldn't be.

With this branch
- Open the GUI 10 times pointing at an instrument with a running blockserver
- Confirm that the correct set of menu items is enabled reliably

### Unit tests

This is to do with multithreading - it would be very hard to unit test.

### System tests

This already has appropriate system test coverage because almost all of the squish tests interact with the configuration menu(s) in some way. The original bug was caught by the existing squish tests.

### Documentation

Comments added to code to clarify thread safety conditions.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

