### PR TITLE
Ticket3425 fix memory leak

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/IocState.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/IocState.java
@@ -38,19 +38,20 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
 
 /**
  * Class to hold information about the state of an IOC.
- *
- * Note: instances of this class are recreated each time the configuration changes.
- * Need to make sure that there are no references to this class left over after a 
- * configuration change, otherwise will get a memory leak. Registering an observer
- * in an observable means you WILL have a reference back from the observable to this
- * class.
  */
 public class IocState extends ModelObject implements Comparable<IocState>, INamed {
-	
+    
+    /**
+     * Note: instances of this class are recreated each time the configuration changes.
+     * Need to make sure that there are no references to this class left over after a 
+     * configuration change, otherwise will get a memory leak. Registering an observer
+     * in an observable means you WILL have a reference back from the observable to this
+     * class.
+     */
     private static final ForwardingObservable<Configuration> CURRENT_CONFIG_OBSERVABLE = 
-    		Configurations.getInstance().server().currentConfig();
+            Configurations.getInstance().server().currentConfig();
 
-	private final String name;
+    private final String name;
 
     private boolean isRunning;
     private final String description;
@@ -105,13 +106,16 @@ public class IocState extends ModelObject implements Comparable<IocState>, IName
     }
 
     /**
-     * Gets whether or not the IOC is in the current configuration.
+     * Gets whether or not the IOC is in the current configuration. The result is calculated
+     * at run-time so that it is as up to date as possible with the actual configuration
+     * being used. Can't easily use listeners here because it will cause a memory leak (see
+     * javadoc at top of class)
      * 
      * @return true if it is in the current configuration; false otherwise.
      */
     public boolean getInCurrentConfig() {
         return CURRENT_CONFIG_OBSERVABLE.getValue().getIocs().stream()
-        		.anyMatch(ioc -> Objects.equals(ioc.getName(), name));
+                .anyMatch(ioc -> Objects.equals(ioc.getName(), name));
     }
 
     @Override

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/IocState.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/IocState.java
@@ -38,22 +38,24 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
 
 /**
  * Class to hold information about the state of an IOC.
+ * 
+ * Implementation note: this class represents an immutable instance of the state
+ * of an IOC at a particular time.
  */
 public class IocState extends ModelObject implements Comparable<IocState>, INamed {
-    
+
     /**
-     * Note: instances of this class are recreated each time the configuration changes.
-     * Need to make sure that there are no references to this class left over after a 
-     * configuration change, otherwise will get a memory leak. Registering an observer
-     * in an observable means you WILL have a reference back from the observable to this
-     * class.
+     * Note: instances of this class are recreated each time the configuration
+     * changes. Need to make sure that there are no references to this class
+     * left over after a configuration change, otherwise will get a memory leak.
+     * Registering an observer in an observable means you WILL have a reference
+     * back from the observable to this class.
      */
-    private static final ForwardingObservable<Configuration> CURRENT_CONFIG_OBSERVABLE = 
-            Configurations.getInstance().server().currentConfig();
+    private static final ForwardingObservable<Configuration> CURRENT_CONFIG_OBSERVABLE = Configurations.getInstance()
+	    .server().currentConfig();
 
     private final String name;
-
-    private boolean isRunning;
+    private final boolean isRunning;
     private final String description;
 
     /**
@@ -65,35 +67,30 @@ public class IocState extends ModelObject implements Comparable<IocState>, IName
      *            whether the IOC is running
      * @param description
      *            description of the IOC
-     * @param allowControl
-     *            whether the user is allowed control it
      */
     public IocState(String name, boolean isRunning, String description) {
-        this.name = name;
-        this.isRunning = isRunning;
-        this.description = description;
+	this.name = name;
+	this.isRunning = isRunning;
+	this.description = description;
     }
 
+    /**
+     * Gets the name of the IOC corresponding to this IOCState.
+     * 
+     * @return the name
+     */
     @Override
     public String getName() {
-        return name;
+	return name;
     }
 
     /**
+     * Gets whether this IOC is running or not.
      * 
-     * @return True if it is running; False otherwise
+     * @return true if it is running; false otherwise
      */
     public boolean getIsRunning() {
-        return isRunning;
-    }
-
-    /**
-     *
-     * @param isRunning
-     *            true if it is running; False if not running
-     */
-    public void setIsRunning(boolean isRunning) {
-        firePropertyChange("isRunning", this.isRunning, this.isRunning = isRunning);
+	return isRunning;
     }
 
     /**
@@ -102,24 +99,27 @@ public class IocState extends ModelObject implements Comparable<IocState>, IName
      * @return the description
      */
     public String getDescription() {
-        return description;
+	return description;
     }
 
     /**
-     * Gets whether or not the IOC is in the current configuration. The result is calculated
-     * at run-time so that it is as up to date as possible with the actual configuration
-     * being used. Can't easily use listeners here because it will cause a memory leak (see
-     * javadoc at top of class)
+     * Gets whether or not the IOC is in the current configuration. The result
+     * is calculated at run-time so that it is as up to date as possible with
+     * the actual configuration being used. Can't easily use listeners here
+     * because it will cause a memory leak.
      * 
      * @return true if it is in the current configuration; false otherwise.
      */
     public boolean getInCurrentConfig() {
-        return CURRENT_CONFIG_OBSERVABLE.getValue().getIocs().stream()
-                .anyMatch(ioc -> Objects.equals(ioc.getName(), name));
+	return CURRENT_CONFIG_OBSERVABLE.getValue().getIocs().stream()
+		.anyMatch(ioc -> Objects.equals(ioc.getName(), name));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int compareTo(IocState iocState) {
-        return name.compareTo(iocState.getName());
+	return name.compareTo(iocState.getName());
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/json/IocStateConverter.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/json/IocStateConverter.java
@@ -21,28 +21,28 @@ package uk.ac.stfc.isis.ibex.configserver.json;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Map.Entry;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import java.util.stream.Collectors;
 
 import uk.ac.stfc.isis.ibex.configserver.IocState;
 import uk.ac.stfc.isis.ibex.configserver.internal.IocParameters;
 import uk.ac.stfc.isis.ibex.epics.conversion.ConversionException;
 import uk.ac.stfc.isis.ibex.epics.conversion.Converter;
 
+/**
+ * Converts a JSON representation of the state of an IOC into a java object representation.
+ */
 public class IocStateConverter extends Converter<Map<String, IocParameters>, Collection<IocState>> {
-	
+	/**
+	 * Converts a JSON representation of the state of an IOC into a java object representation.
+	 * 
+	 * @param value the value to convert
+	 * 
+	 * @return a collection of converted values
+	 */
 	@Override
 	public Collection<IocState> convert(Map<String, IocParameters> value) throws ConversionException {
-		return Lists.newArrayList(Iterables.transform(value.entrySet(), new Function<Map.Entry<String, IocParameters>, IocState>() {
-			@Override
-			public IocState apply(Entry<String, IocParameters> entry) {
-				String name = entry.getKey();
-                IocParameters parameters = entry.getValue();
-                return new IocState(name, parameters.isRunning(), parameters.getDescription(), true);
-			}
-		}));
+		return value.entrySet().stream()
+				.map(entry -> new IocState(entry.getKey(), entry.getValue().isRunning(), entry.getValue().getDescription()))
+				.collect(Collectors.toSet());
 	}
 }


### PR DESCRIPTION
### Description of work

Fixes a memory leak when repeatedly loading configurations.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3425

### Acceptance criteria

- Loading configs repeatedly does not cause memory usage to continuously increase (look for the amount of memory immediately after forcing a garbage-collection using the java visual VM).

### Unit tests

- They should all still pass

### System tests

...

### Documentation

Comments added to relevant area of code.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

