### PR TITLE
Better logic for stop all button.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.banner/src/uk/ac/stfc/isis/ibex/banner/motion/ObservableMotionControl.java
+++ b/base/uk.ac.stfc.isis.ibex.banner/src/uk/ac/stfc/isis/ibex/banner/motion/ObservableMotionControl.java
@@ -32,7 +32,7 @@ public class ObservableMotionControl extends ModelAdapter {
 
 	private static final Long STOP_VALUE = 1L;
 	
-	private final SameTypeWriter<Long> stop = new SameTypeWriter<Long>();;
+	private final SameTypeWriter<Long> stop = new SameTypeWriter<Long>();
 
 	private SettableUpdatedValue<Boolean> canWrite = new SettableUpdatedValue<Boolean>();
 	

--- a/base/uk.ac.stfc.isis.ibex.banner/src/uk/ac/stfc/isis/ibex/banner/motion/ObservableMotionControl.java
+++ b/base/uk.ac.stfc.isis.ibex.banner/src/uk/ac/stfc/isis/ibex/banner/motion/ObservableMotionControl.java
@@ -22,6 +22,8 @@ package uk.ac.stfc.isis.ibex.banner.motion;
 import uk.ac.stfc.isis.ibex.epics.adapters.ModelAdapter;
 import uk.ac.stfc.isis.ibex.epics.writing.SameTypeWriter;
 import uk.ac.stfc.isis.ibex.epics.writing.Writable;
+import uk.ac.stfc.isis.ibex.model.SettableUpdatedValue;
+import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 
 /**
  * An observable used to control the motors.
@@ -30,7 +32,9 @@ public class ObservableMotionControl extends ModelAdapter {
 
 	private static final Long STOP_VALUE = 1L;
 	
-	private final SameTypeWriter<Long> stop = new SameTypeWriter<>();
+	private final SameTypeWriter<Long> stop = new SameTypeWriter<Long>();;
+
+	private SettableUpdatedValue<Boolean> canWrite = new SettableUpdatedValue<Boolean>();
 	
     /**
      * Constructor for the observable.
@@ -40,6 +44,12 @@ public class ObservableMotionControl extends ModelAdapter {
      */
 	public ObservableMotionControl(Writable<Long> stop) {
 		this.stop.writeTo(stop);
+		stop.subscribe(new SameTypeWriter<Long>() {
+			@Override
+			public void onCanWriteChanged(boolean canwrite) {
+				ObservableMotionControl.this.canWrite.setValue(canwrite);
+			}
+		});
 	}
 
     /**
@@ -47,5 +57,13 @@ public class ObservableMotionControl extends ModelAdapter {
      */
 	public void stop() {
 	    stop.uncheckedWrite(STOP_VALUE);
+	}
+
+	/**
+	 * Whether this writable can be written to at present.
+	 * @return an updated value wrapping whether you can write to this writable
+	 */
+	public UpdatedValue<Boolean> canWrite() {
+		return canWrite;
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.banner/src/uk/ac/stfc/isis/ibex/ui/banner/models/MotionControlModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.banner/src/uk/ac/stfc/isis/ibex/ui/banner/models/MotionControlModel.java
@@ -19,34 +19,44 @@
 
 package uk.ac.stfc.isis.ibex.ui.banner.models;
 
-import uk.ac.stfc.isis.ibex.banner.InMotionState;
 import uk.ac.stfc.isis.ibex.banner.Observables;
 import uk.ac.stfc.isis.ibex.banner.motion.ObservableMotionControl;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 import uk.ac.stfc.isis.ibex.ui.banner.controls.ControlModel;
-import uk.ac.stfc.isis.ibex.ui.banner.indicators.IndicatorStateObserver;
 
+/**
+ * The model for the stop all motors button in the banner.
+ */
 public class MotionControlModel extends ModelObject implements ControlModel {
 	
 	private final ObservableMotionControl motionControl;
 	private static final String TEXT = "Stop All";
 	
-	private IndicatorStateObserver<InMotionState> inMotion;
-	
 	public MotionControlModel(Observables observables) {
 		motionControl = new ObservableMotionControl(observables.stop);
-		inMotion = new IndicatorStateObserver<InMotionState>(observables.inMotion, new InMotionViewState());
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public UpdatedValue<Boolean> enabled() {	
-		return inMotion.bool();
+		return motionControl.canWrite();
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public void click() {
 		motionControl.stop();
 	}
 	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
 	public String text() {
 		return TEXT;
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.banner/src/uk/ac/stfc/isis/ibex/ui/banner/models/MotionControlModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.banner/src/uk/ac/stfc/isis/ibex/ui/banner/models/MotionControlModel.java
@@ -33,6 +33,12 @@ public class MotionControlModel extends ModelObject implements ControlModel {
 	private final ObservableMotionControl motionControl;
 	private static final String TEXT = "Stop All";
 	
+	/**
+	 * The model for the stop all motors button in the banner.
+	 * 
+	 * @param observables
+	 *                     The observables class associated with the motion control.
+	 */
 	public MotionControlModel(Observables observables) {
 		motionControl = new ObservableMotionControl(observables.stop);
 	}


### PR DESCRIPTION
### Description of work

Stop all button is permanently enabled when it is writable (even if motors not moving)

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3399

### Acceptance criteria

Stop all button is permanently enabled when it is writable (even if motors not moving)

### Unit tests

n/a - UI change only

### System tests

n/a

### Documentation

n/a

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

