### PR TITLE
Can now delete synoptics

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -569,7 +569,7 @@
   <commands xmi:id="_kcuRwHtaEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.configuration.delete" commandName="Delete configuration" description="Delete an existing configuration" category="_La_dMHtbEeeIzM7lvAxMoQ"/>
   <commands xmi:id="_jpCRYHtiEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.component.new" commandName="New component" description="Create a new component" category="_DlkfcHtjEeeIzM7lvAxMoQ"/>
   <commands xmi:id="_kNSN8HtiEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.component.edit" commandName="Edit component" description="Select and edit an existing component" category="_DlkfcHtjEeeIzM7lvAxMoQ"/>
-  <commands xmi:id="_keEb8HtiEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.component.delete" commandName="Delete component" description="Delete an existing component" category="_DlkfcHtjEeeIzM7lvAxMoQ"/>
+  <commands xmi:id="_keEb8HtiEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.component.delete" commandName="Delete component " description="Delete an existing component" category="_DlkfcHtjEeeIzM7lvAxMoQ"/>
   <commands xmi:id="_bjIjUHz5EeeSXZfE9ugy5A" elementId="uk.ac.stfc.isis.ibex.e4.client.command.waitfor" commandName="Wait for Instrument" description="Command indicating that the client is waiting for the instrument"/>
   <commands xmi:id="_QRQe4JojEeeX2q28a93CXA" elementId="uk.ac.stfc.isis.ibex.e4.client.command.switchinstruments" commandName="Switch Instruments"/>
   <commands xmi:id="_5YCA0JxFEeeX2q28a93CXA" elementId="uk.ac.stfc.isis.ibex.e4.client.command.managermode" commandName="Manager mode" description="Manager mode"/>

--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -569,7 +569,7 @@
   <commands xmi:id="_kcuRwHtaEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.configuration.delete" commandName="Delete configuration" description="Delete an existing configuration" category="_La_dMHtbEeeIzM7lvAxMoQ"/>
   <commands xmi:id="_jpCRYHtiEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.component.new" commandName="New component" description="Create a new component" category="_DlkfcHtjEeeIzM7lvAxMoQ"/>
   <commands xmi:id="_kNSN8HtiEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.component.edit" commandName="Edit component" description="Select and edit an existing component" category="_DlkfcHtjEeeIzM7lvAxMoQ"/>
-  <commands xmi:id="_keEb8HtiEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.component.delete" commandName="Delete component " description="Delete an existing component" category="_DlkfcHtjEeeIzM7lvAxMoQ"/>
+  <commands xmi:id="_keEb8HtiEeeIzM7lvAxMoQ" elementId="uk.ac.stfc.isis.ibex.e4.client.component.delete" commandName="Delete component" description="Delete an existing component" category="_DlkfcHtjEeeIzM7lvAxMoQ"/>
   <commands xmi:id="_bjIjUHz5EeeSXZfE9ugy5A" elementId="uk.ac.stfc.isis.ibex.e4.client.command.waitfor" commandName="Wait for Instrument" description="Command indicating that the client is waiting for the instrument"/>
   <commands xmi:id="_QRQe4JojEeeX2q28a93CXA" elementId="uk.ac.stfc.isis.ibex.e4.client.command.switchinstruments" commandName="Switch Instruments"/>
   <commands xmi:id="_5YCA0JxFEeeX2q28a93CXA" elementId="uk.ac.stfc.isis.ibex.e4.client.command.managermode" commandName="Manager mode" description="Manager mode"/>

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/DeleteSynopticHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/DeleteSynopticHandler.java
@@ -37,6 +37,7 @@ import uk.ac.stfc.isis.ibex.configserver.Configurations;
 import uk.ac.stfc.isis.ibex.configserver.configuration.ConfigInfo;
 import uk.ac.stfc.isis.ibex.epics.writing.SameTypeWriter;
 import uk.ac.stfc.isis.ibex.synoptic.Synoptic;
+import uk.ac.stfc.isis.ibex.synoptic.model.desc.SynopticDescription;
 import uk.ac.stfc.isis.ibex.ui.synoptic.editor.dialogs.MultipleSynopticsSelectionDialog;
 
 /**
@@ -62,10 +63,18 @@ public class DeleteSynopticHandler extends SynopticEditorHandler {
                         + configsUsingSynoptics + ". Are you sure you want to delete them?");
     }
 
+    /**
+     * Runs dialog and tries to delete selected synoptic.
+     *
+     * @throws ExecutionException thrown when it can't find/write to PV.
+     *
+     * @return null.
+     */
     @Execute
-    public Object execute(ExecutionEvent event) throws ExecutionException {
-        MultipleSynopticsSelectionDialog dialog = new MultipleSynopticsSelectionDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), TITLE,
-                SYNOPTIC.availableEditableSynoptics());
+    public Object execute(Shell shell) throws ExecutionException {
+
+        MultipleSynopticsSelectionDialog dialog = new MultipleSynopticsSelectionDialog(shell, TITLE, SYNOPTIC.availableEditableSynoptics());
+
 		if (dialog.open() == Window.OK) {
             ConfigServer server = Configurations.getInstance().server();
             Collection<ConfigInfo> existingConfigs = server.configsInfo().getValue();

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/NewSynopticHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/NewSynopticHandler.java
@@ -33,7 +33,7 @@ public class NewSynopticHandler extends SynopticEditorHandler {
 	private static final String TITLE = "New Synoptic";
 	
 	@Execute
-	public Object execute(Shell shell) throws ExecutionException {	
+	public Object execute(Shell shell) throws ExecutionException {
 		openDialog(shell, new SynopticDescription(), TITLE, true);
 		return null;
 	}


### PR DESCRIPTION
### Description of work

Users can now delete synoptics again 

### Ticket

[3488](https://github.com/ISISComputingGroup/IBEX/issues/3488)

### Acceptance criteria

- Can delete synoptics 

### Unit tests

None

### System tests

Squish test under creaion now 

### Documentation

None

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

