### PR TITLE
Ticket 3515 - Added test for duplicate OPI keys and removed exisiting duplicates.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlDupeCheck.java
+++ b/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlDupeCheck.java
@@ -1,0 +1,74 @@
+package uk.ac.stfc.isis.ibex.opis.tests.desc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.Path;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.epics.conversion.XMLUtil;
+import uk.ac.stfc.isis.ibex.opis.OpiProvider;
+import uk.ac.stfc.isis.ibex.opis.desc.OpiDescription;
+
+public class XmlDupeCheck {
+	
+	@XmlAccessorType(XmlAccessType.FIELD)
+	private static class OpiEntry {
+		public String key;
+		public OpiDescription value;
+	}
+	
+	@XmlRootElement(name = "descriptions")
+	@XmlAccessorType(XmlAccessType.FIELD)
+	private static class KeyList {
+		@XmlElementWrapper(name = "opis")
+		@XmlElement(name = "entry", type = OpiEntry.class)
+		public List<OpiEntry> keys;
+		
+		public Set<String> getDuplicateKeys() {
+			Set<String> uniques = new HashSet<>();
+			return keys.stream()
+					.map(entry -> entry.key)
+					.filter(key -> !uniques.add(key))
+					.collect(Collectors.toSet());
+		}
+		
+	}
+	
+	@Test
+	public void test_that_fails() throws IOException, JAXBException {
+	   	
+		Path path = new Path("../uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml");
+		assertNotNull("Path not found", path);
+	    KeyList keyList = XMLUtil.fromXml(new FileReader(path.toOSString()), KeyList.class);
+	    
+	    Set<String> duplicates = keyList.getDuplicateKeys();
+	    
+	    StringBuilder builder = new StringBuilder();
+	    builder.append("The following keys are duplicated in opi_info: ");
+
+	    for (String a : duplicates) {
+	    	builder.append(String.format("%s, ", a));
+	    }
+	    
+	    assertEquals(builder.toString(), 0, duplicates.size());
+	}
+
+}

--- a/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlDuplicateCheck.java
+++ b/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlDuplicateCheck.java
@@ -22,8 +22,8 @@ import org.junit.Test;
 import uk.ac.stfc.isis.ibex.epics.conversion.XMLUtil;
 
 /**
- * Here we don't use the default Xml parser class is we need to check the keys in the OPI list. 
- * 
+ * Here we don't use the default Xml parser class in Descriptions.java as it uses
+ * a map and we need to check all keys in the OPI list. 
  *
  */
 public class XmlDuplicateCheck {

--- a/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlDuplicateCheck.java
+++ b/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlDuplicateCheck.java
@@ -1,11 +1,8 @@
 package uk.ac.stfc.isis.ibex.opis.tests.desc;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.FileReader;
 import java.io.IOException;
-import java.net.URL;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -19,20 +16,21 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Path;
 import org.junit.Test;
 
 import uk.ac.stfc.isis.ibex.epics.conversion.XMLUtil;
-import uk.ac.stfc.isis.ibex.opis.OpiProvider;
-import uk.ac.stfc.isis.ibex.opis.desc.OpiDescription;
 
-public class XmlDupeCheck {
+/**
+ * Here we don't use the default Xml parser class is we need to check the keys in the OPI list. 
+ * 
+ *
+ */
+public class XmlDuplicateCheck {
 	
 	@XmlAccessorType(XmlAccessType.FIELD)
 	private static class OpiEntry {
 		public String key;
-		public OpiDescription value;
 	}
 	
 	@XmlRootElement(name = "descriptions")
@@ -42,33 +40,25 @@ public class XmlDupeCheck {
 		@XmlElement(name = "entry", type = OpiEntry.class)
 		public List<OpiEntry> keys;
 		
-		public Set<String> getDuplicateKeys() {
+		public Stream<String> getDuplicateKeys() {
 			Set<String> uniques = new HashSet<>();
 			return keys.stream()
 					.map(entry -> entry.key)
-					.filter(key -> !uniques.add(key))
-					.collect(Collectors.toSet());
-		}
-		
+					.filter(key -> !uniques.add(key));
+		}	
 	}
 	
 	@Test
-	public void test_that_fails() throws IOException, JAXBException {
-	   	
+	public void test_that_opi_info_file_does_not_contain_any_duplicate_keys() throws IOException, JAXBException {
 		Path path = new Path("../uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml");
-		assertNotNull("Path not found", path);
 	    KeyList keyList = XMLUtil.fromXml(new FileReader(path.toOSString()), KeyList.class);
 	    
-	    Set<String> duplicates = keyList.getDuplicateKeys();
+	    Set<String> duplicateKeys = keyList.getDuplicateKeys().collect(Collectors.toSet());
 	    
-	    StringBuilder builder = new StringBuilder();
-	    builder.append("The following keys are duplicated in opi_info: ");
-
-	    for (String a : duplicates) {
-	    	builder.append(String.format("%s, ", a));
-	    }
+		String error = String.format("The following keys are duplicated in opi_info: %s", 
+				String.join(", ", duplicateKeys));
 	    
-	    assertEquals(builder.toString(), 0, duplicates.size());
+	    assertEquals(error, 0, duplicateKeys.size());
 	}
 
 }

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -1,2533 +1,1555 @@
-<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <descriptions>
-	<opis>
-		<entry>
-			<key>Analyser</key>
-			<value>
-				<categories>
-					<category>Monitors</category>
-				</categories>
-				<type>ANALYSER</type>
-				<path>analyser.opi</path>
-				<description>The OPI for the analyser. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Attenuator</key>
-			<value>
-				<type>ATTENUATOR</type>
-				<path>attenuator.opi</path>
-				<description>The OPI for the attenuator. No properties required.</description>
-				<macros>               
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>XY Beam-stop</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>BEAMSTOP</type>
-				<path>beamstop.opi</path>
-				<description>The OPI for the XY beam-stop. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Caen HV</key>
-			<value>
-				<categories>
-					<category>Power supplies</category>
-				</categories>
-				<type>CAEN</type>
-				<path>HV/HVMonitorSummaryDisplay.opi</path>
-				<description>Summary display for Caens (maintenance of list via the button on this OPI). No properties required.</description>
-				<macros>
-					<macro>
-						<name>MAX_CRATES</name>
-						<description>The maximum number of crates to display (default: 2, max: 15)</description>
-					</macro>
-					<macro>
-						<name>MAX_SLOTS</name>
-						<description>The maximum number of slots to display per crate (default: 5)</description>
-					</macro>
-					<macro>
-						<name>MAX_CHANNELS</name>
-						<description>The maximum number of channels per slot per crate to display (default: 25)</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>CCD100</key>
-			<value>
-				<type>CCD100</type>
-				<path>CCD100/CCD100.opi</path>
-				<description>The OPI for a Chell CCD100</description>
-				<categories>
-					<category>Pressure sensors</category>
-					<category>Flow meters</category>
-				</categories>
-				<macros>
-          <macro>
-            <name>CCD_1</name>
-            <description>The PV prefix for the first CCD100 (e.g CCD100_01).</description>
-          </macro>
-          <macro>
-            <name>CCD_2</name>
-            <description>The PV prefix for the second CCD100 (e.g CCD100_01).</description>
-          </macro>
-          <macro>
-            <name>CCD_3</name>
-            <description>The PV prefix for the third CCD100 (e.g CCD100_01).</description>
-          </macro>
-          <macro>
-            <name>CCD_4</name>
-            <description>The PV prefix for the fourth CCD100 (e.g CCD100_01).</description>
-          </macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-      <key>Double Monitor</key>
-      <value>
-				<categories>
-					<category>Monitors</category>
-				</categories>
-				<type>MONITOR</type>
-        <path>double_monitor.opi</path>
-        <description>The OPI for a double fixed monitor.</description>
-        <macros>
-          <macro>
-            <name>M</name>
-            <description>The monitor number (e.g. 1).</description>
-          </macro>
-          <macro>
-            <name>MA</name>
-            <description>The internal number for the first channel (e.g. 1).</description>
-          </macro>
-          <macro>
-            <name>MB</name>
-            <description>The internal number for the second channel (e.g. 2).</description>
-          </macro>
-          <macro>
-            <name>MAHVCHAN</name>
-            <description>CAEN HV channel for A (e.g. 0).</description>
-          </macro>
-          <macro>
-            <name>MBHVCHAN</name>
-            <description>CAEN HV channel for B (e.g. 1).</description>
-          </macro>
-					<macro>		
-						<name>MAHVSLOT</name>		
-						<description>CAEN HV slot for A (e.g. 0).</description>		
-					</macro>						
-					<macro>		
-						<name>MBHVSLOT</name>		
-						<description>CAEN HV slot for B (e.g. 1).</description>		
-					</macro>
-				</macros>
-      </value>
-    </entry>
-		<entry>
-			<key>Eurotherm</key>
-			<value>
-				<categories>
-					<category>Temperature controllers</category>
-				</categories>
-				<type>EUROTHERM</type>
-				<path>Eurotherm.opi</path>
-				<description>The OPI for the Eurotherm crate connected to multiple Eurotherm temperature controllers.</description>
-				<macros>
-					<macro>
-						<name>EURO</name>
-						<description>The Eurotherm PV prefix (e.g. EUROTHRM_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Mercury iTC</key>
-			<value>
-				<categories>
-					<category>Temperature controllers</category>
-					<category>Cryogenics</category>
-				</categories>
-				<type>MERCURY</type>
-				<path>mercuryiTC\mercuryiTC.opi</path>
-				<description>The OPI for the Mercury temperature controller.</description>
-				<macros>
-					<macro>
-						<name>MERCURY</name>
-						<description>The Mercury PV prefix (e.g. MERCURY_01).</description>
-					</macro>
-					<macro>
-						<name>TEMP_NUM1</name>
-						<description>The first temperature card number (e.g. 1, optional).</description>
-					</macro>
-					<macro>
-						<name>TEMP_NUM2</name>
-						<description>The second temperature card number (e.g. 2, optional).</description>
-					</macro>
-					<macro>
-						<name>TEMP_NUM3</name>
-						<description>The third temperature card number (e.g. 3, optional).</description>
-					</macro>
-					<macro>
-						<name>TEMP_NUM4</name>
-						<description>The fourth temperature card number (e.g. 4, optional).</description>
-					</macro>
-					<macro>
-						<name>LEVEL_NUM1</name>
-						<description>The first level card number (e.g. 1, optional).</description>
-					</macro>
-					<macro>
-						<name>LEVEL_NUM2</name>
-						<description>The second level card number (e.g. 1, optional).</description>
-          </macro>
-				</macros>
-			</value>
-    </entry>
-		<entry>
-			<key>In Out Monitor</key>
-			<value>
-				<categories>
-					<category>Monitors</category>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>MOVINGMONITOR</type>
-				<path>inout_monitor.opi</path>
-				<description>The OPI for a moving monitor.</description>
-				<macros>
-					<macro>
-						<name>M</name>
-						<description>The monitor number (e.g. 1).</description>
-					</macro>
-					<macro>
-						<name>MM</name>
-						<description>The motor PV relating to the motor controlling the monitor (e.g. MOT:MTR0605).</description>
-          </macro>
-					<macro>		
-						<name>MHVCHAN</name>		
-						<description>CAEN HV channel for the monitor (default: 0).</description>		
-					</macro>
-					<macro>		
-						<name>MHVSLOT</name>		
-						<description>CAEN HV slot for the monitor (default: 0).</description>		
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Jaws</key>
-			<value>
-				<categories>
-					<category>Jaws and slits</category>
-				</categories>
-				<type>JAWS</type>
-				<path>jaws/jaws.opi</path>
-				<description>The OPI for a Jaw set.</description>
-				<macros>
-					<macro>
-						<name>J</name>
-						<description>The Jaws PV (e.g. MOT:JAWS1).</description>
-          </macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Julabo FL300</key>
-			<value>
-				<categories>
-					<category>Water baths</category>
-					<category>Temperature controllers</category>
-				</categories>
-				<type>JULABO</type>
-				<path>JulaboFL300.opi</path>
-				<description>The OPI for the Julabo FL300 temperature controller. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Julabo FP50</key>
-			<value>
-				<categories>
-					<category>Water baths</category>
-					<category>Temperature controllers</category>
-				</categories>
-				<type>JULABO</type>
-				<path>JulaboFP50.opi</path>
-				<description>The OPI for the Julabo FP50 temperature controller..</description>
-				<macros>
-					<macro>
-						<name>JULABO</name>
-						<description>The Julabo PV prefix (e.g. JULABO_01).</description>
-          </macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Linkam 95</key>
-			<value>
-				<categories>
-					<category>Temperature controllers</category>
-				</categories>
-				<type>LINKAM95</type>
-				<path>linkam95.opi</path>
-				<description>The OPI for the Linkam 95 temperature controller.</description>
-        <macros>
-					<macro>
-						<name>LINKAM95</name>
-						<description>The Linkam 95 PV prefix (e.g. LINKAM95_01).</description>
-          </macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Keithley 2400</key>
-			<value>
-				<categories>
-					<category>Multimeters</category>
-				</categories>
-				<type>KHLY2400</type>
-				<path>Keithley2400/Keithley2400.opi</path>
-				<description>The OPI for the Keithley 2400 Source Meter.</description>
-				<macros>
-					<macro>
-						<name>KHLY2400</name>
-						<description>The Keithley 2400 PV name (e.g. KHLY2400_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Keithley 2700</key>
-			<value>
-				<categories>
-					<category>Multimeters</category>
-				</categories>
-				<type>KHLY2700</type>
-				<path>Keithley2700/keithley_scanner_values.opi</path>
-				<description>The OPI for the Keithley 2700 Source Meter.</description>
-				<macros>
-					<macro>
-						<name>KHLY2700</name>
-						<description>The Keithley 2700 PV name (e.g. KHLY2700_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Kepco</key>
-			<value>
-				<categories>
-					<category>Power supplies</category>
-				</categories>
-				<type>KEPCO</type>
-				<path>kepco.opi</path>
-				<description>The OPI for the Kepco power supply.</description>
-				<macros>
-					<macro>
-						<name>KEPCO</name>
-						<description>The Kepco PV name (e.g. KEPCO_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Lakeshore 218</key>
-			<value>
-				<categories>
-					<category>Temperature controllers</category>
-				</categories>
-				<type>LAKESHORE</type>
-				<path>Lakeshore218.opi</path>
-				<description>The OPI for the Lakeshore 218 temperature controller.</description>
-				<macros>
-					<macro>
-						<name>LAKESHORE218</name>
-            <description>The Lakeshore 218 PV prefix (e.g. LKSH218_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Lakeshore 336</key>
-			<value>
-				<categories>
-					<category>Temperature controllers</category>
-				</categories>
-				<type>LAKESHORE</type>
-				<path>Lakeshore336/Lakeshore336.opi</path>
-				<description>The OPI for the Lakeshore 336 temperature controller.</description>
-				<macros>
-					<macro>
-						<name>LAKESHORE336</name>
-            <description>The Lakeshore 336 PV prefix (e.g. LKSH336_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Mk3 Chopper</key>
-			<value>
-				<categories>
-					<category>Choppers</category>
-				</categories>
-				<type>CHOPPER</type>
-				<path>Mk3Chopper/multiple_choppers.opi</path>
-				<description>The OPI for the Mk3 chopper. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Mk2 Chopper</key>
-			<value>
-				<categories>
-					<category>Choppers</category>
-				</categories>
-				<type>CHOPPER</type>
-				<path>Mk2Chopper.opi</path>
-				<description>The OPI for the Mk2 chopper.</description>
-				<macros>
-					<macro>
-						<name>MK2CHOPR</name>
-            <description>The Mk2 Chopper PV prefix (e.g. MK2CHOPR_01).</description>
-					</macro>
-				</macros>
-			</value>
-    </entry>
-		<entry>
-			<key>Monitor</key>
-			<value>
-				<categories>
-					<category>Monitors</category>
-				</categories>
-				<type>MONITOR</type>
-				<path>monitor.opi</path>
-				<description>The OPI for a fixed monitor.</description>
-				<macros>
-					<macro>
-						<name>M</name>
-						<description>The monitor number (e.g. 1).</description>
-          </macro>
-					<macro>
-						<name>MHVCHAN</name>
-						<description>CAEN HV channel for the monitor (default: 0).</description>
-					</macro>
+    <opis>
+        <entry>
+            <key>Motion Set Point</key>
+            <value>
+                <type>MOTION_SET_POINTS</type>
+                <path>stage/motion_setpoint.opi</path>
+                <description>The OPI for motion setpoints</description>
+                <macros>
                     <macro>
-						<name>MHVSLOT</name>
-						<description>CAEN HV slot for the monitor (default: 0).</description>
-					</macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Moxa E1210</key>
-      <value>
-        <categories>
-        </categories>
-        <type>MOXA_1210</type>
-        <path>moxa1210.opi</path>
-        <description>The OPI for a Moxa E1210 remote I/O.</description>
-        <macros>
-          <macro>
-            <name>MOXA1210</name>
-            <description>The Moxa E1210 PV prefix (e.g. MOXA1210_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Pinhole Selector</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-        </categories>
-        <type>PINHOLESELECTOR</type>
-        <path>pinhole_selector\pinhole_selector.opi</path>
-        <description>The OPI for the pinhole selector.</description>
-        <macros>
-          <macro>
-            <name>PH</name>
-            <description>The name of the device, as defined in the positions look-up file (e.g. PINHOLE)</description>
-          </macro>
-          <macro>
-            <name>MM</name>
-            <description>The motor PV to point at, as defined in the motionsetpoints file (e.g. MOT:MTR0605)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>PGC</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-        </categories>
-        <type>PGC</type>
-        <path>pgc\pgc.opi</path>
-        <description>The OPI for the Polariser , Guide and Collimation ticket.</description>
-        <macros>
-          <macro>
-            <name>PGC</name>
-            <description>The name of the device, as defined in the positions look-up file (e.g. PGC))</description>
-          </macro>
-          <macro>
-            <name>MM</name>
-            <description>The motor PV to point at (as defined in the motionsetpoints file (e.g. MOT:MTR0101))</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Pixelman</key>
-      <value>
-        <categories>
-          <category>Imaging cameras</category>
-        </categories>
-        <type>PIXELMAN</type>
-        <path>pixelman.opi</path>
-        <description>Description required.</description>
-        <macros>
-          <macro>
-            <name>Q</name>
-            <description>Description required.</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Polariser</key>
-      <value>
-        <type>POLARISER</type>
-        <path>polariser.opi</path>
-        <description>The OPI for the polariser. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Rotating Bench</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-        </categories>
-        <type>ROTATINGBENCH</type>
-        <path>rotating_bench.opi</path>
-        <description>The OPI for the LARMOR rotating bench.</description>
-        <macros>
-          <macro>
-            <name>MM</name>
-            <description>The PV for the motor controlling the bench rotation (e.g. MOT:MTR0605).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Sample changer</key>
-      <value>
-        <categories>
-          <category>Sample changers</category>
-        </categories>
-        <type>SAMPLECHANGER</type>
-        <path>stage/sample_changer.opi</path>
-        <description>The OPI for the sample changer. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Linear sample changer</key>
-      <value>
-        <categories>
-          <category>Sample changers</category>
-        </categories>
-        <type>LINEARSAMPLECHANGER</type>
-        <path>stage/linear_sample_changer.opi</path>
-        <description>The OPI for the linear sample changer. No properties required.</description>
-        <macros>
-				</macros>
-			</value>
-		</entry> 
-		<entry>
-			<key>In Out Monitor</key>
-			<value>
-				<categories>
-					<category>Monitors</category>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>MOVINGMONITOR</type>
-				<path>inout_monitor.opi</path>
-				<description>The OPI for a moving monitor.</description>
-				<macros>
-					<macro>
-						<name>M</name>
-						<description>The monitor number (e.g. 1).</description>
-					</macro>
-					<macro>
-						<name>MM</name>
-						<description>The motor PV relating to the motor controlling the monitor (e.g. MOT:MTR0605).</description>
-					</macro>              
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Sample stage</key>
-      <value>
-        <categories>
-          <category>Sample stacks and goniometers</category>
-        </categories>
-        <type>SAMPLESTACK</type>
-        <path>stage/sample.opi</path>
-        <description>The OPI for the sample stage. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>SD Test</key>
-      <value>
-        <type>UNCONFIRMED</type>
-        <path>SDTEST.opi</path>
-        <description>Software development test OPI.</description>
-        <macros>
-          <macro>
-            <name>DEV</name>
-            <description>The SDTest PV prefix (e.g. SDTEST_01)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Single Stage</key>
-      <value>
-        <categories>
-          <category>Sample stacks and goniometers</category>
-        </categories>
-        <type>SINGLESTAGE</type>
-        <path>single_stage.opi</path>
-        <description>The OPI displaying a single Motor along with a designated ID.</description>
-        <macros>
-          <macro>
-            <name>S</name>
-            <description>The name to display for the stage</description>
-          </macro>
-          <macro>
-            <name>MM</name>
-            <description>The motor PV relating to the motor controlling the stage (e.g. MOT:MTR0605).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>SKF G5 Chopper</key>
-      <value>
-        <categories>
-          <category>Choppers</category>
-        </categories>
-        <type>CHOPPER</type>
-        <path>SKFG5Chopper/SKFChopper.opi</path>
-        <description>The OPI for the SKF G5 chopper controllers.</description>
-        <macros>
-          <macro>
-            <name>DEFAULT_ACTIVE_TAB</name>
-            <description>The tab which is displayed when the OPI is opened (1 to 5).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Slit 1</key>
-      <value>
-        <categories>
-          <category>Jaws and slits</category>
-        </categories>
-        <type>JAWS</type>
-        <path>jaws/slit1.opi</path>
-        <description>The OPI for a 2D set of rectangular jaws controlled by 4 motors.</description>
-        <macros>
-          <macro>
-            <name>J</name>
-            <description>The Jaws PV (e.g. MOT:JAWS1).</description>
-          </macro>
-          <macro>
-            <name>M1</name>
-            <description>The motor PV relating to motor 1 (e.g. MTR0601).</description>
-          </macro>
-          <macro>
-            <name>M2</name>
-            <description>The motor PV relating to motor 2 (e.g. MTR0602).</description>
-          </macro>
-          <macro>
-            <name>M3</name>
-            <description>The motor PV relating to motor 3 (e.g. MTR0603).</description>
-          </macro>
-          <macro>
-            <name>M4</name>
-            <description>The motor PV relating to motor 4 (e.g. MTR0604).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Coupled Slit</key>
-      <value>
-        <categories>
-          <category>Jaws and slits</category>
-        </categories>
-        <type>JAWS</type>
-        <path>jaws/coupled_slit.opi</path>
-        <description>The OPI for a 2D set of rectangular jaws controlled by 2 motors.</description>
-        <macros>
-          <macro>
-            <name>J</name>
-            <description>The Jaws PV (e.g. MOT:JAWS1).</description>
-          </macro>
-          <macro>
-            <name>M1</name>
-            <description>The motor PV relating to motor 1 (e.g. MTR0601).</description>
-          </macro>
-          <macro>
-            <name>M2</name>
-            <description>The motor PV relating to motor 2 (e.g. MTR0602).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Slit motors</key>
-      <value>
-        <categories>
-          <category>Jaws and slits</category>
-        </categories>
-        <type>JAWS</type>
-        <path>slit_motors.opi</path>
-        <description>The OPI displaying the motors of a slit.</description>
-        <macros>
-          <macro>
-            <name>M1</name>
-            <description>The motor PV relating to motor 1 (e.g. MTR0601).</description>
-          </macro>
-          <macro>
-            <name>M2</name>
-            <description>The motor PV relating to motor 2 (e.g. MTR0602).</description>
-          </macro>
-          <macro>
-            <name>M3</name>
-            <description>The motor PV relating to motor 3 (e.g. MTR0603).</description>
-          </macro>
-          <macro>
-            <name>M4</name>
-            <description>The motor PV relating to motor 4 (e.g. MTR0604).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>TPG300</key>
-      <value>
-        <categories>
-          <category>Pressure sensors</category>
-        </categories>
-        <type>PRESSURE_GAUGE</type>
-        <path>TPG300.opi</path>
-        <description>The OPI for the PFEIFFER 300 Vacuum Gauge.</description>
-        <macros>
-          <macro>
-            <name>TPG300</name>
-            <description>The TPG300 PV prefix (e.g. TPG300_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>TPG26x</key>
-      <value>
-        <categories>
-          <category>Pressure sensors</category>
-        </categories>
-        <type>PRESSURE_GAUGE</type>
-        <path>TPG26x.opi</path>
-        <description>The OPI for the PFEIFFER 26x Vacuum Gauge.</description>
-        <macros>
-          <macro>
-            <name>TPG</name>
-            <description>The TPG26x PV prefix (e.g. TPG26X_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>LARMOR Spin Flipper</key>
-      <value>
-        <type>UNCONFIRMED</type>
-        <path>SpinFlipper306015.opi</path>
-        <description>The OPI for the LARMOR Spin Flipper.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>TDK Lambda Genesys</key>
-      <value>
-        <categories>
-          <category>Power supplies</category>
-        </categories>
-        <type>TDK_LAMBDA_GENESYS</type>
-        <path>genesys.opi</path>
-        <description>The OPI for the TDK Lambda Genesys PSU.</description>
-        <macros>
-          <macro>
-            <name>IOC_NUM</name>
-            <description>PSU IOC Number, two digits (e.g. 01).</description>
-          </macro>
-          <macro>
-            <name>PS_NUM</name>
-            <description>Number of the unit within the IOC (e.g. 3).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Danfysik</key>
-      <value>
-        <categories>
-          <category>Power supplies</category>
-        </categories>
-        <type>DANFYSIK</type>
-        <path>danfysik.opi</path>
-        <description>The OPI for the Danfysik power supply for magnets.</description>
-        <macros>
-          <macro>
-            <name>DFKPS</name>
-            <description>The Danfysik PV prefix (e.g. DFKPS_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>PDR2000</key>
-      <value>
-        <categories>
-          <category>Pressure sensors</category>
-        </categories>
-        <type>PDR2000</type>
-        <path>pdr2000.opi</path>
-        <description>The OPI for the MKS PDR 2000 pressure transducer</description>
-        <macros>
-          <macro>
-            <name>PDR2000</name>
-            <description>The MKS PDR 2000 PV prefix (e.g. PDR2000_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Cryo valve</key>
-      <value>
-        <categories>
-          <category>Cryogenics</category>
-        </categories>
-        <type>CRYVALVE</type>
-        <path>cryValve.opi</path>
-        <description>The OPI for the Iris cryo valve.</description>
-        <macros>
-          <macro>
-            <name>CRYVALVE</name>
-            <description>The cryo valve PV prefix (e.g. CRYVALVE_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Slits (single motor)</key>
-      <value>
-        <categories>
-          <category>Jaws and slits</category>
-        </categories>
-        <type>JAWS</type>
-        <path>slits_single_motor.opi</path>
-        <description>The OPI for a slit set with one degree of  freedom.</description>
-        <macros>
-          <macro>
-            <name>MOT</name>
-            <description>The PV for this slit set's motor (e.g. MOT:MTR0101).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>SCIMAG3D</key>
-      <value>
-        <categories>
-          <category>Magnets</category>
-        </categories>
-        <type>SCIMAG3D</type>
-        <path>scimag3D.opi</path>
-        <description>The OPI for the Scientific Magnetics 3D Magnet.</description>
-        <macros>
-          <macro>
-            <name>SCIMAG3D</name>
-            <description>The magnet PV prefix (e.g. SCIMAG3D_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Detector motion system</key>
-      <value>
-        <type>DETECTOR_MOTION_SYSTEM</type>
-        <path>detector_motion_system/detector_motion_system.opi</path>
-        <description>The OPI for the detector motion system. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Zoom sample stack</key>
-      <value>
-        <categories>
-          <category>Sample stacks and goniometers</category>
-        </categories>
-        <type>ZOOM_SAMPLE_STACK</type>
-        <path>zoom_sample_stack/zoom_sample_stack.opi</path>
-        <description>The OPI for the ZOOM sample stack. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Neocera LTC21</key>
-      <value>
-        <categories>
-          <category>Temperature controllers</category>
-          <category>Cryogenics</category>
-        </categories>
-        <type>NEOCERA</type>
-        <path>neocera_ltc21.opi</path>
-        <description>The OPI for the Neocera LTC21.</description>
-        <macros>
-          <macro>
-            <name>NEOCERA</name>
-            <description>The neocera PV prefix (e.g. NEOCERA_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Goniometer</key>
-      <value>
-        <categories>
-          <category>Sample stacks and goniometers</category>
-        </categories>
-        <type>GONIOMETER</type>
-        <path>goniometer/goniometer.opi</path>
-        <description>The OPI for a goniometer. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Rotating Sample Changer</key>
-      <value>
-        <categories>
-          <category>Sample changers</category>
-        </categories>
-        <type>ROT_SAMPLE_CHANGER</type>
-        <path>rot_sample_changer.opi</path>
-        <description>The OPI for the rotating sample changer on HRPD/GEM/POLARIS. No properties required.</description>
-      </value>
-    </entry>
-    <entry>
-      <key>Omron PLC</key>
-      <value>
-        <type>PLC</type>
-        <path>omron_plc.opi</path>
-        <description>The OPI for a PLC. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Mk3 Chopper (single)</key>
-      <value>
-        <categories>
-          <category>Choppers</category>
-        </categories>
-        <type>CHOPPER</type>
-        <path>Mk3Chopper/single_chopper.opi</path>
-        <description>The OPI for a single Mk3 Chopper.</description>
-        <macros>
-          <macro>
-            <name>NUMBER</name>
-            <description>The chopper number (e.g. CH1).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Polaris jaw set</key>
-      <value>
-        <categories>
-          <category>Jaws and slits</category>
-        </categories>
-        <type>JAWS</type>
-        <path>jaws/polaris_jaws/Jaws_polaris.opi</path>
-        <description>The OPI for the Polaris jaw set. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Gem jaw set</key>
-      <value>
-        <categories>
-          <category>Jaws and slits</category>
-        </categories>
-        <type>JAWS</type>
-        <path>jaws/gem_jaws/Jaws_gem.opi</path>
-        <description>The OPI for the Gem jaw set. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Instron stress rig</key>
-      <value>
-        <categories>
-          <category>Loading rigs</category>
-        </categories>
-        <type>STRESS_RIG</type>
-        <path>stress_rig/stress_rig.opi</path>
-        <description>The OPI for the Instron stress rig. No properties required.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Applied Measurements Int2-L</key>
-      <value>
-        <categories>
-          <category>Pressure sensors</category>
-        </categories>
-        <type>PRESSURE_GAUGE</type>
-        <path>amint2l/amint2l.opi</path>
-        <description>The OPI for the Applied Measurements Int2-L pressure measurement system.</description>
-        <macros>
-          <macro>
-            <name>AMINT2L</name>
-            <description>The AM Int2-L PV prefix (e.g. AMINT2L_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Muon Front End Overview</key>
-      <value>
-        <type>MUON_FRONT_END</type>
-        <path>muon_overviews/muon_front_end_overview.opi</path>
-        <description>The OPI for the Muon front end.</description>
-        <macros>
-          <macro>
-            <name>MM_EMU</name>
-            <description>The motor PV relating to the EMU barndoors (e.g. MOT:MTR0101).</description>
-          </macro>
-          <macro>
-            <name>MM_MUSR</name>
-            <description>The motor PV relating to the MuSR barndoors (e.g. MOT:MTR0102).</description>
-          </macro>
-          <macro>
-            <name>MM_HIFI</name>
-            <description>The motor PV relating to the HiFi barndoors (e.g. MOT:MTR0103).</description>
-          </macro>
-          <macro>
-            <name>MM_MOMENTUM</name>
-            <description>The motor PV relating to the momentum slits (e.g. MOT:MTR0104).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Riken Front End Overview</key>
-      <value>
-        <type>MUON_FRONT_END</type>
-        <path>muon_overviews/riken_front_end_overview.opi</path>
-        <description>The OPI for the Riken front end. No properties required.</description>
-      </value>
-    </entry>
-    <entry>
-      <key>Superlogics</key>
-      <value>
-        <type>MERCURY</type>
-        <path>superlogics.opi</path>
-        <description>The OPI for the Superlogics data acquisition system.</description>
-        <macros>
-          <macro>
-            <name>SPRLG</name>
-            <description>The Superlogics PV prefix (e.g. SPRLG_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>XY Shutter Arm Beam-stop</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-        </categories>
-        <type>BEAMSTOP</type>
-        <path>xyShutterArmBeamstop.opi</path>
-        <description>The OPI for the XY Arm Beam-stop with a shutter.</description>
-        <macros>
-          <macro>
-            <name>XYSHUTTERARMBEAMSTOP</name>
-            <description>The XY Arm Shutter Beamstop PV prefix (e.g. MOT).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Engin-X sample postioning system</key>
-      <value>
-        <categories>
-          <category>Sample stacks and goniometers</category>
-        </categories>
-        <type>SAMPLESTACK</type>
-        <path>enginx_sample_position_system.opi</path>
-        <description>The OPI for the Engin-X sample positioning system.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Fermi chopper</key>
-      <value>
-        <categories>
-          <category>Choppers</category>
-        </categories>
-        <type>FERMI_CHOPPER</type>
-        <path>fermi_chopper.opi</path>
-        <description>The OPI for the Fermi chopper.</description>
-        <macros>
-          <macro>
-            <name>FERMCHOP</name>
-            <description>The Fermi chopper PV prefix (e.g. FERMCHOP_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Fermi chopper - Digital Drive</key>
-      <value>
-        <categories>
-          <category>Choppers</category>
-        </categories>
-        <type>FERMI_CHOPPER</type>
-        <path>FZJ_DD_Fermi_Chopper.opi</path>
-        <description>The OPI for the FZJ Digital Drive Fermi Chopper.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>EnginX 3rd Jaw</key>
-      <value>
-        <categories>
-          <category>Jaws and slits</category>
-        </categories>
-        <type>JAWS</type>
-        <path>jaws/enginx_jaws/jaw_overview.opi</path>
-        <description>The OPI for the 3rd Enginx Jawset.</description>
-        <macros>
-          <macro>
-            <name>J</name>
-            <description>The Jaws PV (e.g. MOT:JAWS1).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Zoom FINS PLC</key>
-      <value>
-        <type>PLC</type>
-        <path>PLCZoomVacuum.opi</path>
-        <description>The OPI for the Omron FINS PLC for the ZOOM vacuum.</description>
-        <macros>
-          <macro>
-            <name>Q</name>
-            <description>The Omron FINS PLC Zoom vacuum PV prefix (e.g. VACUUM).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Engin-X collimators</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-        </categories>
-        <type>JAWS</type>
-        <path>enginx_collimators/enginx_collimators.opi</path>
-        <description>The OPI for the Engin-X collimators.</description>
-        <macros>
-				</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>IEG system</key>
-      <value>
-        <categories>
-          <category>Gas handling systems</category>
-        </categories>
-        <type>GAS_EXCHANGE</type>
-        <path>ieg_system.opi</path>
-        <description>The OPI for the gas exchange system.</description>
-        <macros>
-          <macro>
-            <name>IEG</name>
-            <description>The gas exchange system PV prefix (e.g. IEG_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Cybaman</key>
-      <value>
-        <categories>
-          <category>Sample stacks and goniometers</category>
-        </categories>
-        <type>GONIOMETER</type>
-        <path>cybaman.opi</path>
-        <description>The OPI for the cybaman.</description>
-        <macros>
-          <macro>
-            <name>CYBAMAN</name>
-            <description>The cybaman PV prefix (e.g. CYBAMAN_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Fermi chopper lifter</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-        </categories>
-        <type>FERMI_CHOPPER</type>
-        <path>fermi_chopper_lift.opi</path>
-        <description>The OPI for the Fermi chopper lifter.</description>
-        <macros>
-				</macros>
-			</value>
-		</entry> 
-		<entry>
-			<key>PGC</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>PGC</type>
-				<path>pgc\pgc.opi</path>
-				<description>The OPI for the Polariser , Guide and Collimation ticket.</description>
-				<macros>
-					<macro>
-						<name>PGC</name>
-						<description>The name of the device, as defined in the positions look-up file (e.g. PGC))</description>
-					</macro>
-					<macro>
-						<name>MM</name>
-						<description>The motor PV to point at (as defined in the motionsetpoints file (e.g. MOT:MTR0101))</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>       
-		<entry>
-			<key>Pixelman</key>
-			<value>
-				<categories>
-					<category>Imaging cameras</category>
-				</categories>
-				<type>PIXELMAN</type>
-				<path>pixelman.opi</path>
-				<description>Description required.</description>
-				<macros>
-					<macro>
-						<name>Q</name>
-						<description>Description required.</description>
-					</macro>                
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Polariser</key>
-			<value>
-				<type>POLARISER</type>
-				<path>polariser.opi</path>
-				<description>The OPI for the polariser. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Rotating Bench</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>ROTATINGBENCH</type>
-				<path>rotating_bench.opi</path>
-				<description>The OPI for the LARMOR rotating bench.</description>
-				<macros>
-					<macro>
-						<name>MM</name>
-						<description>The PV for the motor controlling the bench rotation (e.g. MOT:MTR0605).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>        
-		<entry>
-			<key>Sample changer</key>
-			<value>
-				<categories>
-					<category>Sample changers</category>
-				</categories>
-				<type>SAMPLECHANGER</type>
-				<path>stage/sample_changer.opi</path>
-				<description>The OPI for the sample changer. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>   
-		<entry>
-			<key>Linear sample changer</key>
-			<value>
-				<categories>
-					<category>Sample changers</category>
-				</categories>
-				<type>LINEARSAMPLECHANGER</type>
-				<path>stage/linear_sample_changer.opi</path>
-				<description>The OPI for the linear sample changer. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Pixelman</key>
-			<value>
-				<categories>
-					<category>Imaging cameras</category>
-				</categories>
-				<type>PIXELMAN</type>
-				<path>pixelman.opi</path>
-				<description>Pixelman camera.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Sample stage</key>
-			<value>
-				<categories>
-					<category>Sample stacks and goniometers</category>
-				</categories>
-				<type>SAMPLESTACK</type>
-				<path>stage/sample.opi</path>
-				<description>The OPI for the sample stage. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>        
-		<entry>
-			<key>SD Test</key>
-			<value>
-				<type>UNCONFIRMED</type>
-				<path>SDTEST.opi</path>
-				<description>Software development test OPI.</description>
-				<macros>
-					<macro>
-						<name>DEV</name>
-						<description>The SDTest PV prefix (e.g. SDTEST_01)</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Single Stage</key>
-			<value>
-				<categories>
-					<category>Sample stacks and goniometers</category>
-				</categories>
-				<type>SINGLESTAGE</type>
-				<path>single_stage.opi</path>
-				<description>The OPI displaying a single Motor along with a designated ID.</description>
-				<macros>
-					<macro>
-						<name>S</name>
-						<description>The name to display for the stage</description>
-					</macro>
-					<macro>
-						<name>MM</name>
-						<description>The motor PV relating to the motor controlling the stage (e.g. MOT:MTR0605).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>SKF G5 Chopper</key>
-			<value>
-				<categories>
-					<category>Choppers</category>
-				</categories>
-				<type>CHOPPER</type>
-				<path>SKFG5Chopper/SKFChopper.opi</path>
-				<description>The OPI for the SKF G5 chopper controllers.</description>
-				<macros>
-					<macro>
-						<name>DEFAULT_ACTIVE_TAB</name>
-						<description>The tab which is displayed when the OPI is opened (1 to 5).</description>  
-					</macro>
-				</macros>
-			</value>
-		</entry>        
-		<entry>
-			<key>Slit 1</key>
-			<value>
-				<categories>
-					<category>Jaws and slits</category>
-				</categories>
-				<type>JAWS</type>
-				<path>jaws/slit1.opi</path>
-				<description>The OPI for a 2D set of rectangular jaws controlled by 4 motors.</description>
-				<macros>
-					<macro>
-						<name>J</name>
-						<description>The Jaws PV (e.g. MOT:JAWS1).</description>
-					</macro>                    
-					<macro>
-						<name>M1</name>
-						<description>The motor PV relating to motor 1 (e.g. MTR0601).</description>
-					</macro>
-					<macro>
-						<name>M2</name>
-						<description>The motor PV relating to motor 2 (e.g. MTR0602).</description>
-					</macro>
-					<macro>
-						<name>M3</name>
-						<description>The motor PV relating to motor 3 (e.g. MTR0603).</description>
-					</macro>
-					<macro>
-						<name>M4</name>
-						<description>The motor PV relating to motor 4 (e.g. MTR0604).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>        
-		<entry>
-			<key>Coupled Slit</key>
-			<value>
-				<categories>
-					<category>Jaws and slits</category>
-				</categories>
-				<type>JAWS</type>
-				<path>jaws/coupled_slit.opi</path>
-				<description>The OPI for a 2D set of rectangular jaws controlled by 2 motors.</description>
-				<macros>
-					<macro>
-						<name>J</name>
-						<description>The Jaws PV (e.g. MOT:JAWS1).</description>
-					</macro>                    
-					<macro>
-						<name>M1</name>
-						<description>The motor PV relating to motor 1 (e.g. MTR0601).</description>
-					</macro>
-					<macro>
-						<name>M2</name>
-						<description>The motor PV relating to motor 2 (e.g. MTR0602).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>        
-		<entry>
-			<key>Slit motors</key>
-			<value>
-				<categories>
-					<category>Jaws and slits</category>
-				</categories>
-				<type>JAWS</type>
-				<path>slit_motors.opi</path>
-				<description>The OPI displaying the motors of a slit.</description>
-				<macros>
-					<macro>
-						<name>M1</name>
-						<description>The motor PV relating to motor 1 (e.g. MTR0601).</description>
-					</macro>
-					<macro>
-						<name>M2</name>
-						<description>The motor PV relating to motor 2 (e.g. MTR0602).</description>
-					</macro>
-					<macro>
-						<name>M3</name>
-						<description>The motor PV relating to motor 3 (e.g. MTR0603).</description>
-					</macro>
-					<macro>
-						<name>M4</name>
-						<description>The motor PV relating to motor 4 (e.g. MTR0604).</description>
-					</macro>                
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>TPG300</key>
-			<value>
-				<categories>
-					<category>Pressure sensors</category>
-				</categories>
-				<type>PRESSURE_GAUGE</type>
-				<path>TPG300.opi</path>
-				<description>The OPI for the PFEIFFER 300 Vacuum Gauge.</description>
-				<macros>
-					<macro>
-						<name>TPG300</name>
-						<description>The TPG300 PV prefix (e.g. TPG300_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>TPG26x</key>
-			<value>
-				<categories>
-					<category>Pressure sensors</category>
-				</categories>
-				<type>PRESSURE_GAUGE</type>
-				<path>TPG26x.opi</path>
-				<description>The OPI for the PFEIFFER 26x Vacuum Gauge.</description>
-				<macros>
-					<macro>
-						<name>TPG</name>
-						<description>The TPG26x PV prefix (e.g. TPG26X_01).</description>
-					</macro>                  
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>LARMOR Spin Flipper</key>
-			<value>
-				<type>UNCONFIRMED</type>
-				<path>SpinFlipper306015.opi</path>
-				<description>The OPI for the LARMOR Spin Flipper.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>TDK Lambda Genesys</key>
-			<value>
-				<categories>
-					<category>Power supplies</category>
-				</categories>
-				<type>TDK_LAMBDA_GENESYS</type>
-				<path>genesys.opi</path>
-				<description>The OPI for the TDK Lambda Genesys PSU.</description>
-				<macros>
-					<macro>
-						<name>IOC_NUM</name>
-						<description>PSU IOC Number, two digits (e.g. 01).</description>
-					</macro>
-					<macro>
-						<name>PS_NUM</name>
-						<description>Number of the unit within the IOC (e.g. 3).</description>
-					</macro>                  
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Danfysik</key>
-			<value>
-				<categories>
-					<category>Power supplies</category>
-				</categories>
-				<type>DANFYSIK</type>
-				<path>danfysik.opi</path>
-				<description>The OPI for the Danfysik power supply for magnets.</description>
-				<macros>
-					<macro>
-						<name>DFKPS</name>
-						<description>The Danfysik PV prefix (e.g. DFKPS_01).</description>
-					</macro>                  
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>PDR2000</key>
-			<value>
-				<categories>
-					<category>Pressure sensors</category>
-				</categories>
-				<type>PDR2000</type>
-				<path>pdr2000.opi</path>
-				<description>The OPI for the MKS PDR 2000 pressure transducer</description>
-				<macros>    
-					<macro>
-						<name>PDR2000</name>
-						<description>The MKS PDR 2000 PV prefix (e.g. PDR2000_01).</description>
-					</macro>               
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Cryo valve</key>
-			<value>
-				<categories>
-					<category>Cryogenics</category>
-				</categories>
-				<type>CRYVALVE</type>
-				<path>cryValve.opi</path>
-				<description>The OPI for the Iris cryo valve.</description>
-				<macros>    
-					<macro>
-						<name>CRYVALVE</name>
-						<description>The cryo valve PV prefix (e.g. CRYVALVE_01).</description>
-					</macro>  
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Slits (single motor)</key>
-			<value>
-				<categories>
-					<category>Jaws and slits</category>
-				</categories>
-				<type>JAWS</type>
-				<path>slits_single_motor.opi</path>
-				<description>The OPI for a slit set with one degree of  freedom.</description>
-				<macros>
-					<macro>
-						<name>MOT</name>
-						<description>The PV for this slit set's motor (e.g. MOT:MTR0101).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>SCIMAG3D</key>
-			<value>
-				<categories>
-					<category>Magnets</category>
-				</categories>
-				<type>SCIMAG3D</type>
-				<path>scimag3D.opi</path>
-				<description>The OPI for the Scientific Magnetics 3D Magnet.</description>
-				<macros>
-					<macro>
-						<name>SCIMAG3D</name>
-						<description>The magnet PV prefix (e.g. SCIMAG3D_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Detector motion system</key>
-			<value>
-				<type>DETECTOR_MOTION_SYSTEM</type>
-				<path>detector_motion_system/detector_motion_system.opi</path>
-				<description>The OPI for the detector motion system. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Zoom sample stack</key>
-			<value>
-				<categories>
-					<category>Sample stacks and goniometers</category>
-				</categories>
-				<type>ZOOM_SAMPLE_STACK</type>
-				<path>zoom_sample_stack/zoom_sample_stack.opi</path>
-				<description>The OPI for the ZOOM sample stack. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Neocera LTC21</key>
-			<value>
-				<categories>
-					<category>Temperature controllers</category>
-					<category>Cryogenics</category>
-				</categories>
-				<type>NEOCERA</type>
-				<path>neocera_ltc21.opi</path>
-				<description>The OPI for the Neocera LTC21.</description>
-				<macros>
-					<macro>
-						<name>NEOCERA</name>
-						<description>The neocera PV prefix (e.g. NEOCERA_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Goniometer</key>
-			<value>
-				<categories>
-					<category>Sample stacks and goniometers</category>
-				</categories>
-				<type>GONIOMETER</type>
-				<path>goniometer/goniometer.opi</path>
-				<description>The OPI for a goniometer. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry> 
-		<entry>
-			<key>Rotating Sample Changer</key>
-			<value>
-				<categories>
-					<category>Sample changers</category>
-				</categories>
-				<type>ROT_SAMPLE_CHANGER</type>
-				<path>rot_sample_changer.opi</path>
-				<description>The OPI for the rotating sample changer on HRPD/GEM/POLARIS. No properties required.</description>
-			</value>
-		</entry> 	
-		<entry>
-			<key>Omron PLC</key>
-			<value>
-				<type>PLC</type>
-				<path>omron_plc.opi</path>
-				<description>The OPI for a PLC. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry> 	
-		<entry>
-			<key>Mk3 Chopper (single)</key>
-			<value>
-				<categories>
-					<category>Choppers</category>
-				</categories>
-				<type>CHOPPER</type>
-				<path>Mk3Chopper/single_chopper.opi</path>
-				<description>The OPI for a single Mk3 Chopper.</description>
-				<macros>
-					<macro>
-						<name>NUMBER</name>
-						<description>The chopper number (e.g. CH1).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry> 
-		<entry>
-			<key>Polaris jaw set</key>
-			<value>
-				<categories>
-					<category>Jaws and slits</category>
-				</categories>
-				<type>JAWS</type>
-				<path>jaws/polaris_jaws/Jaws_polaris.opi</path>
-				<description>The OPI for the Polaris jaw set. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Gem jaw set</key>
-			<value>
-				<categories>
-					<category>Jaws and slits</category>
-				</categories>
-				<type>JAWS</type>
-				<path>jaws/gem_jaws/Jaws_gem.opi</path>
-				<description>The OPI for the Gem jaw set. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>		
-		<entry>
-			<key>Instron stress rig</key>
-			<value>
-				<categories>
-					<category>Loading rigs</category>
-				</categories>
-				<type>STRESS_RIG</type>
-				<path>stress_rig/stress_rig.opi</path>
-				<description>The OPI for the Instron stress rig. No properties required.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>	
-		<entry>
-			<key>Applied Measurements Int2-L</key>
-			<value>
-				<categories>
-					<category>Pressure sensors</category>
-				</categories>
-				<type>PRESSURE_GAUGE</type>
-				<path>amint2l/amint2l.opi</path>
-				<description>The OPI for the Applied Measurements Int2-L pressure measurement system.</description>
-				<macros>
-					<macro>
-						<name>AMINT2L</name>
-						<description>The AM Int2-L PV prefix (e.g. AMINT2L_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Muon Front End Overview</key>
-			<value>
-				<type>MUON_FRONT_END</type>
-				<path>muon_overviews/muon_front_end_overview.opi</path>
-				<description>The OPI for the Muon front end.</description>
-				<macros>
-					<macro>
-						<name>MM_EMU</name>
-						<description>The motor PV relating to the EMU barndoors (e.g. MOT:MTR0101).</description>
-					</macro>
-					<macro>
-						<name>MM_MUSR</name>
-						<description>The motor PV relating to the MuSR barndoors (e.g. MOT:MTR0102).</description>
-					</macro>
-					<macro>
-						<name>MM_HIFI</name>
-						<description>The motor PV relating to the HiFi barndoors (e.g. MOT:MTR0103).</description>
-					</macro>
-					<macro>
-						<name>MM_MOMENTUM</name>
-						<description>The motor PV relating to the momentum slits (e.g. MOT:MTR0104).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Riken Front End Overview</key>
-			<value>
-				<type>MUON_FRONT_END</type>
-				<path>muon_overviews/riken_front_end_overview.opi</path>
-				<description>The OPI for the Riken front end. No properties required.</description>
-			</value>
-		</entry>
-		<entry>
-			<key>Superlogics</key>
-			<value>
-				<type>MERCURY</type>
-				<path>superlogics.opi</path>
-				<description>The OPI for the Superlogics data acquisition system.</description>
-				<macros>
-					<macro>
-						<name>SPRLG</name>
-						<description>The Superlogics PV prefix (e.g. SPRLG_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>XY Shutter Arm Beam-stop</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>BEAMSTOP</type>
-				<path>xyShutterArmBeamstop.opi</path>
-				<description>The OPI for the XY Arm Beam-stop with a shutter.</description>
-				<macros>
-					<macro>
-						<name>XYSHUTTERARMBEAMSTOP</name>
-						<description>The XY Arm Shutter Beamstop PV prefix (e.g. MOT).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Engin-X sample postioning system</key>
-			<value>
-				<categories>
-					<category>Sample stacks and goniometers</category>
-				</categories>
-				<type>SAMPLESTACK</type>
-				<path>enginx_sample_position_system.opi</path>
-				<description>The OPI for the Engin-X sample positioning system.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Fermi chopper</key>
-			<value>
-				<categories>
-					<category>Choppers</category>
-				</categories>
-				<type>FERMI_CHOPPER</type>
-				<path>fermi_chopper.opi</path>
-				<description>The OPI for the Fermi chopper.</description>
-				<macros>
-					<macro>
-						<name>FERMCHOP</name>
-						<description>The Fermi chopper PV prefix (e.g. FERMCHOP_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Fermi chopper - Digital Drive</key>
-			<value>
-				<categories>
-					<category>Choppers</category>
-				</categories>
-				<type>FERMI_CHOPPER</type>
-				<path>FZJ_DD_Fermi_Chopper.opi</path>
-				<description>The OPI for the FZJ Digital Drive Fermi Chopper.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>  
-		<entry>
-			<key>EnginX 3rd Jaw</key>
-			<value>
-				<categories>
-					<category>Jaws and slits</category>
-				</categories>
-				<type>JAWS</type>
-				<path>jaws/enginx_jaws/jaw_overview.opi</path>
-				<description>The OPI for the 3rd Enginx Jawset.</description>
-				<macros>
-					<macro>
-						<name>J</name>
-						<description>The Jaws PV (e.g. MOT:JAWS1).</description>
-					</macro>            
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Zoom FINS PLC</key>
-			<value>
-				<type>PLC</type>
-				<path>PLCZoomVacuum.opi</path>
-				<description>The OPI for the Omron FINS PLC for the ZOOM vacuum.</description>
-				<macros>
-					<macro>
-						<name>Q</name>
-						<description>The Omron FINS PLC Zoom vacuum PV prefix (e.g. VACUUM).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Engin-X collimators</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>JAWS</type>
-				<path>enginx_collimators/enginx_collimators.opi</path>
-				<description>The OPI for the Engin-X collimators.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>    
-		<entry>
-			<key>IEG system</key>
-			<value>
-				<categories>
-					<category>Gas and liquid handling systems</category>
-				</categories>
-				<type>GAS_EXCHANGE</type>
-				<path>ieg_system.opi</path>
-				<description>The OPI for the gas exchange system.</description>
-				<macros>
-					<macro>
-						<name>IEG</name>
-						<description>The gas exchange system PV prefix (e.g. IEG_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Cybaman</key>
-			<value>
-				<categories>
-					<category>Sample stacks and goniometers</category>
-				</categories>
-				<type>GONIOMETER</type>
-				<path>cybaman.opi</path>
-				<description>The OPI for the cybaman.</description>
-				<macros>
-					<macro>
-						<name>CYBAMAN</name>
-						<description>The cybaman PV prefix (e.g. CYBAMAN_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Fermi chopper lifter</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>FERMI_CHOPPER</type>
-				<path>fermi_chopper_lift.opi</path>
-				<description>The OPI for the Fermi chopper lifter.</description>
-				<macros>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Sample stack</key>
-			<value>
-				<categories>
-					<category>Sample stacks and goniometers</category>
-				</categories>
-				<type>SAMPLESTACK</type>
-				<path>sample_stack\sample_stack.opi</path>
-				<description>Generic sample stack OPI supporting up to 8 motors. PV prefixs are typically of the form MOT:STACK:Z </description>
-				<macros>
-					<macro>
-						<name>AXIS_PV_1</name>
-						<description>The axis PV for motor 1</description>
-					</macro>
-					<macro>
-						<name>AXIS_PV_2</name>
-						<description>The axis PV for motor 2</description>
-					</macro>
-					<macro>
-						<name>AXIS_PV_3</name>
-						<description>The axis PV for motor 3</description>
-					</macro>
-					<macro>
-						<name>AXIS_PV_4</name>
-						<description>The axis PV for motor 4</description>
-					</macro>
-					<macro>
-						<name>AXIS_PV_5</name>
-						<description>The axis PV for motor 5</description>
-					</macro>
-					<macro>
-						<name>AXIS_PV_6</name>
-						<description>The axis PV for motor 6</description>
-					</macro>
-					<macro>
-						<name>AXIS_PV_7</name>
-						<description>The axis PV for motor 7</description>
-					</macro>
-					<macro>
-						<name>AXIS_PV_8</name>
-						<description>The axis PV for motor 8</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>Galil Engineering View</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>GALIL_ENGINEERING</type>
-				<path>galil/galil.opi</path>
-				<description>The OPI giving a detailed engineering view of a galil.</description>
-				<macros>
-					<macro>
-						<name>M</name>
-						<description>The galil number to view. E.g. the galil at MOT:MTR0304 would be 03</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>GEMOscillatingRadialCollimator</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>OSCILLATING_COLLIMATOR</type>
-				<path>gemorc.opi</path>
-				<description>The OPI for the GEM Oscillating Radial Collimator</description>
-				<macros/>
-			</value>
-		</entry>
+                        <name>MOTION_SET_POINT</name>
+                        <description>The motion setpoint to display (e.g. LKUP:SAMPLE)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                    <category>Sample stacks and goniometers</category>
+                    <category>Sample changers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Mk3 Chopper</key>
+            <value>
+                <type>CHOPPER</type>
+                <path>Mk3Chopper/multiple_choppers.opi</path>
+                <description>The OPI for the Mk3 chopper. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Choppers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>SP2XX</key>
+            <value>
+                <type>SYRINGE_PUMP</type>
+                <path>sp2xx.opi</path>
+                <description>The OPI for the SP2XX</description>
+                <macros>
+                    <macro>
+                        <name>SP2XX</name>
+                        <description>The SP2XX PV prefix (e.g. SP2XX_01)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Gas and liquid handling systems</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Keyence TM-3001P</key>
+            <value>
+                <type>KEYENCE</type>
+                <path>kynctm3k.opi</path>
+                <description>The OPI for the Keyence TM-3001P optical micrometer</description>
+                <macros>
+                    <macro>
+                        <name>KEYENCE</name>
+                        <description>The Keyence PV prefix (e.g. KYNCTM3K_01)</description>
+                    </macro>
+                </macros>
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Sample changer</key>
+            <value>
+                <type>SAMPLECHANGER</type>
+                <path>stage/sample_changer.opi</path>
+                <description>The OPI for the sample changer. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Sample changers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>OscillatingCollimator</key>
+            <value>
+                <type>OSCILLATING_COLLIMATOR</type>
+                <path>OscillatingCollimator/OscillatingCollimator.opi</path>
+                <description>The OPI for the LET oscillating collimator.</description>
+                <macros>
+                    <macro>
+                        <name>MOT</name>
+                        <description>The motor controlling the collimator (e.g. MOT:MTR0101)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Fermi chopper</key>
+            <value>
+                <type>FERMI_CHOPPER</type>
+                <path>fermi_chopper.opi</path>
+                <description>The OPI for the Fermi chopper.</description>
+                <macros>
+                    <macro>
+                        <name>FERMCHOP</name>
+                        <description>The Fermi chopper PV prefix (e.g. FERMCHOP_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Choppers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Double Monitor</key>
+            <value>
+                <type>MONITOR</type>
+                <path>double_monitor.opi</path>
+                <description>The OPI for a double fixed monitor.</description>
+                <macros>
+                    <macro>
+                        <name>M</name>
+                        <description>The monitor number (e.g. 1).</description>
+                    </macro>
+                    <macro>
+                        <name>MA</name>
+                        <description>The internal number for the first channel (e.g. 1).</description>
+                    </macro>
+                    <macro>
+                        <name>MB</name>
+                        <description>The internal number for the second channel (e.g. 2).</description>
+                    </macro>
+                    <macro>
+                        <name>MAHVCHAN</name>
+                        <description>CAEN HV channel for A (e.g. 0).</description>
+                    </macro>
+                    <macro>
+                        <name>MBHVCHAN</name>
+                        <description>CAEN HV channel for B (e.g. 1).</description>
+                    </macro>
+                    <macro>
+                        <name>MAHVSLOT</name>
+                        <description>CAEN HV slot for A (e.g. 0).</description>
+                    </macro>
+                    <macro>
+                        <name>MBHVSLOT</name>
+                        <description>CAEN HV slot for B (e.g. 1).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Monitors</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>PDR2000</key>
+            <value>
+                <type>PDR2000</type>
+                <path>pdr2000.opi</path>
+                <description>The OPI for the MKS PDR 2000 pressure transducer</description>
+                <macros>
+                    <macro>
+                        <name>PDR2000</name>
+                        <description>The MKS PDR 2000 PV prefix (e.g. PDR2000_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Pressure sensors</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Coupled Slit</key>
+            <value>
+                <type>JAWS</type>
+                <path>jaws/coupled_slit.opi</path>
+                <description>The OPI for a 2D set of rectangular jaws controlled by 2 motors.</description>
+                <macros>
+                    <macro>
+                        <name>J</name>
+                        <description>The Jaws PV (e.g. MOT:JAWS1).</description>
+                    </macro>
+                    <macro>
+                        <name>M1</name>
+                        <description>The motor PV relating to motor 1 (e.g. MTR0601).</description>
+                    </macro>
+                    <macro>
+                        <name>M2</name>
+                        <description>The motor PV relating to motor 2 (e.g. MTR0602).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Jaws and slits</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>ILM200</key>
+            <value>
+                <type>CRYO_LEVEL_GAUGE</type>
+                <path>ilm200\ilm200.opi</path>
+                <description>The OPI for the ILM200</description>
+                <macros>
+                    <macro>
+                        <name>ILM200</name>
+                        <description>The ILM200 PV prefix (e.g. ILM200_01)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Cryogenics</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>IPS</key>
+            <value>
+                <type>IPS</type>
+                <path>ips.opi</path>
+                <description>The OPI for the Oxford Instruments IPS</description>
+                <macros />
+                <categories>
+                    <category>Power supplies</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Linkam 95</key>
+            <value>
+                <type>LINKAM95</type>
+                <path>linkam95.opi</path>
+                <description>The OPI for the Linkam 95 temperature controller.</description>
+                <macros>
+                    <macro>
+                        <name>LINKAM95</name>
+                        <description>The Linkam 95 PV prefix (e.g. LINKAM95_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Temperature controllers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Pinhole Selector</key>
+            <value>
+                <type>PINHOLESELECTOR</type>
+                <path>pinhole_selector\pinhole_selector.opi</path>
+                <description>The OPI for the pinhole selector.</description>
+                <macros>
+                    <macro>
+                        <name>PH</name>
+                        <description>The name of the device, as defined in the positions look-up file (e.g. PINHOLE)</description>
+                    </macro>
+                    <macro>
+                        <name>MM</name>
+                        <description>The motor PV to point at, as defined in the motionsetpoints file (e.g. MOT:MTR0605)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Slit motors</key>
+            <value>
+                <type>JAWS</type>
+                <path>slit_motors.opi</path>
+                <description>The OPI displaying the motors of a slit.</description>
+                <macros>
+                    <macro>
+                        <name>M1</name>
+                        <description>The motor PV relating to motor 1 (e.g. MTR0601).</description>
+                    </macro>
+                    <macro>
+                        <name>M2</name>
+                        <description>The motor PV relating to motor 2 (e.g. MTR0602).</description>
+                    </macro>
+                    <macro>
+                        <name>M3</name>
+                        <description>The motor PV relating to motor 3 (e.g. MTR0603).</description>
+                    </macro>
+                    <macro>
+                        <name>M4</name>
+                        <description>The motor PV relating to motor 4 (e.g. MTR0604).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Jaws and slits</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Zoom sample stack</key>
+            <value>
+                <type>ZOOM_SAMPLE_STACK</type>
+                <path>zoom_sample_stack/zoom_sample_stack.opi</path>
+                <description>The OPI for the ZOOM sample stack. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Sample stacks and goniometers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Julabo FL300</key>
+            <value>
+                <type>JULABO</type>
+                <path>JulaboFL300.opi</path>
+                <description>The OPI for the Julabo FL300 temperature controller. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Water baths</category>
+                    <category>Temperature controllers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Single Stage</key>
+            <value>
+                <type>SINGLESTAGE</type>
+                <path>single_stage.opi</path>
+                <description>The OPI displaying a single Motor along with a designated ID.</description>
+                <macros>
+                    <macro>
+                        <name>S</name>
+                        <description>The name to display for the stage</description>
+                    </macro>
+                    <macro>
+                        <name>MM</name>
+                        <description>The motor PV relating to the motor controlling the stage (e.g. MOT:MTR0605).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Sample stacks and goniometers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Lakeshore 460</key>
+            <value>
+                <type>LKSH460</type>
+                <path>Lakeshore460/lakeshore460.opi</path>
+                <description>The OPI for the Lakeshore 460 Gaussmeter.</description>
+                <macros>
+                    <macro>
+                        <name>LKSH460</name>
+                        <description>The Lakeshore460 PV prefix (e.g. LKSH460_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Gaussmeter</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>TPG300</key>
+            <value>
+                <type>PRESSURE_GAUGE</type>
+                <path>TPG300.opi</path>
+                <description>The OPI for the PFEIFFER 300 Vacuum Gauge.</description>
+                <macros>
+                    <macro>
+                        <name>TPG300</name>
+                        <description>The TPG300 PV prefix (e.g. TPG300_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Pressure sensors</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>In Out Monitor</key>
+            <value>
+                <type>MOVINGMONITOR</type>
+                <path>inout_monitor.opi</path>
+                <description>The OPI for a moving monitor.</description>
+                <macros>
+                    <macro>
+                        <name>M</name>
+                        <description>The monitor number (e.g. 1).</description>
+                    </macro>
+                    <macro>
+                        <name>MM</name>
+                        <description>The motor PV relating to the motor controlling the monitor (e.g. MOT:MTR0605).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Monitors</category>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Moxa E1210</key>
+            <value>
+                <type>MOXA_1210</type>
+                <path>moxa1210.opi</path>
+                <description>The OPI for a Moxa E1210 remote I/O.</description>
+                <macros>
+                    <macro>
+                        <name>MOXA1210</name>
+                        <description>The Moxa E1210 PV prefix (e.g. MOXA1210_01).</description>
+                    </macro>
+                </macros>
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Eurotherm</key>
+            <value>
+                <type>EUROTHERM</type>
+                <path>Eurotherm.opi</path>
+                <description>The OPI for the Eurotherm crate connected to multiple Eurotherm temperature controllers.</description>
+                <macros>
+                    <macro>
+                        <name>EURO</name>
+                        <description>The Eurotherm PV prefix (e.g. EUROTHRM_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Temperature controllers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Mercury iTC</key>
+            <value>
+                <type>MERCURY</type>
+                <path>mercuryiTC\mercuryiTC.opi</path>
+                <description>The OPI for the Mercury temperature controller.</description>
+                <macros>
+                    <macro>
+                        <name>MERCURY</name>
+                        <description>The Mercury PV prefix (e.g. MERCURY_01).</description>
+                    </macro>
+                    <macro>
+                        <name>TEMP_NUM1</name>
+                        <description>The first temperature card number (e.g. 1, optional).</description>
+                    </macro>
+                    <macro>
+                        <name>TEMP_NUM2</name>
+                        <description>The second temperature card number (e.g. 2, optional).</description>
+                    </macro>
+                    <macro>
+                        <name>TEMP_NUM3</name>
+                        <description>The third temperature card number (e.g. 3, optional).</description>
+                    </macro>
+                    <macro>
+                        <name>TEMP_NUM4</name>
+                        <description>The fourth temperature card number (e.g. 4, optional).</description>
+                    </macro>
+                    <macro>
+                        <name>LEVEL_NUM1</name>
+                        <description>The first level card number (e.g. 1, optional).</description>
+                    </macro>
+                    <macro>
+                        <name>LEVEL_NUM2</name>
+                        <description>The second level card number (e.g. 1, optional).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Temperature controllers</category>
+                    <category>Cryogenics</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Keithley 2400</key>
+            <value>
+                <type>KHLY2400</type>
+                <path>Keithley2400/Keithley2400.opi</path>
+                <description>The OPI for the Keithley 2400 Source Meter.</description>
+                <macros>
+                    <macro>
+                        <name>KHLY2400</name>
+                        <description>The Keithley 2400 PV name (e.g. KHLY2400_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Multimeters</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Slits (single motor)</key>
+            <value>
+                <type>JAWS</type>
+                <path>slits_single_motor.opi</path>
+                <description>The OPI for a slit set with one degree of  freedom.</description>
+                <macros>
+                    <macro>
+                        <name>MOT</name>
+                        <description>The PV for this slit set's motor (e.g. MOT:MTR0101).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Jaws and slits</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>GEMOscillatingRadialCollimator</key>
+            <value>
+                <type>OSCILLATING_COLLIMATOR</type>
+                <path>gemorc.opi</path>
+                <description>The OPI for the GEM Oscillating Radial Collimator</description>
+                <macros />
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>CCD100</key>
+            <value>
+                <type>CCD100</type>
+                <path>CCD100/CCD100.opi</path>
+                <description>The OPI for a Chell CCD100</description>
+                <macros>
+                    <macro>
+                        <name>CCD_1</name>
+                        <description>The PV prefix for the first CCD100 (e.g CCD100_01).</description>
+                    </macro>
+                    <macro>
+                        <name>CCD_2</name>
+                        <description>The PV prefix for the second CCD100 (e.g CCD100_01).</description>
+                    </macro>
+                    <macro>
+                        <name>CCD_3</name>
+                        <description>The PV prefix for the third CCD100 (e.g CCD100_01).</description>
+                    </macro>
+                    <macro>
+                        <name>CCD_4</name>
+                        <description>The PV prefix for the fourth CCD100 (e.g CCD100_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Pressure sensors</category>
+                    <category>Flow meters</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Cybaman</key>
+            <value>
+                <type>GONIOMETER</type>
+                <path>cybaman.opi</path>
+                <description>The OPI for the cybaman.</description>
+                <macros>
+                    <macro>
+                        <name>CYBAMAN</name>
+                        <description>The cybaman PV prefix (e.g. CYBAMAN_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Sample stacks and goniometers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Lakeshore 336</key>
+            <value>
+                <type>LAKESHORE</type>
+                <path>Lakeshore336/Lakeshore336.opi</path>
+                <description>The OPI for the Lakeshore 336 temperature controller.</description>
+                <macros>
+                    <macro>
+                        <name>LAKESHORE336</name>
+                        <description>The Lakeshore 336 PV prefix (e.g. LKSH336_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Temperature controllers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>PGC</key>
+            <value>
+                <type>PGC</type>
+                <path>pgc\pgc.opi</path>
+                <description>The OPI for the Polariser , Guide and Collimation ticket.</description>
+                <macros>
+                    <macro>
+                        <name>PGC</name>
+                        <description>The name of the device, as defined in the positions look-up file (e.g. PGC))</description>
+                    </macro>
+                    <macro>
+                        <name>MM</name>
+                        <description>The motor PV to point at (as defined in the motionsetpoints file (e.g. MOT:MTR0101))</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>TDK Lambda Genesys</key>
+            <value>
+                <type>TDK_LAMBDA_GENESYS</type>
+                <path>genesys.opi</path>
+                <description>The OPI for the TDK Lambda Genesys PSU.</description>
+                <macros>
+                    <macro>
+                        <name>IOC_NUM</name>
+                        <description>PSU IOC Number, two digits (e.g. 01).</description>
+                    </macro>
+                    <macro>
+                        <name>PS_NUM</name>
+                        <description>Number of the unit within the IOC (e.g. 3).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Power supplies</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Caen HV</key>
+            <value>
+                <type>CAEN</type>
+                <path>HV/HVMonitorSummaryDisplay.opi</path>
+                <description>Summary display for Caens (maintenance of list via the button on this OPI). No properties required.</description>
+                <macros>
+                    <macro>
+                        <name>MAX_CRATES</name>
+                        <description>The maximum number of crates to display (default: 2, max: 15)</description>
+                    </macro>
+                    <macro>
+                        <name>MAX_SLOTS</name>
+                        <description>The maximum number of slots to display per crate (default: 5)</description>
+                    </macro>
+                    <macro>
+                        <name>MAX_CHANNELS</name>
+                        <description>The maximum number of channels per slot per crate to display (default: 25)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Power supplies</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Cryo valve</key>
+            <value>
+                <type>CRYVALVE</type>
+                <path>cryValve.opi</path>
+                <description>The OPI for the Iris cryo valve.</description>
+                <macros>
+                    <macro>
+                        <name>CRYVALVE</name>
+                        <description>The cryo valve PV prefix (e.g. CRYVALVE_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Cryogenics</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Goniometer</key>
+            <value>
+                <type>GONIOMETER</type>
+                <path>goniometer/goniometer.opi</path>
+                <description>The OPI for a goniometer. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Sample stacks and goniometers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Polaris jaw set</key>
+            <value>
+                <type>JAWS</type>
+                <path>jaws/polaris_jaws/Jaws_polaris.opi</path>
+                <description>The OPI for the Polaris jaw set. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Jaws and slits</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Lakeshore 218</key>
+            <value>
+                <type>LAKESHORE</type>
+                <path>Lakeshore218.opi</path>
+                <description>The OPI for the Lakeshore 218 temperature controller.</description>
+                <macros>
+                    <macro>
+                        <name>LAKESHORE218</name>
+                        <description>The Lakeshore 218 PV prefix (e.g. LKSH218_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Temperature controllers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Slit 1</key>
+            <value>
+                <type>JAWS</type>
+                <path>jaws/slit1.opi</path>
+                <description>The OPI for a 2D set of rectangular jaws controlled by 4 motors.</description>
+                <macros>
+                    <macro>
+                        <name>J</name>
+                        <description>The Jaws PV (e.g. MOT:JAWS1).</description>
+                    </macro>
+                    <macro>
+                        <name>M1</name>
+                        <description>The motor PV relating to motor 1 (e.g. MTR0601).</description>
+                    </macro>
+                    <macro>
+                        <name>M2</name>
+                        <description>The motor PV relating to motor 2 (e.g. MTR0602).</description>
+                    </macro>
+                    <macro>
+                        <name>M3</name>
+                        <description>The motor PV relating to motor 3 (e.g. MTR0603).</description>
+                    </macro>
+                    <macro>
+                        <name>M4</name>
+                        <description>The motor PV relating to motor 4 (e.g. MTR0604).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Jaws and slits</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>TDS 3000 Trace</key>
+            <value>
+                <type>OSCILLOSCOPE</type>
+                <path>TDS3000_trace.opi</path>
+                <description>The trace shown by a TDS 3000 series oscilloscope</description>
+                <macros>
+                    <macro>
+                        <name>IP</name>
+                        <description>The IP address of the oscilloscope.</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Oscilloscopes</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Mk3 Chopper (single)</key>
+            <value>
+                <type>CHOPPER</type>
+                <path>Mk3Chopper/single_chopper.opi</path>
+                <description>The OPI for a single Mk3 Chopper.</description>
+                <macros>
+                    <macro>
+                        <name>NUMBER</name>
+                        <description>The chopper number (e.g. CH1).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Choppers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Analyser</key>
+            <value>
+                <type>ANALYSER</type>
+                <path>analyser.opi</path>
+                <description>The OPI for the analyser. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Monitors</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Omron PLC</key>
+            <value>
+                <type>PLC</type>
+                <path>omron_plc.opi</path>
+                <description>The OPI for a PLC. No properties required.</description>
+                <macros />
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>EnginX 3rd Jaw</key>
+            <value>
+                <type>JAWS</type>
+                <path>jaws/enginx_jaws/jaw_overview.opi</path>
+                <description>The OPI for the 3rd Enginx Jawset.</description>
+                <macros>
+                    <macro>
+                        <name>J</name>
+                        <description>The Jaws PV (e.g. MOT:JAWS1).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Jaws and slits</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Couette Cell</key>
+            <value>
+                <type>COUETTE</type>
+                <path>couette_cell.opi</path>
+                <description>The OPI for the Couette cell</description>
+                <macros>
+                    <macro>
+                        <name>COUETTE</name>
+                        <description>The COUETTE PV prefix (e.g. COUETTE_01)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Rheometers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>SD Test</key>
+            <value>
+                <type>UNCONFIRMED</type>
+                <path>SDTEST.opi</path>
+                <description>Software development test OPI.</description>
+                <macros>
+                    <macro>
+                        <name>DEV</name>
+                        <description>The SDTest PV prefix (e.g. SDTEST_01)</description>
+                    </macro>
+                </macros>
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Galil Engineering View</key>
+            <value>
+                <type>GALIL_ENGINEERING</type>
+                <path>galil/galil.opi</path>
+                <description>The OPI giving a detailed engineering view of a galil.</description>
+                <macros>
+                    <macro>
+                        <name>M</name>
+                        <description>The galil number to view. E.g. the galil at MOT:MTR0304 would be 03</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>SCIMAG3D</key>
+            <value>
+                <type>SCIMAG3D</type>
+                <path>scimag3D.opi</path>
+                <description>The OPI for the Scientific Magnetics 3D Magnet.</description>
+                <macros>
+                    <macro>
+                        <name>SCIMAG3D</name>
+                        <description>The magnet PV prefix (e.g. SCIMAG3D_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Magnets</category>
+                </categories>
+            </value>
+        </entry>
         <entry>
             <key>SKF MB350 Chopper</key>
-			<value>
-			    <categories>
-					<category>Choppers</category>
-				</categories>
-				<type>CHOPPER</type>
-				<path>skf_mb350.opi</path>
-				<description>The OPI for the SKF MB350 Chopper.</description>
-				<macros>
-					<macro>
-						<name>SKFMB350</name>
-						<description>The chopper PV prefix (e.g. SKFMB350_01).</description>
-					</macro>
-				</macros>        
-        	</value>
-		</entry>
-		<entry>
-			<key>HLG</key>
-			<value>
-				<categories>
-					<category>Cryogenics</category>
-				</categories>
-				<type>HE_LEVEL_GAUGE</type>
-				<path>hlg.opi</path>
-				<description>The OPI for the helium level gauge.</description>
-				<macros>
-					<macro>
-						<name>HLG</name>
-						<description>The HLG PV prefix (e.g. HLG_01).</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>OscillatingCollimator</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>OSCILLATING_COLLIMATOR</type>
-				<path>OscillatingCollimator/OscillatingCollimator.opi</path>
-				<description>The OPI for the LET oscillating collimator.</description>
-				<macros>
-					<macro>
-						<name>MOT</name>
-						<description>The motor controlling the collimator (e.g. MOT:MTR0101)</description>
-					</macro>
-				</macros>
-			</value>
-		</entry>
-	    <entry>
-	    	<key>Motion Set Point</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-					<category>Sample stacks and goniometers</category>
-					<category>Sample changers</category>
-				</categories>
-				<type>MOTION_SET_POINTS</type>
-	    		<path>stage/motion_setpoint.opi</path>
-	    		<description>The OPI for motion setpoints</description>
-	    		<macros>
-	    			<macro>
-						<name>MOTION_SET_POINT</name>
-						<description>The motion setpoint to display (e.g. LKUP:SAMPLE)</description>
-					</macro>	    		
-				</macros>
-			</value>
-		</entry>
-		<entry>
-	    	<key>Motion Set Point (Few)</key>
-			<value>
-				<categories>
-					<category>Miscellaneous motion control</category>
-				</categories>
-				<type>MOTION_SET_POINTS_FEW</type>
-	    		        <path>stage/inout_motion_setpoints.opi</path>
-	    		        <description>The OPI for motion setpoints for one to three setpoints.</description>
-	    		        <macros>
-	    			        <macro>
-						<name>MOTION_SET_POINT</name>
-						<description>The motion setpoint to display (e.g. LKUP:LSR)</description>
-					</macro>	    		
-				</macros>
-			</value>
-		</entry>
-		<entry>
-			<key>SM300 Sample Changer</key>
-			<value>
-				<categories>
-					<category>Sample changers</category>
-				</categories>
-				<type>SM300_SAMPLE_CHANGER</type>
-				<path>sample_stack/sm300sampos.opi</path>
-				<description>The OPI for the SM300 Sample changer</description>
-				<macros>
-					<macro>
-						<name>MOTION_SET_POINT</name>
-						<description>The prefix of the Motion set points being used(e.g. LKUP:SAMPLE)</description>
-					</macro>				
-				</macros>
-			</value>
-		</entry>
+            <value>
+                <type>CHOPPER</type>
+                <path>skf_mb350.opi</path>
+                <description>The OPI for the SKF MB350 Chopper.</description>
+                <macros>
+                    <macro>
+                        <name>SKFMB350</name>
+                        <description>The chopper PV prefix (e.g. SKFMB350_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Choppers</category>
+                </categories>
+            </value>
+        </entry>
         <entry>
-			<key>Lakeshore 460</key>
-			<value>
-			    <categories>
-					<category>Gaussmeter</category>
-				</categories>
-				<type>LKSH460</type>
-				<path>Lakeshore460/lakeshore460.opi</path>
-				<description>The OPI for the Lakeshore 460 Gaussmeter.</description>
-				<macros>
-					<macro>
-						<name>LKSH460</name>
-						<description>The Lakeshore460 PV prefix (e.g. LKSH460_01).</description>
-					</macro>
-				</macros>
-			</value>
-	    </entry>
-    <entry>
-      <key>Sample stack</key>
-      <value>
-        <categories>
-          <category>Sample stacks and goniometers</category>
-        </categories>
-        <type>SAMPLESTACK</type>
-        <path>sample_stack\sample_stack.opi</path>
-        <description>Generic sample stack OPI supporting up to 8 motors. PV prefixs are typically of the form MOT:STACK:Z </description>
-        <macros>
-          <macro>
-            <name>AXIS_PV_1</name>
-            <description>The axis PV for motor 1</description>
-          </macro>
-          <macro>
-            <name>AXIS_PV_2</name>
-            <description>The axis PV for motor 2</description>
-          </macro>
-          <macro>
-            <name>AXIS_PV_3</name>
-            <description>The axis PV for motor 3</description>
-          </macro>
-          <macro>
-            <name>AXIS_PV_4</name>
-            <description>The axis PV for motor 4</description>
-          </macro>
-          <macro>
-            <name>AXIS_PV_5</name>
-            <description>The axis PV for motor 5</description>
-          </macro>
-          <macro>
-            <name>AXIS_PV_6</name>
-            <description>The axis PV for motor 6</description>
-          </macro>
-          <macro>
-            <name>AXIS_PV_7</name>
-            <description>The axis PV for motor 7</description>
-          </macro>
-          <macro>
-            <name>AXIS_PV_8</name>
-            <description>The axis PV for motor 8</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Galil Engineering View</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-        </categories>
-        <type>GALIL_ENGINEERING</type>
-        <path>galil/galil.opi</path>
-        <description>The OPI giving a detailed engineering view of a galil.</description>
-        <macros>
-          <macro>
-            <name>M</name>
-            <description>The galil number to view. E.g. the galil at MOT:MTR0304 would be 03</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>GEMOscillatingRadialCollimator</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-        </categories>
-        <type>OSCILLATING_COLLIMATOR</type>
-        <path>gemorc.opi</path>
-        <description>The OPI for the GEM Oscillating Radial Collimator</description>
-        <macros/>
-      </value>
-    </entry>
-    <entry>
-      <key>SKF MB350 Chopper</key>
-      <value>
-        <categories>
-          <category>Choppers</category>
-        </categories>
-        <type>CHOPPER</type>
-        <path>skf_mb350.opi</path>
-        <description>The OPI for the SKF MB350 Chopper.</description>
-        <macros>
-          <macro>
-            <name>SKFMB350</name>
-            <description>The chopper PV prefix (e.g. SKFMB350_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>HLG</key>
-      <value>
-        <categories>
-          <category>Cryogenics</category>
-        </categories>
-        <type>HE_LEVEL_GAUGE</type>
-        <path>hlg.opi</path>
-        <description>The OPI for the helium level gauge.</description>
-        <macros>
-          <macro>
-            <name>HLG</name>
-            <description>The HLG PV prefix (e.g. HLG_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>OscillatingCollimator</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-        </categories>
-        <type>OSCILLATING_COLLIMATOR</type>
-        <path>OscillatingCollimator/OscillatingCollimator.opi</path>
-        <description>The OPI for the LET oscillating collimator.</description>
-        <macros>
-          <macro>
-            <name>MOT</name>
-            <description>The motor controlling the collimator (e.g. MOT:MTR0101)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Motion Set Point</key>
-      <value>
-        <categories>
-          <category>Miscellaneous motion control</category>
-          <category>Sample stacks and goniometers</category>
-          <category>Sample changers</category>
-        </categories>
-        <type>MOTION_SET_POINTS</type>
-        <path>stage/motion_setpoint.opi</path>
-        <description>The OPI for motion setpoints</description>
-        <macros>
-          <macro>
-            <name>MOTION_SET_POINT</name>
-            <description>The motion setpoint to display (e.g. LKUP:SAMPLE)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>SM300 Sample Changer</key>
-      <value>
-        <categories>
-          <category>Sample changers</category>
-        </categories>
-        <type>SM300_SAMPLE_CHANGER</type>
-        <path>sample_stack/sm300sampos.opi</path>
-        <description>The OPI for the SM300 Sample changer</description>
-        <macros>
-          <macro>
-            <name>MOTION_SET_POINT</name>
-            <description>The prefix of the Motion set points being used(e.g. LKUP:SAMPLE)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Lakeshore 460</key>
-      <value>
-        <categories>
-          <category>Gaussmeter</category>
-        </categories>
-        <type>LKSH460</type>
-        <path>Lakeshore460/lakeshore460.opi</path>
-        <description>The OPI for the Lakeshore 460 Gaussmeter.</description>
-        <macros>
-          <macro>
-            <name>LKSH460</name>
-            <description>The Lakeshore460 PV prefix (e.g. LKSH460_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Triton dilution fridge</key>
-      <value>
-        <categories>
-          <category>Cryogenics</category>
-          <category>Temperature controllers</category>
-        </categories>
-        <type>DILUTION_FRIDGE</type>
-        <path>triton\triton.opi</path>
-        <description>The OPI for the Triton</description>
-        <macros>
-          <macro>
-            <name>TRITON</name>
-            <description>The triton PV prefix (e.g. TRITON_01).</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>ILM200</key>
-      <value>
-        <categories>
-          <category>Cryogenics</category>
-        </categories>
-        <type>CRYO_LEVEL_GAUGE</type>
-        <path>ilm200\ilm200.opi</path>
-        <description>The OPI for the ILM200</description>
-        <macros>
-          <macro>
-            <name>ILM200</name>
-            <description>The ILM200 PV prefix (e.g. ILM200_01)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>Couette Cell</key>
-      <value>
-        <categories>
-          <category>Rheometers</category>
-        </categories>
-        <type>COUETTE</type>
-        <path>couette_cell.opi</path>
-        <description>The OPI for the Couette cell</description>
-        <macros>
-          <macro>
-            <name>COUETTE</name>
-            <description>The COUETTE PV prefix (e.g. COUETTE_01)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>IPS</key>
-      <value>
-        <categories>
-          <category>Power supplies</category>
-        </categories>
-        <type>IPS</type>
-        <path>ips.opi</path>
-        <description>The OPI for the Oxford Instruments IPS</description>
-        <macros>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-      <key>ITC503</key>
-      <value>
-        <categories>
-          <category>Temperature controllers</category>
-        </categories>
-        <type>EUROTHERM</type>
-        <path>itc503\itc503.opi</path>
-        <description>The OPI for the OI ITC503 temperature controller</description>
-        <macros>
-          <macro>
-            <name>ITC503</name>
-            <description>The ITC503 PV prefix (e.g. ITC503_01)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-	<entry>
-      <key>SP2XX</key>
-      <value>
-        <categories>
-			<category>Gas and liquid handling systems</category>
-		</categories>
-        <type>SYRINGE_PUMP</type>
-        <path>sp2xx.opi</path>
-        <description>The OPI for the SP2XX</description>
-        <macros>
-          <macro>
-            <name>SP2XX</name>
-            <description>The SP2XX PV prefix (e.g. SP2XX_01)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>
-		<key>Keyence TM-3001P</key>
-		<value>
-			<type>KEYENCE</type>
-			<path>kynctm3k.opi</path>
-			<description>The OPI for the Keyence TM-3001P optical micrometer</description>
-		<macros>
-			<macro>
-				<name>KEYENCE</name>
-				<description>The Keyence PV prefix (e.g. KYNCTM3K_01)</description>
-			</macro>
-		</macros>
-		</value>
-	</entry>
-    <entry>        
-      <key>Live View</key>
-      <value>
-        <categories>
-          <category>Monitors</category>
-        </categories>
-        <type>DAE</type>
-        <path>live_view.opi</path>
-        <description>The OPI for a live view of the detector</description>
-		<macros>
-			<macro>
-				<name>DET</name>
-				<description>Detector number (1 is first)</description>
-			</macro>
-		</macros>
-      </value>
-    </entry>
-    <entry>
-      <key>NGPSPSU</key>
-      <value>
-        <categories>
-            <category>Power supplies</category>
-        </categories>
-        <type>POWER_SUPPLY</type>
-        <path>ngpspsu.opi</path>
-        <description>The OPI for the NGPS power supply unit</description>
-        <macros>
-          <macro>
-            <name>NGPSPSU</name>
-            <description>The NGPSPSU PV prefix (e.g. NGPSPSU_01)</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-    <entry>        
-      <key>Matplotlib viewer</key>
-      <value>
-        <categories>
-        </categories>
-        <type>UNKNOWN</type>
-        <path>matplotlib.opi</path>
-        <description>The OPI for displaying plots created via matplotlib</description>
-        <macros>
-        </macros>
-      </value>
-    </entry>
-    <entry>        
-      <key>TDS 3000 Trace</key>
-      <value>
-        <categories>
-          <category>Oscilloscopes</category>
-        </categories>
-        <type>OSCILLOSCOPE</type>
-        <path>TDS3000_trace.opi</path>
-        <description>The trace shown by a TDS 3000 series oscilloscope</description>
-        <macros>
-          <macro>
-            <name>IP</name>
-            <description>The IP address of the oscilloscope.</description>
-          </macro>
-        </macros>
-      </value>
-    </entry>
-	</opis>
+            <key>Rotating Sample Changer</key>
+            <value>
+                <type>ROT_SAMPLE_CHANGER</type>
+                <path>rot_sample_changer.opi</path>
+                <description>The OPI for the rotating sample changer on HRPD/GEM/POLARIS. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Sample changers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Detector motion system</key>
+            <value>
+                <type>DETECTOR_MOTION_SYSTEM</type>
+                <path>detector_motion_system/detector_motion_system.opi</path>
+                <description>The OPI for the detector motion system. No properties required.</description>
+                <macros />
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Rotating Bench</key>
+            <value>
+                <type>ROTATINGBENCH</type>
+                <path>rotating_bench.opi</path>
+                <description>The OPI for the LARMOR rotating bench.</description>
+                <macros>
+                    <macro>
+                        <name>MM</name>
+                        <description>The PV for the motor controlling the bench rotation (e.g. MOT:MTR0605).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Applied Measurements Int2-L</key>
+            <value>
+                <type>PRESSURE_GAUGE</type>
+                <path>amint2l/amint2l.opi</path>
+                <description>The OPI for the Applied Measurements Int2-L pressure measurement system.</description>
+                <macros>
+                    <macro>
+                        <name>AMINT2L</name>
+                        <description>The AM Int2-L PV prefix (e.g. AMINT2L_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Pressure sensors</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Mk2 Chopper</key>
+            <value>
+                <type>CHOPPER</type>
+                <path>Mk2Chopper.opi</path>
+                <description>The OPI for the Mk2 chopper.</description>
+                <macros>
+                    <macro>
+                        <name>MK2CHOPR</name>
+                        <description>The Mk2 Chopper PV prefix (e.g. MK2CHOPR_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Choppers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Sample stack</key>
+            <value>
+                <type>SAMPLESTACK</type>
+                <path>sample_stack\sample_stack.opi</path>
+                <description>Generic sample stack OPI supporting up to 8 motors. PV prefixs are typically of the form MOT:STACK:Z </description>
+                <macros>
+                    <macro>
+                        <name>AXIS_PV_1</name>
+                        <description>The axis PV for motor 1</description>
+                    </macro>
+                    <macro>
+                        <name>AXIS_PV_2</name>
+                        <description>The axis PV for motor 2</description>
+                    </macro>
+                    <macro>
+                        <name>AXIS_PV_3</name>
+                        <description>The axis PV for motor 3</description>
+                    </macro>
+                    <macro>
+                        <name>AXIS_PV_4</name>
+                        <description>The axis PV for motor 4</description>
+                    </macro>
+                    <macro>
+                        <name>AXIS_PV_5</name>
+                        <description>The axis PV for motor 5</description>
+                    </macro>
+                    <macro>
+                        <name>AXIS_PV_6</name>
+                        <description>The axis PV for motor 6</description>
+                    </macro>
+                    <macro>
+                        <name>AXIS_PV_7</name>
+                        <description>The axis PV for motor 7</description>
+                    </macro>
+                    <macro>
+                        <name>AXIS_PV_8</name>
+                        <description>The axis PV for motor 8</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Sample stacks and goniometers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>HLG</key>
+            <value>
+                <type>HE_LEVEL_GAUGE</type>
+                <path>hlg.opi</path>
+                <description>The OPI for the helium level gauge.</description>
+                <macros>
+                    <macro>
+                        <name>HLG</name>
+                        <description>The HLG PV prefix (e.g. HLG_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Cryogenics</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Danfysik</key>
+            <value>
+                <type>DANFYSIK</type>
+                <path>danfysik.opi</path>
+                <description>The OPI for the Danfysik power supply for magnets.</description>
+                <macros>
+                    <macro>
+                        <name>DFKPS</name>
+                        <description>The Danfysik PV prefix (e.g. DFKPS_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Power supplies</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Engin-X sample postioning system</key>
+            <value>
+                <type>SAMPLESTACK</type>
+                <path>enginx_sample_position_system.opi</path>
+                <description>The OPI for the Engin-X sample positioning system.</description>
+                <macros />
+                <categories>
+                    <category>Sample stacks and goniometers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>LARMOR Spin Flipper</key>
+            <value>
+                <type>UNCONFIRMED</type>
+                <path>SpinFlipper306015.opi</path>
+                <description>The OPI for the LARMOR Spin Flipper.</description>
+                <macros />
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>XY Beam-stop</key>
+            <value>
+                <type>BEAMSTOP</type>
+                <path>beamstop.opi</path>
+                <description>The OPI for the XY beam-stop. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Live View</key>
+            <value>
+                <type>DAE</type>
+                <path>live_view.opi</path>
+                <description>The OPI for a live view of the detector</description>
+                <macros>
+                    <macro>
+                        <name>DET</name>
+                        <description>Detector number (1 is first)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Monitors</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Riken Front End Overview</key>
+            <value>
+                <type>MUON_FRONT_END</type>
+                <path>muon_overviews/riken_front_end_overview.opi</path>
+                <description>The OPI for the Riken front end. No properties required.</description>
+                <macros />
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Jaws</key>
+            <value>
+                <type>JAWS</type>
+                <path>jaws/jaws.opi</path>
+                <description>The OPI for a Jaw set.</description>
+                <macros>
+                    <macro>
+                        <name>J</name>
+                        <description>The Jaws PV (e.g. MOT:JAWS1).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Jaws and slits</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>ITC503</key>
+            <value>
+                <type>EUROTHERM</type>
+                <path>itc503\itc503.opi</path>
+                <description>The OPI for the OI ITC503 temperature controller</description>
+                <macros>
+                    <macro>
+                        <name>ITC503</name>
+                        <description>The ITC503 PV prefix (e.g. ITC503_01)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Temperature controllers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Polariser</key>
+            <value>
+                <type>POLARISER</type>
+                <path>polariser.opi</path>
+                <description>The OPI for the polariser. No properties required.</description>
+                <macros />
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Monitor</key>
+            <value>
+                <type>MONITOR</type>
+                <path>monitor.opi</path>
+                <description>The OPI for a fixed monitor.</description>
+                <macros>
+                    <macro>
+                        <name>M</name>
+                        <description>The monitor number (e.g. 1).</description>
+                    </macro>
+                    <macro>
+                        <name>MHVCHAN</name>
+                        <description>CAEN HV channel for the monitor (default: 0).</description>
+                    </macro>
+                    <macro>
+                        <name>MHVSLOT</name>
+                        <description>CAEN HV slot for the monitor (default: 0).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Monitors</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>TPG26x</key>
+            <value>
+                <type>PRESSURE_GAUGE</type>
+                <path>TPG26x.opi</path>
+                <description>The OPI for the PFEIFFER 26x Vacuum Gauge.</description>
+                <macros>
+                    <macro>
+                        <name>TPG</name>
+                        <description>The TPG26x PV prefix (e.g. TPG26X_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Pressure sensors</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Gem jaw set</key>
+            <value>
+                <type>JAWS</type>
+                <path>jaws/gem_jaws/Jaws_gem.opi</path>
+                <description>The OPI for the Gem jaw set. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Jaws and slits</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Muon Front End Overview</key>
+            <value>
+                <type>MUON_FRONT_END</type>
+                <path>muon_overviews/muon_front_end_overview.opi</path>
+                <description>The OPI for the Muon front end.</description>
+                <macros>
+                    <macro>
+                        <name>MM_EMU</name>
+                        <description>The motor PV relating to the EMU barndoors (e.g. MOT:MTR0101).</description>
+                    </macro>
+                    <macro>
+                        <name>MM_MUSR</name>
+                        <description>The motor PV relating to the MuSR barndoors (e.g. MOT:MTR0102).</description>
+                    </macro>
+                    <macro>
+                        <name>MM_HIFI</name>
+                        <description>The motor PV relating to the HiFi barndoors (e.g. MOT:MTR0103).</description>
+                    </macro>
+                    <macro>
+                        <name>MM_MOMENTUM</name>
+                        <description>The motor PV relating to the momentum slits (e.g. MOT:MTR0104).</description>
+                    </macro>
+                </macros>
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Sample stage</key>
+            <value>
+                <type>SAMPLESTACK</type>
+                <path>stage/sample.opi</path>
+                <description>The OPI for the sample stage. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Sample stacks and goniometers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Fermi chopper - Digital Drive</key>
+            <value>
+                <type>FERMI_CHOPPER</type>
+                <path>FZJ_DD_Fermi_Chopper.opi</path>
+                <description>The OPI for the FZJ Digital Drive Fermi Chopper.</description>
+                <macros />
+                <categories>
+                    <category>Choppers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Fermi chopper lifter</key>
+            <value>
+                <type>FERMI_CHOPPER</type>
+                <path>fermi_chopper_lift.opi</path>
+                <description>The OPI for the Fermi chopper lifter.</description>
+                <macros />
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Motion Set Point (Few)</key>
+            <value>
+                <type>MOTION_SET_POINTS_FEW</type>
+                <path>stage/inout_motion_setpoints.opi</path>
+                <description>The OPI for motion setpoints for one to three setpoints.</description>
+                <macros>
+                    <macro>
+                        <name>MOTION_SET_POINT</name>
+                        <description>The motion setpoint to display (e.g. LKUP:LSR)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Neocera LTC21</key>
+            <value>
+                <type>NEOCERA</type>
+                <path>neocera_ltc21.opi</path>
+                <description>The OPI for the Neocera LTC21.</description>
+                <macros>
+                    <macro>
+                        <name>NEOCERA</name>
+                        <description>The neocera PV prefix (e.g. NEOCERA_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Temperature controllers</category>
+                    <category>Cryogenics</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Triton dilution fridge</key>
+            <value>
+                <type>DILUTION_FRIDGE</type>
+                <path>triton\triton.opi</path>
+                <description>The OPI for the Triton</description>
+                <macros>
+                    <macro>
+                        <name>TRITON</name>
+                        <description>The triton PV prefix (e.g. TRITON_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Cryogenics</category>
+                    <category>Temperature controllers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Pixelman</key>
+            <value>
+                <type>PIXELMAN</type>
+                <path>pixelman.opi</path>
+                <description>Pixelman camera.</description>
+                <macros />
+                <categories>
+                    <category>Imaging cameras</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>NGPSPSU</key>
+            <value>
+                <type>POWER_SUPPLY</type>
+                <path>ngpspsu.opi</path>
+                <description>The OPI for the NGPS power supply unit</description>
+                <macros>
+                    <macro>
+                        <name>NGPSPSU</name>
+                        <description>The NGPSPSU PV prefix (e.g. NGPSPSU_01)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Power supplies</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Keithley 2700</key>
+            <value>
+                <type>KHLY2700</type>
+                <path>Keithley2700/keithley_scanner_values.opi</path>
+                <description>The OPI for the Keithley 2700 Source Meter.</description>
+                <macros>
+                    <macro>
+                        <name>KHLY2700</name>
+                        <description>The Keithley 2700 PV name (e.g. KHLY2700_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Multimeters</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Superlogics</key>
+            <value>
+                <type>MERCURY</type>
+                <path>superlogics.opi</path>
+                <description>The OPI for the Superlogics data acquisition system.</description>
+                <macros>
+                    <macro>
+                        <name>SPRLG</name>
+                        <description>The Superlogics PV prefix (e.g. SPRLG_01).</description>
+                    </macro>
+                </macros>
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Kepco</key>
+            <value>
+                <type>KEPCO</type>
+                <path>kepco.opi</path>
+                <description>The OPI for the Kepco power supply.</description>
+                <macros>
+                    <macro>
+                        <name>KEPCO</name>
+                        <description>The Kepco PV name (e.g. KEPCO_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Power supplies</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>XY Shutter Arm Beam-stop</key>
+            <value>
+                <type>BEAMSTOP</type>
+                <path>xyShutterArmBeamstop.opi</path>
+                <description>The OPI for the XY Arm Beam-stop with a shutter.</description>
+                <macros>
+                    <macro>
+                        <name>XYSHUTTERARMBEAMSTOP</name>
+                        <description>The XY Arm Shutter Beamstop PV prefix (e.g. MOT).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Zoom FINS PLC</key>
+            <value>
+                <type>PLC</type>
+                <path>PLCZoomVacuum.opi</path>
+                <description>The OPI for the Omron FINS PLC for the ZOOM vacuum.</description>
+                <macros>
+                    <macro>
+                        <name>Q</name>
+                        <description>The Omron FINS PLC Zoom vacuum PV prefix (e.g. VACUUM).</description>
+                    </macro>
+                </macros>
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Matplotlib viewer</key>
+            <value>
+                <type>UNKNOWN</type>
+                <path>matplotlib.opi</path>
+                <description>The OPI for displaying plots created via matplotlib</description>
+                <macros />
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>Julabo FP50</key>
+            <value>
+                <type>JULABO</type>
+                <path>JulaboFP50.opi</path>
+                <description>The OPI for the Julabo FP50 temperature controller..</description>
+                <macros>
+                    <macro>
+                        <name>JULABO</name>
+                        <description>The Julabo PV prefix (e.g. JULABO_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Water baths</category>
+                    <category>Temperature controllers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Linear sample changer</key>
+            <value>
+                <type>LINEARSAMPLECHANGER</type>
+                <path>stage/linear_sample_changer.opi</path>
+                <description>The OPI for the linear sample changer. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Sample changers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Engin-X collimators</key>
+            <value>
+                <type>JAWS</type>
+                <path>enginx_collimators/enginx_collimators.opi</path>
+                <description>The OPI for the Engin-X collimators.</description>
+                <macros />
+                <categories>
+                    <category>Miscellaneous motion control</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Attenuator</key>
+            <value>
+                <type>ATTENUATOR</type>
+                <path>attenuator.opi</path>
+                <description>The OPI for the attenuator. No properties required.</description>
+                <macros />
+                <categories />
+            </value>
+        </entry>
+        <entry>
+            <key>SKF G5 Chopper</key>
+            <value>
+                <type>CHOPPER</type>
+                <path>SKFG5Chopper/SKFChopper.opi</path>
+                <description>The OPI for the SKF G5 chopper controllers.</description>
+                <macros>
+                    <macro>
+                        <name>DEFAULT_ACTIVE_TAB</name>
+                        <description>The tab which is displayed when the OPI is opened (1 to 5).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Choppers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>IEG system</key>
+            <value>
+                <type>GAS_EXCHANGE</type>
+                <path>ieg_system.opi</path>
+                <description>The OPI for the gas exchange system.</description>
+                <macros>
+                    <macro>
+                        <name>IEG</name>
+                        <description>The gas exchange system PV prefix (e.g. IEG_01).</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Gas and liquid handling systems</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>SM300 Sample Changer</key>
+            <value>
+                <type>SM300_SAMPLE_CHANGER</type>
+                <path>sample_stack/sm300sampos.opi</path>
+                <description>The OPI for the SM300 Sample changer</description>
+                <macros>
+                    <macro>
+                        <name>MOTION_SET_POINT</name>
+                        <description>The prefix of the Motion set points being used(e.g. LKUP:SAMPLE)</description>
+                    </macro>
+                </macros>
+                <categories>
+                    <category>Sample changers</category>
+                </categories>
+            </value>
+        </entry>
+        <entry>
+            <key>Instron stress rig</key>
+            <value>
+                <type>STRESS_RIG</type>
+                <path>stress_rig/stress_rig.opi</path>
+                <description>The OPI for the Instron stress rig. No properties required.</description>
+                <macros />
+                <categories>
+                    <category>Loading rigs</category>
+                </categories>
+            </value>
+        </entry>
+    </opis>
 </descriptions>


### PR DESCRIPTION
### Description of work

The opi_info.xml  contained duplicate keys. A test was created to check for duplicate entries and warn if they exist. The exisiting opi_info.xml file was cleaned up and duplicates were removed.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3515

### Acceptance criteria

Duplicate keys could exist for OPI's in the opi_info list. A test was created that parses the xml file and filters a list of non-uniques. The test fails if duplicates exist. The duplicate entries are repoted and the number of instances.

### Unit tests

The following test was created: test_that_opi_file_does_not_contain_any_duplicate_keys()

### System tests

None

### Documentation

None

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

