### PR TITLE
Fixed size for block name label

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/GroupRow.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/GroupRow.java
@@ -23,6 +23,7 @@ import uk.ac.stfc.isis.ibex.configserver.displaying.DisplayBlock;
 public class GroupRow extends Composite {
 	
     private static final Color WHITE = SWTResourceManager.getColor(SWT.COLOR_WHITE);
+    private static final int NAME_WIDTH = 100;
     private static final int VALUE_WIDTH = 75;
     private static final int VALUE_HEIGHT = 17;
     private static final int VALUE_WIDTH_MARGIN = 4;
@@ -50,9 +51,11 @@ public class GroupRow extends Composite {
         this.setBackground(WHITE);
         this.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
         
-        lblName =
-                labelMaker(this, SWT.NONE, block.getName() + ": ", block.getDescription(), null);
-        lblName.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 1, 1));
+        lblName = labelMaker(this, SWT.NONE, block.getName() + ": ", block.getDescription());
+        GridData gdLblName = new GridData(SWT.LEFT, SWT.CENTER, true, false, 1, 1);
+        gdLblName.widthHint = NAME_WIDTH;
+        lblName.setLayoutData(gdLblName);
+        
 
         // additional container to hold value label to draw a border around it
         Composite valueContainer = new Composite(this, SWT.CENTER);
@@ -69,15 +72,14 @@ public class GroupRow extends Composite {
         valueContainer.setLayoutData(gdValueContainer);
 
         lblValue =
-                labelMaker(valueContainer, SWT.RIGHT, block.getValue(), block.getDescription(),
-                        null);
+                labelMaker(valueContainer, SWT.RIGHT, block.getValue(), block.getDescription());
         GridData gdValue = new GridData(SWT.CENTER, SWT.NONE, false, false, 1, 1);
         gdValue.widthHint = VALUE_WIDTH;
         lblValue.setLayoutData(gdValue);
         lblValue.setVisible(true);
         valueContainer.pack();
 
-        lblStatus = labelMaker(this, SWT.CENTER, "", "Run Control Status", null);
+        lblStatus = labelMaker(this, SWT.CENTER, "", "Run Control Status");
         FontDescriptor boldDescriptor = FontDescriptor.createFrom(lblStatus.getFont()).setStyle(SWT.BOLD);
         Font boldFont = boldDescriptor.createFont(lblStatus.getDisplay());
         lblStatus.setFont(boldFont);
@@ -126,7 +128,7 @@ public class GroupRow extends Composite {
 		lblStatus.setMenu(menu);
 	}
 
-    private Label labelMaker(Composite composite, int style, String text, String toolTip, Font font) {
+    private Label labelMaker(Composite composite, int style, String text, String description) {
         Label label = new Label(composite, style);
         if (text != null) {
             label.setText(text);
@@ -134,13 +136,7 @@ public class GroupRow extends Composite {
 
         label.setBackground(WHITE);
 
-        if (toolTip != null) {
-            label.setToolTipText(toolTip);
-        }
-
-        if (font != null) {
-            label.setFont(font);
-        }
+        label.setToolTipText(text + System.lineSeparator() + description);
 
         return label;
     }


### PR DESCRIPTION
### Description of work

Fixed an issue where the blocks panel would get stuck continuously resizing itself due to changing column widths. Gave the block names label a fixed size and added the block's full name to the tooltip (in case it is too long and gets truncated).

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3554

### Acceptance criteria

- The juddering behaviour described in the original ticket is not observed anymore
- All information on the blocks panel is still clearly visible to the user.

### Unit tests

/

### System tests

/

### Documentation

/

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

