### PR TITLE
Ticket3697 fix synoptic copy

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/model/desc/TargetDescriptionTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/model/desc/TargetDescriptionTest.java
@@ -133,7 +133,7 @@ public class TargetDescriptionTest {
     	TargetDescription copied = new TargetDescription(source);
     	
         // Act (should not affect property of source).
-        copied.getProperties().get(0).setValue("COPIED");
+        copied.getProperties().get(0).setValue(copiedPropertyValue);
 
         // Assert
         assertEquals(source.getProperties().get(0).getValue(), sourcePropertyValue);

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/model/desc/TargetDescriptionTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/model/desc/TargetDescriptionTest.java
@@ -122,6 +122,23 @@ public class TargetDescriptionTest {
         assertEquals(TargetType.OPI, source.type());
         assertEquals(TargetType.COMPONENT, copied.type());
     }
+    
+    @Test
+    public void copied_object_has_macros_that_are_not_linked_to_source_object() {
+    	final String sourcePropertyValue = "SOURCE";
+    	final String copiedPropertyValue = "COPIED";
+    	
+    	// Arrange
+    	source.getProperties().get(0).setValue(sourcePropertyValue);
+    	TargetDescription copied = new TargetDescription(source);
+    	
+        // Act (should not affect property of source).
+        copied.getProperties().get(0).setValue("COPIED");
+
+        // Assert
+        assertEquals(source.getProperties().get(0).getValue(), sourcePropertyValue);
+        assertEquals(copied.getProperties().get(0).getValue(), copiedPropertyValue);
+    }
 
     @Test
     public void copied_object_has_same_properties_as_source_object_with_no_name_changes() {

--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/ComponentDescription.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/ComponentDescription.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.synoptic.model.desc;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -98,10 +99,7 @@ public class ComponentDescription extends ModelObject implements SynopticParentD
         this.type = other.type;
         this.target = other.target != null ? new TargetDescription(other.target) : null;
 
-        this.pvs = new ArrayList<>();
-        for (PV pv : other.pvs) {
-            this.pvs.add(new PV(pv));
-        }
+        this.pvs = other.pvs().stream().map(PV::new).collect(Collectors.toList());
 
         this.components = new ArrayList<>();
         for (ComponentDescription cd : other.components) {

--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/Property.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/Property.java
@@ -43,6 +43,13 @@ public class Property extends ModelObject {
 	public Property() {
 	}
 	
+	/**
+	 * Clones an existing property.
+	 */
+	public Property(Property other) {
+		this(other.key, other.value);
+	}
+	
     /**
      * Instantiates a new property.
      *

--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/Property.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/Property.java
@@ -45,6 +45,8 @@ public class Property extends ModelObject {
 	
 	/**
 	 * Clones an existing property.
+	 * 
+	 * @param other the property to clone
 	 */
 	public Property(Property other) {
 		this(other.key, other.value);

--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/TargetDescription.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/model/desc/TargetDescription.java
@@ -22,6 +22,7 @@ package uk.ac.stfc.isis.ibex.synoptic.model.desc;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -41,7 +42,7 @@ public class TargetDescription {
 	
 	@XmlElementWrapper(name = "properties")
 	@XmlElement(name = "property", type = Property.class)
-	private ArrayList<Property> properties = new ArrayList<>();
+	private List<Property> properties = new ArrayList<>();
 	
     /**
      * Default constructor, required due to existence of copy constructor.
@@ -69,7 +70,7 @@ public class TargetDescription {
     public TargetDescription(TargetDescription other) {
         this.name = other.name;
         this.type = other.type;
-        this.properties = new ArrayList<>(other.getProperties());
+        this.properties = other.getProperties().stream().map(Property::new).collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
### Description of work

Fixes an implicit link between a source & copied synoptic component's macros.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3697

### Acceptance criteria

- Workflow in ticket is no longer broken

### Unit tests

Added a test simulating the workflow in ticket

### System tests

This is adequately tested by unit tests; system tests at this level of detail not needed.

### Documentation

N/a

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

