### PR TITLE
Ticket 3605: IOC's auto-start/restart when adding to a configuration.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Ioc.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Ioc.java
@@ -45,13 +45,13 @@ public class Ioc extends ModelObject implements Comparable<Ioc>, INamed {
      * The IOC will be started along with the config and restarted when the
      * block server restarts.
      */
-	private boolean autostart;
+	private boolean autostart = true;
 
     /**
      * If the IOC is terminated unexpectedly, and autostart is also true, the
      * IOC will be restarted.
      */
-	private boolean restart;
+	private boolean restart = true;
 
 	private SimLevel simlevel = SimLevel.NONE;
 	private Collection<PVSet> pvsets = new ArrayList<PVSet>();


### PR DESCRIPTION
### Description of work

Updated the default boolean value to true for if an IOC should auto-restart and auto-start when being added to a configuration. We want these as defaults as we only do not want it to happen in edge cases.

### Ticket

See: https://github.com/ISISComputingGroup/IBEX/issues/3605

### Acceptance criteria

When adding an IOC to a configuration, the default state is for the IOC to have auto-restart and auto-start to be true.

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

