### PR TITLE
Footprint in tabs. input for sample length

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/beam_footprint.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/beam_footprint.opi
@@ -1,0 +1,485 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
+  <actions hook="false" hook_all="false" />
+  <auto_scale_widgets>
+    <auto_scale_widgets>false</auto_scale_widgets>
+    <min_width>-1</min_width>
+    <min_height>-1</min_height>
+  </auto_scale_widgets>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <background_color>
+    <color red="240" green="240" blue="240" />
+  </background_color>
+  <boy_version>5.1.0.201707071649</boy_version>
+  <foreground_color>
+    <color red="192" green="192" blue="192" />
+  </foreground_color>
+  <grid_space>6</grid_space>
+  <height>66</height>
+  <macros>
+    <include_parent_macros>true</include_parent_macros>
+  </macros>
+  <name></name>
+  <rules />
+  <scripts />
+  <show_close_button>true</show_close_button>
+  <show_edit_range>true</show_edit_range>
+  <show_grid>true</show_grid>
+  <show_ruler>true</show_ruler>
+  <snap_to_geometry>true</snap_to_geometry>
+  <widget_type>Display</widget_type>
+  <width>250</width>
+  <wuid>-66312240:1683d19d453:-7d9d</wuid>
+  <x>-1</x>
+  <y>-1</y>
+  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <bg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </bg_gradient_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </fg_gradient_color>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <gradient>false</gradient>
+    <height>66</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_color>
+      <color red="128" green="0" blue="255" />
+    </line_color>
+    <line_style>0</line_style>
+    <line_width>0</line_width>
+    <name>Rectangle</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Rectangle</widget_type>
+    <width>250</width>
+    <wuid>-66312240:1683d19d453:-7c0b</wuid>
+    <x>0</x>
+    <y>0</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label_1</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Qmin:</text>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>35</width>
+    <wrap_words>true</wrap_words>
+    <wuid>-66312240:1683d19d453:-7c1d</wuid>
+    <x>144</x>
+    <y>6</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label_3</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Resolution:</text>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>67</width>
+    <wrap_words>true</wrap_words>
+    <wuid>-66312240:1683d19d453:-7c19</wuid>
+    <x>0</x>
+    <y>6</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>3</border_style>
+    <border_width>1</border_width>
+    <confirm_message></confirm_message>
+    <enabled>false</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>25</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <limits_from_pv>false</limits_from_pv>
+    <maximum>1.7976931348623157E308</maximum>
+    <minimum>-1.7976931348623157E308</minimum>
+    <multiline_input>false</multiline_input>
+    <name>Text Input_2</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(PV_ROOT)FP:FOOTPRINT_$(SUFFIX)</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selector_type>0</selector_type>
+    <show_units>true</show_units>
+    <style>0</style>
+    <text></text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>true</transparent>
+    <visible>true</visible>
+    <widget_type>Text Input</widget_type>
+    <width>62</width>
+    <wuid>-66312240:1683d19d453:-7c1c</wuid>
+    <x>72</x>
+    <y>33</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label_2</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Footprint:</text>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>67</width>
+    <wrap_words>true</wrap_words>
+    <wuid>-66312240:1683d19d453:-7c1b</wuid>
+    <x>0</x>
+    <y>36</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>20</height>
+    <horizontal_alignment>2</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Qmax:</text>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>37</width>
+    <wrap_words>true</wrap_words>
+    <wuid>-66312240:1683d19d453:-7c1e</wuid>
+    <x>143</x>
+    <y>36</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>3</border_style>
+    <border_width>1</border_width>
+    <confirm_message></confirm_message>
+    <enabled>false</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>25</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <limits_from_pv>false</limits_from_pv>
+    <maximum>1.7976931348623157E308</maximum>
+    <minimum>-1.7976931348623157E308</minimum>
+    <multiline_input>false</multiline_input>
+    <name>Text Input_3</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(PV_ROOT)FP:DQQ_$(SUFFIX)</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selector_type>0</selector_type>
+    <show_units>true</show_units>
+    <style>0</style>
+    <text></text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>true</transparent>
+    <visible>true</visible>
+    <widget_type>Text Input</widget_type>
+    <width>62</width>
+    <wuid>-66312240:1683d19d453:-7c1a</wuid>
+    <x>72</x>
+    <y>3</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>3</border_style>
+    <border_width>1</border_width>
+    <confirm_message></confirm_message>
+    <enabled>false</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>25</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <limits_from_pv>false</limits_from_pv>
+    <maximum>1.7976931348623157E308</maximum>
+    <minimum>-1.7976931348623157E308</minimum>
+    <multiline_input>false</multiline_input>
+    <name>Text Input_1</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(PV_ROOT)FP:QMIN_$(SUFFIX)</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selector_type>0</selector_type>
+    <show_units>true</show_units>
+    <style>0</style>
+    <text></text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>true</transparent>
+    <visible>true</visible>
+    <widget_type>Text Input</widget_type>
+    <width>62</width>
+    <wuid>-66312240:1683d19d453:-7c1f</wuid>
+    <x>187</x>
+    <y>3</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <auto_size>false</auto_size>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>3</border_style>
+    <border_width>1</border_width>
+    <confirm_message></confirm_message>
+    <enabled>false</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <format_type>0</format_type>
+    <height>25</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <limits_from_pv>false</limits_from_pv>
+    <maximum>1.7976931348623157E308</maximum>
+    <minimum>-1.7976931348623157E308</minimum>
+    <multiline_input>false</multiline_input>
+    <name>Text Input</name>
+    <precision>0</precision>
+    <precision_from_pv>true</precision_from_pv>
+    <pv_name>$(PV_ROOT)FP:QMAX_$(SUFFIX)</pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <selector_type>0</selector_type>
+    <show_units>true</show_units>
+    <style>0</style>
+    <text></text>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>true</transparent>
+    <visible>true</visible>
+    <widget_type>Text Input</widget_type>
+    <width>62</width>
+    <wuid>-66312240:1683d19d453:-7c20</wuid>
+    <x>187</x>
+    <y>35</y>
+  </widget>
+</display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -15,7 +15,7 @@
     <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
-  <height>600</height>
+  <height>660</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
     <PV_ROOT>$(P)REFL:</PV_ROOT>
@@ -51,7 +51,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>601</height>
+    <height>660</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -241,7 +241,7 @@ $(pv_value)</tooltip>
       <foreground_color>
         <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
       </foreground_color>
-      <height>505</height>
+      <height>577</height>
       <horizontal_tabs>true</horizontal_tabs>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -305,7 +305,7 @@ $(pv_value)</tooltip>
         <foreground_color>
           <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
         </foreground_color>
-        <height>476</height>
+        <height>548</height>
         <lock_children>false</lock_children>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -345,7 +345,7 @@ $(pv_value)</tooltip>
           <foreground_color>
             <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
           </foreground_color>
-          <height>138</height>
+          <height>212</height>
           <lock_children>false</lock_children>
           <macros>
             <include_parent_macros>true</include_parent_macros>
@@ -388,7 +388,7 @@ $(pv_value)</tooltip>
             <foreground_color>
               <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
             </foreground_color>
-            <height>85</height>
+            <height>163</height>
             <horizontal>false</horizontal>
             <items_from_pv>true</items_from_pv>
             <name>Choice Button</name>
@@ -454,248 +454,33 @@ $(pv_value)</tooltip>
           <wuid>-4805f29c:1579922e8d6:-7f64</wuid>
           <x>12</x>
           <y>12</y>
-          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
-            <auto_size>false</auto_size>
             <background_color>
-              <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+              <color red="240" green="240" blue="240" />
             </background_color>
             <border_color>
-              <color name="ISIS_Border" red="0" green="0" blue="0" />
+              <color red="0" green="128" blue="255" />
             </border_color>
             <border_style>0</border_style>
             <border_width>1</border_width>
             <enabled>true</enabled>
             <font>
-              <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
-            </font>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <height>20</height>
-            <horizontal_alignment>2</horizontal_alignment>
-            <name>Label</name>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <show_scrollbar>false</show_scrollbar>
-            <text>S0VG:</text>
-            <tooltip></tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
-            <visible>true</visible>
-            <widget_type>Label</widget_type>
-            <width>42</width>
-            <wrap_words>true</wrap_words>
-            <wuid>-48159ee9:1567f536160:-5c7e</wuid>
-            <x>0</x>
-            <y>6</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <auto_size>false</auto_size>
-            <background_color>
-              <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color name="ISIS_Border" red="0" green="0" blue="0" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
-            </font>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <height>20</height>
-            <horizontal_alignment>2</horizontal_alignment>
-            <name>Label_2</name>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <show_scrollbar>false</show_scrollbar>
-            <text>S1VG:&#xD;
-</text>
-            <tooltip></tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
-            <visible>true</visible>
-            <widget_type>Label</widget_type>
-            <width>42</width>
-            <wrap_words>true</wrap_words>
-            <wuid>-48159ee9:1567f536160:-5a91</wuid>
-            <x>0</x>
-            <y>36</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <auto_size>false</auto_size>
-            <background_color>
-              <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color name="ISIS_Border" red="0" green="0" blue="0" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
-            </font>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <height>20</height>
-            <horizontal_alignment>2</horizontal_alignment>
-            <name>Label_3</name>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <show_scrollbar>false</show_scrollbar>
-            <text>S2VG:</text>
-            <tooltip></tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
-            <visible>true</visible>
-            <widget_type>Label</widget_type>
-            <width>42</width>
-            <wrap_words>true</wrap_words>
-            <wuid>-48159ee9:1567f536160:-5a81</wuid>
-            <x>0</x>
-            <y>66</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <auto_size>false</auto_size>
-            <background_color>
-              <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color name="ISIS_Border" red="0" green="0" blue="0" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
-            </font>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <height>20</height>
-            <horizontal_alignment>2</horizontal_alignment>
-            <name>Label_3</name>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <show_scrollbar>false</show_scrollbar>
-            <text>S3VG:&#xD;
-</text>
-            <tooltip></tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
-            <visible>true</visible>
-            <widget_type>Label</widget_type>
-            <width>42</width>
-            <wrap_words>true</wrap_words>
-            <wuid>-48159ee9:1567f536160:-5a71</wuid>
-            <x>0</x>
-            <y>96</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <auto_size>false</auto_size>
-            <background_color>
-              <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color name="ISIS_Border" red="0" green="0" blue="0" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
-            </font>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <height>20</height>
-            <horizontal_alignment>2</horizontal_alignment>
-            <name>Label_8</name>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <show_scrollbar>false</show_scrollbar>
-            <text>S4VG:</text>
-            <tooltip></tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
-            <visible>true</visible>
-            <widget_type>Label</widget_type>
-            <width>42</width>
-            <wrap_words>true</wrap_words>
-            <wuid>4c937f8b:15799b33729:-7fc5</wuid>
-            <x>0</x>
-            <y>126</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.spinner" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <background_color>
-              <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
-            </background_color>
-            <border_alarm_sensitive>true</border_alarm_sensitive>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>3</border_style>
-            <border_width>1</border_width>
-            <buttons_on_left>false</buttons_on_left>
-            <enabled>true</enabled>
-            <font>
               <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
             </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
             <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+              <color red="192" green="192" blue="192" />
             </foreground_color>
-            <format>0</format>
-            <height>25</height>
-            <horizontal_alignment>1</horizontal_alignment>
-            <horizontal_buttons_layout>false</horizontal_buttons_layout>
-            <limits_from_pv>true</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <name>Spinner</name>
-            <page_increment>10.0</page_increment>
-            <precision>3</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
+            <group_name></group_name>
+            <height>31</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+              <PARAM_PV>PARAM:S0VG</PARAM_PV>
+              <PARAM_NAME>S0VG</PARAM_NAME>
+            </macros>
+            <name>vgap_1</name>
+            <opi_file>param_gap.opi</opi_file>
+            <resize_behaviour>1</resize_behaviour>
             <rules />
             <scale_options>
               <width_scalable>true</width_scalable>
@@ -703,474 +488,18 @@ $(pv_value)</tooltip>
               <keep_wh_ratio>false</keep_wh_ratio>
             </scale_options>
             <scripts />
-            <show_text>true</show_text>
-            <step_increment>0.01</step_increment>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
+            <tooltip></tooltip>
             <visible>true</visible>
-            <widget_type>Spinner</widget_type>
-            <width>85</width>
-            <wuid>-7578f52:165a3e390a9:-7b9b</wuid>
-            <x>60</x>
-            <y>33</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.spinner" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <background_color>
-              <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
-            </background_color>
-            <border_alarm_sensitive>true</border_alarm_sensitive>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>3</border_style>
-            <border_width>1</border_width>
-            <buttons_on_left>false</buttons_on_left>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <format>0</format>
-            <height>25</height>
-            <horizontal_alignment>1</horizontal_alignment>
-            <horizontal_buttons_layout>false</horizontal_buttons_layout>
-            <limits_from_pv>true</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <name>Spinner</name>
-            <page_increment>10.0</page_increment>
-            <precision>3</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <show_text>true</show_text>
-            <step_increment>0.01</step_increment>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
-            <visible>true</visible>
-            <widget_type>Spinner</widget_type>
-            <width>85</width>
-            <wuid>-7578f52:165a3e390a9:-7b90</wuid>
-            <x>60</x>
-            <y>63</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.spinner" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <background_color>
-              <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
-            </background_color>
-            <border_alarm_sensitive>true</border_alarm_sensitive>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>3</border_style>
-            <border_width>1</border_width>
-            <buttons_on_left>false</buttons_on_left>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <format>0</format>
-            <height>25</height>
-            <horizontal_alignment>1</horizontal_alignment>
-            <horizontal_buttons_layout>false</horizontal_buttons_layout>
-            <limits_from_pv>true</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <name>Spinner_1</name>
-            <page_increment>10.0</page_increment>
-            <precision>3</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <show_text>true</show_text>
-            <step_increment>0.01</step_increment>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
-            <visible>true</visible>
-            <widget_type>Spinner</widget_type>
-            <width>85</width>
-            <wuid>-7578f52:165a3e390a9:-7b8f</wuid>
-            <x>60</x>
-            <y>93</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.spinner" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <background_color>
-              <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
-            </background_color>
-            <border_alarm_sensitive>true</border_alarm_sensitive>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>3</border_style>
-            <border_width>1</border_width>
-            <buttons_on_left>false</buttons_on_left>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <format>0</format>
-            <height>25</height>
-            <horizontal_alignment>1</horizontal_alignment>
-            <horizontal_buttons_layout>false</horizontal_buttons_layout>
-            <limits_from_pv>true</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <name>Spinner_1</name>
-            <page_increment>10.0</page_increment>
-            <precision>3</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <show_text>true</show_text>
-            <step_increment>0.01</step_increment>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
-            <visible>true</visible>
-            <widget_type>Spinner</widget_type>
-            <width>85</width>
-            <wuid>-7578f52:165a3e390a9:-7b87</wuid>
-            <x>60</x>
-            <y>123</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
-            <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <auto_size>false</auto_size>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <background_color>
-              <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
-            </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>3</border_style>
-            <border_width>1</border_width>
-            <confirm_message></confirm_message>
-            <enabled>false</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <format_type>0</format_type>
-            <height>25</height>
-            <horizontal_alignment>0</horizontal_alignment>
-            <limits_from_pv>false</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <multiline_input>false</multiline_input>
-            <name>Text Input</name>
-            <precision>0</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
-            <rotation_angle>0.0</rotation_angle>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <selector_type>0</selector_type>
-            <show_units>true</show_units>
-            <style>0</style>
-            <text></text>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>true</transparent>
-            <visible>true</visible>
-            <widget_type>Text Input</widget_type>
-            <width>85</width>
-            <wuid>-744b7940:165a9b5d31a:-7a54</wuid>
-            <x>160</x>
+            <widget_type>Linking Container</widget_type>
+            <width>246</width>
+            <wuid>3a20c40:16828bf77be:-7bfd</wuid>
+            <x>0</x>
             <y>3</y>
           </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <auto_size>false</auto_size>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
             <background_color>
-              <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
-            </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>3</border_style>
-            <border_width>1</border_width>
-            <confirm_message></confirm_message>
-            <enabled>false</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <format_type>0</format_type>
-            <height>25</height>
-            <horizontal_alignment>0</horizontal_alignment>
-            <limits_from_pv>false</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <multiline_input>false</multiline_input>
-            <name>Text Input</name>
-            <precision>0</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
-            <rotation_angle>0.0</rotation_angle>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <selector_type>0</selector_type>
-            <show_units>true</show_units>
-            <style>0</style>
-            <text></text>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>true</transparent>
-            <visible>true</visible>
-            <widget_type>Text Input</widget_type>
-            <width>85</width>
-            <wuid>-744b7940:165a9b5d31a:-794e</wuid>
-            <x>160</x>
-            <y>33</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
-            <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <auto_size>false</auto_size>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <background_color>
-              <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
-            </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>3</border_style>
-            <border_width>1</border_width>
-            <confirm_message></confirm_message>
-            <enabled>false</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <format_type>0</format_type>
-            <height>25</height>
-            <horizontal_alignment>0</horizontal_alignment>
-            <limits_from_pv>false</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <multiline_input>false</multiline_input>
-            <name>Text Input</name>
-            <precision>0</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
-            <rotation_angle>0.0</rotation_angle>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <selector_type>0</selector_type>
-            <show_units>true</show_units>
-            <style>0</style>
-            <text></text>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>true</transparent>
-            <visible>true</visible>
-            <widget_type>Text Input</widget_type>
-            <width>85</width>
-            <wuid>-744b7940:165a9b5d31a:-7949</wuid>
-            <x>160</x>
-            <y>63</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
-            <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <auto_size>false</auto_size>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <background_color>
-              <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
-            </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>3</border_style>
-            <border_width>1</border_width>
-            <confirm_message></confirm_message>
-            <enabled>false</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <format_type>0</format_type>
-            <height>25</height>
-            <horizontal_alignment>0</horizontal_alignment>
-            <limits_from_pv>false</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <multiline_input>false</multiline_input>
-            <name>Text Input</name>
-            <precision>0</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
-            <rotation_angle>0.0</rotation_angle>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <selector_type>0</selector_type>
-            <show_units>true</show_units>
-            <style>0</style>
-            <text></text>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>true</transparent>
-            <visible>true</visible>
-            <widget_type>Text Input</widget_type>
-            <width>85</width>
-            <wuid>-744b7940:165a9b5d31a:-7944</wuid>
-            <x>160</x>
-            <y>93</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
-            <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <auto_size>false</auto_size>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-            <background_color>
-              <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
-            </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>3</border_style>
-            <border_width>1</border_width>
-            <confirm_message></confirm_message>
-            <enabled>false</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-            <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-            </foreground_color>
-            <format_type>0</format_type>
-            <height>25</height>
-            <horizontal_alignment>0</horizontal_alignment>
-            <limits_from_pv>false</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <multiline_input>false</multiline_input>
-            <name>Text Input</name>
-            <precision>0</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
-            <rotation_angle>0.0</rotation_angle>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <selector_type>0</selector_type>
-            <show_units>true</show_units>
-            <style>0</style>
-            <text></text>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>true</transparent>
-            <visible>true</visible>
-            <widget_type>Text Input</widget_type>
-            <width>85</width>
-            <wuid>-744b7940:165a9b5d31a:-793f</wuid>
-            <x>160</x>
-            <y>123</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <auto_size>false</auto_size>
-            <background_color>
-              <color name="ISIS_Yellow" red="255" green="255" blue="0" />
+              <color red="240" green="240" blue="240" />
             </background_color>
             <border_color>
               <color red="0" green="128" blue="255" />
@@ -1179,14 +508,21 @@ $(pv_value)</tooltip>
             <border_width>1</border_width>
             <enabled>true</enabled>
             <font>
-              <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
             </font>
             <foreground_color>
-              <color red="0" green="0" blue="0" />
+              <color red="192" green="192" blue="192" />
             </foreground_color>
-            <height>49</height>
-            <horizontal_alignment>1</horizontal_alignment>
-            <name>Label_1</name>
+            <group_name></group_name>
+            <height>31</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+              <PARAM_PV>PARAM:S1VG</PARAM_PV>
+              <PARAM_NAME>S1VG</PARAM_NAME>
+            </macros>
+            <name>vgap_1</name>
+            <opi_file>param_gap.opi</opi_file>
+            <resize_behaviour>1</resize_behaviour>
             <rules />
             <scale_options>
               <width_scalable>true</width_scalable>
@@ -1194,53 +530,41 @@ $(pv_value)</tooltip>
               <keep_wh_ratio>false</keep_wh_ratio>
             </scale_options>
             <scripts />
-            <text>TODO</text>
             <tooltip></tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
             <visible>true</visible>
-            <widget_type>Label</widget_type>
-            <width>80</width>
-            <wrap_words>false</wrap_words>
-            <wuid>-16c8e940:165f1448c04:-7e56</wuid>
-            <x>84</x>
-            <y>51</y>
+            <widget_type>Linking Container</widget_type>
+            <width>246</width>
+            <wuid>3a20c40:16828bf77be:-7bb4</wuid>
+            <x>0</x>
+            <y>32</y>
           </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.spinner" version="1.0.0">
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
-            <alarm_pulsing>false</alarm_pulsing>
-            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
             <background_color>
-              <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
+              <color red="240" green="240" blue="240" />
             </background_color>
-            <border_alarm_sensitive>true</border_alarm_sensitive>
             <border_color>
               <color red="0" green="128" blue="255" />
             </border_color>
-            <border_style>3</border_style>
+            <border_style>0</border_style>
             <border_width>1</border_width>
-            <buttons_on_left>false</buttons_on_left>
             <enabled>true</enabled>
             <font>
               <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
             </font>
-            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
             <foreground_color>
-              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+              <color red="192" green="192" blue="192" />
             </foreground_color>
-            <format>0</format>
-            <height>25</height>
-            <horizontal_alignment>1</horizontal_alignment>
-            <horizontal_buttons_layout>false</horizontal_buttons_layout>
-            <limits_from_pv>true</limits_from_pv>
-            <maximum>1.7976931348623157E308</maximum>
-            <minimum>-1.7976931348623157E308</minimum>
-            <name>Spinner</name>
-            <page_increment>10.0</page_increment>
-            <precision>3</precision>
-            <precision_from_pv>true</precision_from_pv>
-            <pv_name></pv_name>
-            <pv_value />
+            <group_name></group_name>
+            <height>31</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+              <PARAM_PV>PARAM:S2VG</PARAM_PV>
+              <PARAM_NAME>S2VG</PARAM_NAME>
+            </macros>
+            <name>vgap_1</name>
+            <opi_file>param_gap.opi</opi_file>
+            <resize_behaviour>1</resize_behaviour>
             <rules />
             <scale_options>
               <width_scalable>true</width_scalable>
@@ -1248,18 +572,97 @@ $(pv_value)</tooltip>
               <keep_wh_ratio>false</keep_wh_ratio>
             </scale_options>
             <scripts />
-            <show_text>true</show_text>
-            <step_increment>0.01</step_increment>
-            <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-            <transparent>false</transparent>
-            <vertical_alignment>1</vertical_alignment>
+            <tooltip></tooltip>
             <visible>true</visible>
-            <widget_type>Spinner</widget_type>
-            <width>85</width>
-            <wuid>-7578f52:165a3e390a9:-7c5f</wuid>
-            <x>60</x>
-            <y>3</y>
+            <widget_type>Linking Container</widget_type>
+            <width>246</width>
+            <wuid>3a20c40:16828bf77be:-7b9a</wuid>
+            <x>0</x>
+            <y>62</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>31</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+              <PARAM_PV>PARAM:S3VG</PARAM_PV>
+              <PARAM_NAME>S3VG</PARAM_NAME>
+            </macros>
+            <name>vgap_1</name>
+            <opi_file>param_gap.opi</opi_file>
+            <resize_behaviour>1</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>true</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>246</width>
+            <wuid>3a20c40:16828bf77be:-7b84</wuid>
+            <x>0</x>
+            <y>92</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>31</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+              <PARAM_PV>PARAM:S4VG</PARAM_PV>
+              <PARAM_NAME>S4VG</PARAM_NAME>
+            </macros>
+            <name>vgap_1</name>
+            <opi_file>param_gap.opi</opi_file>
+            <resize_behaviour>1</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>true</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>246</width>
+            <wuid>3a20c40:16828bf77be:-7b70</wuid>
+            <x>0</x>
+            <y>122</y>
           </widget>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
@@ -3784,8 +3187,6 @@ $(pv_value)</tooltip>
             <height>40</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
-              <PARAM_PV>PARAM:SMANGLE</PARAM_PV>
-              <PARAM_NAME>Super Mirror</PARAM_NAME>
             </macros>
             <name></name>
             <opi_file>component_pos.opi</opi_file>
@@ -3848,6 +3249,465 @@ $(pv_value)</tooltip>
             <y>0</y>
           </widget>
         </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.tab" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <active_tab>0</active_tab>
+          <background_color>
+            <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color name="ISIS_Border" red="0" green="0" blue="0" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <foreground_color>
+            <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+          </foreground_color>
+          <height>103</height>
+          <horizontal_tabs>true</horizontal_tabs>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+            <SUFFIX>SP_RBV</SUFFIX>
+          </macros>
+          <minimum_tab_height>10</minimum_tab_height>
+          <name>Tabbed Container</name>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tab_0_background_color>
+            <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+          </tab_0_background_color>
+          <tab_0_enabled>true</tab_0_enabled>
+          <tab_0_font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
+          </tab_0_font>
+          <tab_0_foreground_color>
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+          </tab_0_foreground_color>
+          <tab_0_icon_path></tab_0_icon_path>
+          <tab_0_title>Setpoint</tab_0_title>
+          <tab_1_background_color>
+            <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+          </tab_1_background_color>
+          <tab_1_enabled>true</tab_1_enabled>
+          <tab_1_font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
+          </tab_1_font>
+          <tab_1_foreground_color>
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+          </tab_1_foreground_color>
+          <tab_1_icon_path></tab_1_icon_path>
+          <tab_1_title>Setpoint Readback</tab_1_title>
+          <tab_2_background_color>
+            <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+          </tab_2_background_color>
+          <tab_2_enabled>true</tab_2_enabled>
+          <tab_2_font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
+          </tab_2_font>
+          <tab_2_foreground_color>
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+          </tab_2_foreground_color>
+          <tab_2_icon_path></tab_2_icon_path>
+          <tab_2_title>Readback</tab_2_title>
+          <tab_count>3</tab_count>
+          <tooltip></tooltip>
+          <visible>true</visible>
+          <widget_type>Tabbed Container</widget_type>
+          <width>265</width>
+          <wuid>-66312240:1683d19d453:-7a24</wuid>
+          <x>19</x>
+          <y>440</y>
+          <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color name="ISIS_Check_Border" red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <fc>false</fc>
+            <font>
+              <opifont.name fontName="Arial" height="9" style="0" pixels="false">ISIS_Label_Small</opifont.name>
+            </font>
+            <foreground_color>
+              <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+            </foreground_color>
+            <height>74</height>
+            <lock_children>false</lock_children>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>Setpoint</name>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <show_scrollbar>true</show_scrollbar>
+            <tooltip></tooltip>
+            <transparent>true</transparent>
+            <visible>true</visible>
+            <widget_type>Grouping Container</widget_type>
+            <width>263</width>
+            <wuid>-66312240:1683d19d453:-7a23</wuid>
+            <x>1</x>
+            <y>1</y>
+            <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+              <actions hook="false" hook_all="false" />
+              <background_color>
+                <color red="240" green="240" blue="240" />
+              </background_color>
+              <border_color>
+                <color red="0" green="128" blue="255" />
+              </border_color>
+              <border_style>0</border_style>
+              <border_width>1</border_width>
+              <enabled>true</enabled>
+              <font>
+                <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+              </font>
+              <foreground_color>
+                <color red="192" green="192" blue="192" />
+              </foreground_color>
+              <group_name></group_name>
+              <height>67</height>
+              <macros>
+                <include_parent_macros>true</include_parent_macros>
+                <SUFFIX>SP</SUFFIX>
+              </macros>
+              <name></name>
+              <opi_file>beam_footprint.opi</opi_file>
+              <resize_behaviour>1</resize_behaviour>
+              <rules />
+              <scale_options>
+                <width_scalable>true</width_scalable>
+                <height_scalable>true</height_scalable>
+                <keep_wh_ratio>false</keep_wh_ratio>
+              </scale_options>
+              <scripts />
+              <tooltip></tooltip>
+              <visible>true</visible>
+              <widget_type>Linking Container</widget_type>
+              <width>251</width>
+              <wuid>-66312240:1683d19d453:-776d</wuid>
+              <x>6</x>
+              <y>6</y>
+            </widget>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color name="ISIS_Check_Border" red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <fc>false</fc>
+            <font>
+              <opifont.name fontName="Arial" height="9" style="0" pixels="false">ISIS_Label_Small</opifont.name>
+            </font>
+            <foreground_color>
+              <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+            </foreground_color>
+            <height>74</height>
+            <lock_children>false</lock_children>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>Setpoint Readback</name>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <show_scrollbar>true</show_scrollbar>
+            <tooltip></tooltip>
+            <transparent>true</transparent>
+            <visible>false</visible>
+            <widget_type>Grouping Container</widget_type>
+            <width>263</width>
+            <wuid>-66312240:1683d19d453:-79e3</wuid>
+            <x>1</x>
+            <y>1</y>
+            <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+              <actions hook="false" hook_all="false" />
+              <background_color>
+                <color red="240" green="240" blue="240" />
+              </background_color>
+              <border_color>
+                <color red="0" green="128" blue="255" />
+              </border_color>
+              <border_style>0</border_style>
+              <border_width>1</border_width>
+              <enabled>true</enabled>
+              <font>
+                <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+              </font>
+              <foreground_color>
+                <color red="192" green="192" blue="192" />
+              </foreground_color>
+              <group_name></group_name>
+              <height>67</height>
+              <macros>
+                <include_parent_macros>true</include_parent_macros>
+              </macros>
+              <name></name>
+              <opi_file>beam_footprint.opi</opi_file>
+              <resize_behaviour>1</resize_behaviour>
+              <rules />
+              <scale_options>
+                <width_scalable>true</width_scalable>
+                <height_scalable>true</height_scalable>
+                <keep_wh_ratio>false</keep_wh_ratio>
+              </scale_options>
+              <scripts />
+              <tooltip></tooltip>
+              <visible>true</visible>
+              <widget_type>Linking Container</widget_type>
+              <width>251</width>
+              <wuid>-66312240:1683d19d453:-75f6</wuid>
+              <x>6</x>
+              <y>6</y>
+            </widget>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <fc>false</fc>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <height>74</height>
+            <lock_children>false</lock_children>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>Readback</name>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <show_scrollbar>true</show_scrollbar>
+            <tooltip></tooltip>
+            <transparent>true</transparent>
+            <visible>false</visible>
+            <widget_type>Grouping Container</widget_type>
+            <width>263</width>
+            <wuid>-66312240:1683d19d453:-77ca</wuid>
+            <x>1</x>
+            <y>1</y>
+            <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+              <actions hook="false" hook_all="false" />
+              <background_color>
+                <color red="240" green="240" blue="240" />
+              </background_color>
+              <border_color>
+                <color red="0" green="128" blue="255" />
+              </border_color>
+              <border_style>0</border_style>
+              <border_width>1</border_width>
+              <enabled>true</enabled>
+              <font>
+                <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+              </font>
+              <foreground_color>
+                <color red="192" green="192" blue="192" />
+              </foreground_color>
+              <group_name></group_name>
+              <height>67</height>
+              <macros>
+                <include_parent_macros>true</include_parent_macros>
+                <SUFFIX>RBV</SUFFIX>
+              </macros>
+              <name></name>
+              <opi_file>beam_footprint.opi</opi_file>
+              <resize_behaviour>1</resize_behaviour>
+              <rules />
+              <scale_options>
+                <width_scalable>true</width_scalable>
+                <height_scalable>true</height_scalable>
+                <keep_wh_ratio>false</keep_wh_ratio>
+              </scale_options>
+              <scripts />
+              <tooltip></tooltip>
+              <visible>true</visible>
+              <widget_type>Linking Container</widget_type>
+              <width>251</width>
+              <wuid>-66312240:1683d19d453:-75d9</wuid>
+              <x>6</x>
+              <y>6</y>
+            </widget>
+          </widget>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>13</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <fc>false</fc>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+          </font>
+          <foreground_color>
+            <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+          </foreground_color>
+          <height>59</height>
+          <lock_children>false</lock_children>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>Beam Footprint</name>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <show_scrollbar>true</show_scrollbar>
+          <tooltip></tooltip>
+          <transparent>false</transparent>
+          <visible>true</visible>
+          <widget_type>Grouping Container</widget_type>
+          <width>280</width>
+          <wuid>-66312240:1683d19d453:-70c9</wuid>
+          <x>12</x>
+          <y>380</y>
+          <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <auto_size>false</auto_size>
+            <background_color>
+              <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color name="ISIS_Border" red="0" green="0" blue="0" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+            </font>
+            <foreground_color>
+              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+            </foreground_color>
+            <height>20</height>
+            <horizontal_alignment>2</horizontal_alignment>
+            <name>Label_3</name>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <show_scrollbar>false</show_scrollbar>
+            <text>Sample Length:</text>
+            <tooltip></tooltip>
+            <transparent>false</transparent>
+            <vertical_alignment>1</vertical_alignment>
+            <visible>true</visible>
+            <widget_type>Label</widget_type>
+            <width>103</width>
+            <wrap_words>true</wrap_words>
+            <wuid>-66312240:1683d19d453:-7097</wuid>
+            <x>24</x>
+            <y>6</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
+            <actions hook="false" hook_all="false" />
+            <alarm_pulsing>false</alarm_pulsing>
+            <auto_size>false</auto_size>
+            <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+            <background_color>
+              <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
+            </background_color>
+            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>3</border_style>
+            <border_width>1</border_width>
+            <confirm_message></confirm_message>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+            <foreground_color>
+              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+            </foreground_color>
+            <format_type>0</format_type>
+            <height>25</height>
+            <horizontal_alignment>0</horizontal_alignment>
+            <limits_from_pv>false</limits_from_pv>
+            <maximum>Infinity</maximum>
+            <minimum>-Infinity</minimum>
+            <multiline_input>false</multiline_input>
+            <name>Text Input</name>
+            <precision>0</precision>
+            <precision_from_pv>true</precision_from_pv>
+            <pv_name>$(PV_ROOT)FP:SAMPLE_LENGTH</pv_name>
+            <pv_value />
+            <rotation_angle>0.0</rotation_angle>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <selector_type>0</selector_type>
+            <show_units>true</show_units>
+            <style>0</style>
+            <text></text>
+            <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+            <transparent>false</transparent>
+            <visible>true</visible>
+            <widget_type>Text Input</widget_type>
+            <width>85</width>
+            <wuid>-66312240:1683d19d453:-7081</wuid>
+            <x>160</x>
+            <y>3</y>
+          </widget>
+        </widget>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
         <actions hook="false" hook_all="false" />
@@ -3867,7 +3727,7 @@ $(pv_value)</tooltip>
         <foreground_color>
           <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
         </foreground_color>
-        <height>476</height>
+        <height>548</height>
         <lock_children>false</lock_children>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -4704,7 +4564,7 @@ $(pv_value)</tooltip>
       <width>967</width>
       <wuid>-744b7940:165a9b5d31a:-7632</wuid>
       <x>0</x>
-      <y>540</y>
+      <y>618</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_gap.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_gap.opi
@@ -15,7 +15,7 @@
     <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
-  <height>600</height>
+  <height>30</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
     <PARAM_ROOT>$(PV_ROOT)</PARAM_ROOT>
@@ -30,7 +30,7 @@
   <show_ruler>true</show_ruler>
   <snap_to_geometry>true</snap_to_geometry>
   <widget_type>Display</widget_type>
-  <width>800</width>
+  <width>245</width>
   <wuid>450885f3:157944e4d4b:-797d</wuid>
   <x>-1</x>
   <y>-1</y>
@@ -52,7 +52,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>29</height>
+    <height>30</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -70,7 +70,7 @@
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>355</width>
+    <width>245</width>
     <wuid>-16c8e940:165f1448c04:-7e27</wuid>
     <x>0</x>
     <y>0</y>
@@ -108,105 +108,11 @@
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>100</width>
+      <width>60</width>
       <wrap_words>false</wrap_words>
       <wuid>-744b7940:165a9b5d31a:-67c9</wuid>
       <x>0</x>
       <y>0</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-      <actions hook="false" hook_all="false">
-        <action type="WRITE_PV">
-          <pv_name>$(pv_name)</pv_name>
-          <value>1</value>
-          <timeout>10</timeout>
-          <confirm_message></confirm_message>
-          <description></description>
-        </action>
-      </actions>
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
-      </font>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <height>28</height>
-      <image></image>
-      <name>Button_1</name>
-      <push_action_index>0</push_action_index>
-      <pv_name>$(PV_ROOT)$(PREFIXED_PV):MOVE</pv_name>
-      <pv_value />
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts />
-      <style>1</style>
-      <text>Move</text>
-      <toggle_button>false</toggle_button>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <visible>true</visible>
-      <widget_type>Action Button</widget_type>
-      <width>75</width>
-      <wuid>-744b7940:165a9b5d31a:-7a6a</wuid>
-      <x>276</x>
-      <y>1</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false" />
-      <auto_size>false</auto_size>
-      <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Header4_NEW</opifont.name>
-      </font>
-      <foreground_color>
-        <color name="ISIS_Blue" red="0" green="0" blue="255" />
-      </foreground_color>
-      <height>20</height>
-      <horizontal_alignment>1</horizontal_alignment>
-      <name>Label_1</name>
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts>
-        <path pathString="setTooltipFromDescription.py" checkConnect="true" sfe="false" seoe="false">
-          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DESC</pv>
-          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP</pv>
-        </path>
-      </scripts>
-      <text>?</text>
-      <tooltip></tooltip>
-      <transparent>true</transparent>
-      <vertical_alignment>1</vertical_alignment>
-      <visible>true</visible>
-      <widget_type>Label</widget_type>
-      <width>19</width>
-      <wrap_words>false</wrap_words>
-      <wuid>-e03d447:166346877c1:-7bf8</wuid>
-      <x>99</x>
-      <y>5</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -257,7 +163,7 @@ $(pv_value)</tooltip>
       <width>49</width>
       <wrap_words>false</wrap_words>
       <wuid>-e03d447:166346877c1:-7bdd</wuid>
-      <x>168</x>
+      <x>125</x>
       <y>5</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
@@ -328,7 +234,7 @@ $(pv_value)</tooltip>
       <widget_type>Text Input</widget_type>
       <width>55</width>
       <wuid>-e03d447:166346877c1:-7bdc</wuid>
-      <x>216</x>
+      <x>186</x>
       <y>5</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -380,7 +286,7 @@ $(pv_value)</tooltip>
       <width>52</width>
       <wrap_words>false</wrap_words>
       <wuid>-5cc9c870:167650cec59:-7fdd</wuid>
-      <x>117</x>
+      <x>65</x>
       <y>5</y>
     </widget>
   </widget>


### PR DESCRIPTION
### Description of work

Edited OPI to provide widgets for beam footprint and slit gaps.

Related PR: https://github.com/ISISComputingGroup/EPICS-inst_servers/pull/186

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3543

### Acceptance criteria

- [ ] Can set/view slit gap parameters
- [ ] Shows beam footprint values for each type of beamline parameter value (SP, SP_RBV and RBV)

### Unit tests

OPI only

### System tests

OPI only

### Documentation
/

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

