### PR TITLE
Change OPI to point to scaled PV

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/moxa1240.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/moxa1240.opi
@@ -1408,7 +1408,7 @@ $(pv_value)</tooltip>
       <name>Text Update</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):CH0:AI:RBV</pv_name>
+      <pv_name>$(PV_ROOT):CH0:AI:SCALED</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules>
@@ -1467,7 +1467,7 @@ $(pv_value)</tooltip>
       <name>Text Update_9</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):CH1:AI:RBV</pv_name>
+      <pv_name>$(PV_ROOT):CH1:AI:SCALED</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules>
@@ -1526,7 +1526,7 @@ $(pv_value)</tooltip>
       <name>Text Update</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):CH2:AI:RBV</pv_name>
+      <pv_name>$(PV_ROOT):CH2:AI:SCALED</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules>
@@ -1585,7 +1585,7 @@ $(pv_value)</tooltip>
       <name>Text Update_9</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):CH3:AI:RBV</pv_name>
+      <pv_name>$(PV_ROOT):CH3:AI:SCALED</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules>
@@ -1644,7 +1644,7 @@ $(pv_value)</tooltip>
       <name>Text Update</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):CH4:AI:RBV</pv_name>
+      <pv_name>$(PV_ROOT):CH4:AI:SCALED</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules>
@@ -1703,7 +1703,7 @@ $(pv_value)</tooltip>
       <name>Text Update_9</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):CH5:AI:RBV</pv_name>
+      <pv_name>$(PV_ROOT):CH5:AI:SCALED</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules>
@@ -1762,7 +1762,7 @@ $(pv_value)</tooltip>
       <name>Text Update_10</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):CH6:AI:RBV</pv_name>
+      <pv_name>$(PV_ROOT):CH6:AI:SCALED</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules>
@@ -1821,7 +1821,7 @@ $(pv_value)</tooltip>
       <name>Text Update_11</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):CH7:AI:RBV</pv_name>
+      <pv_name>$(PV_ROOT):CH7:AI:SCALED</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules>


### PR DESCRIPTION
### Description of work

Change moxa 1240 OPI PVs to point at scaled rather than raw input values 

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3969

### Acceptance criteria

- [ ] OPI now presents scaled data from the IOC

### Unit tests

N/A, OPI change only

### System tests

N/A OPI change only

### Documentation

None

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

