### PR TITLE
Downgrade PyDEV to fix reset layout

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
+++ b/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
@@ -34,10 +34,6 @@
 <unit id="org.eclipse.emf.sdk.feature.group" version="2.13.0.v20170609-0928"/>
 <repository location="http://download.eclipse.org/releases/oxygen"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.python.pydev.feature.feature.group" version="6.5.0.201809011628"/>
-<repository location="http://www.pydev.org/update_sites/6.5.0/"/>
-</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.rcp.feature.group" version="4.8.0.v20180611-0656"/>
 		<unit id="org.eclipse.rcp.source.feature.group" version="4.8.0.v20180611-0656"/>
@@ -58,6 +54,11 @@
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.e4.tools.spies.feature.feature.group" version="0.18.0.v20190227-1016"/>
 		<repository location="http://download.eclipse.org/e4/snapshots/org.eclipse.e4.tools/latest"/>
+	</location>
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.python.pydev.feature.feature.group" version="5.9.2.201708151115"/>
+		<unit id="org.python.pydev.feature.source.feature.group" version="5.9.2.201708151115"/>
+		<repository location="http://www.pydev.org/update_sites/5.9.2"/>
 	</location>
 </locations>
 <environment>

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/GeniePythonConsoleFactory.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/GeniePythonConsoleFactory.java
@@ -24,7 +24,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
-import org.python.pydev.ast.interpreter_managers.InterpreterManagersAPI;
 import org.python.pydev.core.IInterpreterInfo;
 import org.python.pydev.core.IInterpreterManager;
 import org.python.pydev.debug.newconsole.PydevConsoleConstants;
@@ -32,6 +31,8 @@ import org.python.pydev.debug.newconsole.PydevConsoleFactory;
 import org.python.pydev.debug.newconsole.PydevConsoleInterpreter;
 import org.python.pydev.debug.newconsole.env.PydevIProcessFactory;
 import org.python.pydev.debug.newconsole.env.PydevIProcessFactory.PydevConsoleLaunchInfo;
+import org.python.pydev.plugin.PydevPlugin;
+
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.preferences.PreferenceSupplier;
 
@@ -88,7 +89,7 @@ public class GeniePythonConsoleFactory extends PydevConsoleFactory {
 	 *             can throw several different exceptions
 	 */
 	PydevConsoleInterpreter createGeniePydevInterpreter() throws Exception {
-		IInterpreterManager manager = InterpreterManagersAPI.getPythonInterpreterManager();
+		IInterpreterManager manager = PydevPlugin.getPythonInterpreterManager(true);
 		
 		IInterpreterInfo interpreterInfo = manager.createInterpreterInfo(PreferenceSupplier.pythonInterpreterPath(),
 				monitor, false);

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PyDevConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PyDevConfiguration.java
@@ -21,7 +21,6 @@ package uk.ac.stfc.isis.ibex.ui.scripting;
 
 import java.util.Collections;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.python.pydev.ast.interpreter_managers.InterpreterManagersAPI;
 import org.python.pydev.core.IInterpreterInfo;
 import org.python.pydev.core.IInterpreterManager;
 import org.python.pydev.plugin.PydevPlugin;
@@ -41,7 +40,7 @@ public final class PyDevConfiguration {
 	 * Configure PyDev.
 	 */
 	public static void configure() {
-		IInterpreterManager iMan = InterpreterManagersAPI.getPythonInterpreterManager(true);
+		IInterpreterManager iMan = PydevPlugin.getPythonInterpreterManager(true);
 		NullProgressMonitor monitor = new NullProgressMonitor();
 		IInterpreterInfo interpreterInfo = iMan.createInterpreterInfo(PreferenceSupplier.pythonInterpreterPath(),
 				monitor, false);

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PythonInterpreterProviderFactory.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PythonInterpreterProviderFactory.java
@@ -19,9 +19,9 @@
 
 package uk.ac.stfc.isis.ibex.ui.scripting;
 
-import org.python.pydev.ast.interpreter_managers.IInterpreterProvider;
 import org.python.pydev.ui.pythonpathconf.AbstractInterpreterProviderFactory;
 import org.python.pydev.ui.pythonpathconf.AlreadyInstalledInterpreterProvider;
+import org.python.pydev.ui.pythonpathconf.IInterpreterProvider;
 
 import uk.ac.stfc.isis.ibex.preferences.PreferenceSupplier;
 


### PR DESCRIPTION
PyDEV v6 caused an issue with resetting layouts while the python console is open (the upgrade was done in ticket 3506)

Downgrade back down to Pydev 5.9.2 (this is still an upgrade over our previous version).

Flash reviewed by @Alistair-McGann-Tessella 