### PR TITLE
Add support for auto-title from blocks

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeModel.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeModel.java
@@ -103,9 +103,17 @@ public class DaeModel extends Closer implements IDae {
 		return observables.title;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ForwardingObservable<String> titleSP() {
+        return observables.titleSP;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ForwardingObservable<Boolean> displayTitle() {
         return observables.displayTitle;

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeObservables.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/DaeObservables.java
@@ -89,6 +89,11 @@ public class DaeObservables {
     public final ForwardingObservable<String> title;
 
     /**
+     * An observable on the title for the current run.
+     */
+    public final ForwardingObservable<String> titleSP;
+
+    /**
      * An observable giving whether or not to display the title on the webpage.
      */
     public final ForwardingObservable<Boolean> displayTitle;
@@ -331,6 +336,8 @@ public class DaeObservables {
                 InstrumentUtils.addPrefix(DAE.endWith("RUNNUMBER")));
         title = obsFactory.getSwitchableObservable(new CharWaveformChannel(),
                 InstrumentUtils.addPrefix(DAE.endWith("TITLE")));
+        titleSP = obsFactory.getSwitchableObservable(new CharWaveformChannel(),
+                InstrumentUtils.addPrefix(DAE.endWith("TITLE:SP")));
         displayTitle = obsFactory.getSwitchableObservable(new BooleanChannel(),
                 InstrumentUtils.addPrefix(DAE.endWith("TITLE:DISPLAY")));
         users = obsFactory.getSwitchableObservable(new CharWaveformChannel(),

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/IDae.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/IDae.java
@@ -61,6 +61,11 @@ public interface IDae {
 	ForwardingObservable<String> title();
 
     /**
+     * @return An observable on a string giving the title for the current run.
+     */
+    ForwardingObservable<String> titleSP();
+
+    /**
      * @return An observable on a boolean giving whether or not to display the
      *         title on the webpage.
      */

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/run/RunSummaryViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/run/RunSummaryViewModel.java
@@ -58,7 +58,7 @@ public class RunSummaryViewModel extends Closer {
 		runStatus = registerForClose(new TextUpdatedObservableAdapter(registerForClose(new InstrumentState(model.runState()))));
 		runNumber = registerForClose(new TextUpdatedObservableAdapter(model.runNumber()));
 		isisCycle = registerForClose(new TextUpdatedObservableAdapter(model.isisCycle()));
-        title = registerForClose(new StringWritableObservableAdapter(model.setTitle(), model.title()));
+        title = registerForClose(new StringWritableObservableAdapter(model.setTitle(), model.titleSP()));
         displayTitle =
                 registerForClose(new BooleanWritableObservableAdapter(model.setDisplayTitle(), model.displayTitle()));
 


### PR DESCRIPTION
### Description of work

Interact correctly with both TITLE:SP and TITLE to allow auto-population of title to work 

### Ticket

See ISISComputingGroup/IBEX#4140

### Acceptance criteria

* Setting a title containing @blockname@ results in block value appearing in title 

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

