### PR TITLE
Add flag to create dump on crash

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
+++ b/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
@@ -17,6 +17,7 @@
       <vmArgs>-Xms40m
 -Xmx512m
 -Dpython.console.encoding=UTF-8
+-XX:+CreateMinidumpOnCrash
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>
@@ -34,7 +35,6 @@
    <vm>
       <windows include="true">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</windows>
    </vm>
-
 
    <plugins>
    </plugins>


### PR DESCRIPTION
### Description of work

Adds flag to generate core dumps on segmentation fault.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3877

### Acceptance criteria

Core dumps can be analysed.

To test this, here is some code to generate a segmentation fault. Insert it into a location of your choosing. **Ensure that you do not commit this to git**.

```
import sun.misc.Unsafe;

...

try {
    Field f = Unsafe.class.getDeclaredField( "theUnsafe" );
    f.setAccessible( true ); 
    Unsafe unsafe = (Unsafe) f.get( null );
    unsafe.putAddress(0, 0);
} catch (Throwable t) {
    System.out.println("Crashed while trying to crash");
}
```

After IBEX has crashed with the above code, you should be able to run a command like the following to get a traceback of where every thread was at the time of the crash. You may need to change the JDK release depending on what you have installed. The crash dump will also have a name based on the PID ibex was assigned as it started.

```
"C:\Program Files\Java\jdk1.8.0_192\bin\jstack.exe" -J-d64 ibex-client.exe hs_err_pidxxxxx.mdmp
```

One of the threads should contain a traceback which leads back to the place where you inserted the crashing code.

### Unit tests

- We don't yet know how to reproduce the original bug

### System tests

- We don't yet know how to reproduce the original bug

### Documentation

https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Java-Resource-Usage-Tools#jstack

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

