### PR TITLE
Ticket4227 remove locked state from itc ips

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/ips.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/ips.opi
@@ -1096,7 +1096,11 @@ $(pv_value)</tooltip>
             <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
           </foreground_color>
           <height>27</height>
-          <items_from_pv>true</items_from_pv>
+          <items>
+            <s>Local &amp; Unlocked</s>
+            <s>Remote &amp; Unlocked</s>
+          </items>
+          <items_from_pv>false</items_from_pv>
           <name>Combo</name>
           <pv_name>$(PV_ROOT):CONTROL:SP</pv_name>
           <pv_value />

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
@@ -62,7 +62,7 @@
     </scale_options>
     <scripts />
     <show_scrollbar>false</show_scrollbar>
-    <text>Oxford Instruments ITC503_</text>
+    <text>Oxford Instruments ITC503</text>
     <tooltip></tooltip>
     <transparent>false</transparent>
     <vertical_alignment>1</vertical_alignment>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
@@ -272,7 +272,7 @@ $(pv_value)</tooltip>
       <height>23</height>
       <items>
         <s>Local only</s>
-        <s>Local and Remote</s>
+        <s>Local and remote</s>
       </items>
       <items_from_pv>false</items_from_pv>
       <name>Combo_1</name>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
@@ -62,7 +62,7 @@
     </scale_options>
     <scripts />
     <show_scrollbar>false</show_scrollbar>
-    <text>Oxford Instruments ITC503</text>
+    <text>Oxford Instruments ITC503_</text>
     <tooltip></tooltip>
     <transparent>false</transparent>
     <vertical_alignment>1</vertical_alignment>
@@ -270,7 +270,11 @@ $(pv_value)</tooltip>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
       <height>23</height>
-      <items_from_pv>true</items_from_pv>
+      <items>
+        <s>Local only</s>
+        <s>Local and Remote</s>
+      </items>
+      <items_from_pv>false</items_from_pv>
       <name>Combo_1</name>
       <pv_name>$(PV_ROOT):CTRL:SP</pv_name>
       <pv_value />


### PR DESCRIPTION
### Description of work

Cryogenic users do not want to be able to set the ITC or IPS into locked control mode from the GUI.  To implement this, the "Locked/Remote only" modes have been removed from the GUI for ITC503 and the "Local & Locked / Remote & Locked" modes have been removed for IPS. The control mode is no longer populated by PV's and the control mode options are hard coded into the GUI. This removes the possibility of the GUI populating empty items in the drop down menu if the modes were just removed from the DB records.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4227

### Acceptance criteria

- [x] From the GUI, I can no longer set the ITC503 mode to Locked or Remote only. 

- [x] From the GUI, I can no longer set the IPS control mode to Local & Locked or Remote & Locked.

- [x] The IOC's can still be set as locked from the front panels and this state is reflected in the GUI during testing (i.e the lock control mode can be read but not written to from the GUI).

### Documentation

Amended release notes to include suggested changes.
See https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

