### PR TITLE
Linked Septum_A/C to the correct OPI's, made a new SEP E to link to s…

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/muon_overviews/muon_front_end_overview.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/muon_overviews/muon_front_end_overview.opi
@@ -1,344 +1,305 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<display typeId="org.csstudio.opibuilder.Display" version="1.0">
-  <show_close_button>true</show_close_button>
-  <rules />
-  <wuid>-7f86b513:15cbf58a3f3:-7fc7</wuid>
-  <show_grid>true</show_grid>
-  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
-  <scripts />
-  <height>600</height>
-  <macros>
-    <include_parent_macros>true</include_parent_macros>
-  </macros>
-  <boy_version>3.1.4.201301231545</boy_version>
-  <show_edit_range>true</show_edit_range>
-  <widget_type>Display</widget_type>
+<display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
+  <actions hook="false" hook_all="false" />
   <auto_scale_widgets>
     <auto_scale_widgets>false</auto_scale_widgets>
     <min_width>-1</min_width>
     <min_height>-1</min_height>
   </auto_scale_widgets>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
     <color red="240" green="240" blue="240" />
   </background_color>
-  <width>800</width>
-  <x>-1</x>
-  <name></name>
-  <grid_space>6</grid_space>
-  <show_ruler>true</show_ruler>
-  <y>-1</y>
-  <snap_to_geometry>false</snap_to_geometry>
+  <boy_version>5.1.0.201707071649</boy_version>
   <foreground_color>
     <color red="192" green="192" blue="192" />
   </foreground_color>
-  <actions hook="false" hook_all="false" />
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>0</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-7f86b513:15cbf58a3f3:-7e21</wuid>
-    <transparent>false</transparent>
-    <auto_size>false</auto_size>
-    <text>Muon Front End Overview</text>
-    <scripts />
-    <height>37</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>true</wrap_words>
-    <background_color>
-      <color name="ISIS_Title_Background_NEW" red="240" green="240" blue="240" />
-    </background_color>
-    <width>691</width>
-    <x>6</x>
-    <name>Label</name>
-    <y>6</y>
-    <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-    </foreground_color>
+  <grid_space>6</grid_space>
+  <height>600</height>
+  <macros>
+    <include_parent_macros>true</include_parent_macros>
+  </macros>
+  <name></name>
+  <rules />
+  <scripts />
+  <show_close_button>true</show_close_button>
+  <show_edit_range>true</show_edit_range>
+  <show_grid>true</show_grid>
+  <show_ruler>true</show_ruler>
+  <snap_to_geometry>false</snap_to_geometry>
+  <widget_type>Display</widget_type>
+  <width>800</width>
+  <wuid>-7f86b513:15cbf58a3f3:-7fc7</wuid>
+  <x>-1</x>
+  <y>-1</y>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
     <actions hook="false" hook_all="false" />
-    <show_scrollbar>false</show_scrollbar>
-    <font>
-      <opifont.name fontName="Segoe UI" height="18" style="1">ISIS_Header1_NEW</opifont.name>
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
-    <border_style>0</border_style>
-    <tooltip></tooltip>
-    <horizontal_alignment>0</horizontal_alignment>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-7f86b513:15cbf58a3f3:-7e20</wuid>
-    <transparent>false</transparent>
     <auto_size>false</auto_size>
-    <text>$(NAME)</text>
-    <scripts />
-    <height>37</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <vertical_alignment>1</vertical_alignment>
-    <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
-    </border_color>
-    <widget_type>Label</widget_type>
-    <wrap_words>true</wrap_words>
     <background_color>
       <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
     </background_color>
-    <width>691</width>
-    <x>6</x>
-    <name>Label_1</name>
-    <y>42</y>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="14" style="1" pixels="false">ISIS_Header2_NEW</opifont.name>
+    </font>
     <foreground_color>
       <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <show_scrollbar>false</show_scrollbar>
-    <font>
-      <opifont.name fontName="Segoe UI" height="14" style="1">ISIS_Header2_NEW</opifont.name>
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0">
-    <border_style>13</border_style>
-    <tooltip></tooltip>
+    <height>37</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label_1</name>
     <rules />
-    <enabled>true</enabled>
-    <wuid>-7f86b513:15cbf58a3f3:-7e1f</wuid>
-    <transparent>false</transparent>
-    <lock_children>false</lock_children>
-    <scripts />
-    <height>517</height>
-    <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <macros>
-      <include_parent_macros>true</include_parent_macros>
-    </macros>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>$(NAME)</text>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
-    <border_color>
-      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Grouping Container</widget_type>
+    <widget_type>Label</widget_type>
+    <width>691</width>
+    <wrap_words>true</wrap_words>
+    <wuid>-7f86b513:15cbf58a3f3:-7e20</wuid>
+    <x>6</x>
+    <y>6</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+    <actions hook="false" hook_all="false" />
     <background_color>
       <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </background_color>
-    <width>223</width>
-    <x>6</x>
-    <name>Front End</name>
-    <y>78</y>
+    <border_color>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>13</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fc>false</fc>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+    </font>
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <actions hook="false" hook_all="false" />
+    <height>553</height>
+    <lock_children>false</lock_children>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <name>Front End</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
     <show_scrollbar>true</show_scrollbar>
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-    </font>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
-      <opi_file>power_supply_summary.opi</opi_file>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Grouping Container</widget_type>
+    <width>223</width>
+    <wuid>-7f86b513:15cbf58a3f3:-7e1f</wuid>
+    <x>6</x>
+    <y>42</y>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
       <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-66aa</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
       <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ2</PSNAME>
         <DFKPS>DFKPS_04</DFKPS>
         <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
       </macros>
+      <name>A Linking Container That Looks Like a Group Box_1</name>
+      <opi_file>power_supply_summary.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
       <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-66aa</wuid>
+      <x>6</x>
+      <y>52</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>25</height>
+      <horizontal_alignment>1</horizontal_alignment>
+      <name>Label_6</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_scrollbar>false</show_scrollbar>
+      <text>Power</text>
+      <tooltip></tooltip>
+      <transparent>false</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>61</width>
+      <wrap_words>true</wrap_words>
+      <wuid>-7f86b513:15cbf58a3f3:-7792</wuid>
+      <x>78</x>
+      <y>0</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>25</height>
+      <horizontal_alignment>1</horizontal_alignment>
+      <name>Label_18</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_scrollbar>false</show_scrollbar>
+      <text>Alarm</text>
+      <tooltip></tooltip>
+      <transparent>false</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>61</width>
+      <wrap_words>true</wrap_words>
+      <wuid>-7f86b513:15cbf58a3f3:-6bbc</wuid>
+      <x>132</x>
+      <y>0</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
-      <name>A Linking Container That Looks Like a Group Box_1</name>
-      <y>52</y>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
       <foreground_color>
         <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
       </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <horizontal_alignment>1</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-7792</wuid>
-      <transparent>false</transparent>
-      <auto_size>false</auto_size>
-      <text>Power</text>
-      <scripts />
-      <height>25</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>Label</widget_type>
-      <wrap_words>true</wrap_words>
-      <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-      </background_color>
-      <width>61</width>
-      <x>78</x>
-      <name>Label_6</name>
-      <y>0</y>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <show_scrollbar>false</show_scrollbar>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="1">ISIS_Label_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0">
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <horizontal_alignment>1</horizontal_alignment>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-6bbc</wuid>
-      <transparent>false</transparent>
-      <auto_size>false</auto_size>
-      <text>Alarm</text>
-      <scripts />
-      <height>25</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <visible>true</visible>
-      <vertical_alignment>1</vertical_alignment>
-      <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
-      </border_color>
-      <widget_type>Label</widget_type>
-      <wrap_words>true</wrap_words>
-      <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-      </background_color>
-      <width>61</width>
-      <x>132</x>
-      <name>Label_18</name>
-      <y>0</y>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <show_scrollbar>false</show_scrollbar>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="1">ISIS_Label_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
-      <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-66af</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
+      <group_name></group_name>
       <height>26</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ1</PSNAME>
         <DFKPS>DFKPS_03</DFKPS>
         <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box</name>
-      <y>24</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-66a5</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-66af</wuid>
+      <x>6</x>
+      <y>24</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ3</PSNAME>
@@ -346,88 +307,86 @@
         <PS_NUM>1</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_2</name>
-      <y>80</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-66a0</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-66a5</wuid>
+      <x>6</x>
+      <y>80</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UB1</PSNAME>
         <DFKPS>DFKPS_10</DFKPS>
         <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_3</name>
-      <y>108</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-665e</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-66a0</wuid>
+      <x>6</x>
+      <y>108</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ4</PSNAME>
@@ -435,88 +394,86 @@
         <PS_NUM>2</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_4</name>
-      <y>136</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-6659</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-665e</wuid>
+      <x>6</x>
+      <y>136</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ5</PSNAME>
         <DFKPS>DFKPS_05</DFKPS>
         <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_5</name>
-      <y>164</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-6654</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-6659</wuid>
+      <x>6</x>
+      <y>164</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ6</PSNAME>
@@ -524,63 +481,25 @@
         <PS_NUM>3</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_6</name>
-      <y>192</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.NativeButton" version="1.0">
-      <toggle_button>false</toggle_button>
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <push_action_index>0</push_action_index>
+      <opi_file>power_supply_summary.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-2541c3ca:15d0d8c2cc6:-5108</wuid>
-      <pv_value />
-      <text>Momentum Slits</text>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>25</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <image></image>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
-      <pv_name></pv_name>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Button</widget_type>
-      <width>115</width>
-      <x>42</x>
-      <name>Button</name>
-      <y>224</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-6654</wuid>
+      <x>6</x>
+      <y>192</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">
         <action type="OPEN_DISPLAY">
           <path>../slits_single_motor.opi</path>
@@ -588,206 +507,240 @@ $(pv_value)</tooltip>
             <include_parent_macros>true</include_parent_macros>
             <MOT>$(MM_MOMENTUM)</MOT>
           </macros>
-          <replace>1</replace>
+          <mode>0</mode>
           <description></description>
         </action>
       </actions>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
-      <opi_file>power_supply_summary.opi</opi_file>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
       <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-660d</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
       <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>25</height>
+      <image></image>
+      <name>Button</name>
+      <push_action_index>0</push_action_index>
+      <pv_name></pv_name>
+      <pv_value />
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <style>1</style>
+      <text>Momentum Slits</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>115</width>
+      <wuid>-2541c3ca:15d0d8c2cc6:-5108</wuid>
+      <x>42</x>
+      <y>224</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ8</PSNAME>
         <DFKPS>DFKPS_07</DFKPS>
         <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_9</name>
-      <y>310</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-6612</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-660d</wuid>
+      <x>6</x>
+      <y>310</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ7</PSNAME>
         <DFKPS>DFKPS_06</DFKPS>
         <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_8</name>
-      <y>282</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-6617</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-6612</wuid>
+      <x>6</x>
+      <y>282</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UB2</PSNAME>
         <DFKPS>DFKPS_11</DFKPS>
         <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_7</name>
-      <y>254</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-6608</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-6617</wuid>
+      <x>6</x>
+      <y>254</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ9</PSNAME>
         <DFKPS>DFKPS_08</DFKPS>
         <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_10</name>
-      <y>338</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-65c7</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-6608</wuid>
+      <x>6</x>
+      <y>338</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ10</PSNAME>
@@ -795,133 +748,130 @@ $(pv_value)</tooltip>
         <PS_NUM>4</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_12</name>
-      <y>366</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-65cc</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-65c7</wuid>
+      <x>6</x>
+      <y>426</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <PSNAME>SEPARATOR</PSNAME>
+        <PSNAME>Sep B</PSNAME>
         <IOC_NUM>01</IOC_NUM>
         <PS_NUM>6</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_11</name>
-      <y>394</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-65c2</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-65cc</wuid>
+      <x>6</x>
+      <y>366</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ11</PSNAME>
         <DFKPS>DFKPS_09</DFKPS>
         <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
       <name>A Linking Container That Looks Like a Group Box_13</name>
-      <y>422</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-65bd</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-65c2</wuid>
+      <x>6</x>
+      <y>456</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ12</PSNAME>
@@ -929,128 +879,170 @@ $(pv_value)</tooltip>
         <PS_NUM>5</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
+      <name>A Linking Container That Looks Like a Group Box_14</name>
+      <opi_file>power_supply_summary.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
       <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-65bd</wuid>
+      <x>6</x>
+      <y>486</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>6</x>
-      <name>A Linking Container That Looks Like a Group Box_14</name>
-      <y>450</y>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
       <foreground_color>
         <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
       </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
+      <group_name></group_name>
+      <height>26</height>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+        <PSNAME>Sep E</PSNAME>
+        <SEPRTR>SEPRTR_01</SEPRTR>
+        <PV_ROOT>$(P)$(SEPRTR)</PV_ROOT>
+      </macros>
+      <name>A Linking Container That Looks Like a Group Box_11</name>
+      <opi_file>power_supply_summary.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>211ff089:16ab0672000:-72a9</wuid>
+      <x>6</x>
+      <y>396</y>
     </widget>
   </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0">
+  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <background_color>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+    </border_color>
     <border_style>13</border_style>
-    <tooltip></tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-7f86b513:15cbf58a3f3:-6880</wuid>
-    <transparent>false</transparent>
-    <lock_children>false</lock_children>
-    <scripts />
-    <height>193</height>
     <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fc>false</fc>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    </foreground_color>
+    <height>193</height>
+    <lock_children>false</lock_children>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <name>HIFI</name>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <macros>
-      <include_parent_macros>true</include_parent_macros>
-    </macros>
-    <visible>true</visible>
-    <border_color>
-      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Grouping Container</widget_type>
-    <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
-    </background_color>
-    <width>229</width>
-    <x>420</x>
-    <name>HIFI</name>
-    <y>78</y>
-    <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
+    <scripts />
     <show_scrollbar>true</show_scrollbar>
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-    </font>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
-      <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-68d5</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-        <PSNAME>SEPTUM_A</PSNAME>
-        <DFKPS>DFKPS_01</DFKPS>
-        <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
-      </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Grouping Container</widget_type>
+    <width>229</width>
+    <wuid>-7f86b513:15cbf58a3f3:-6880</wuid>
+    <x>420</x>
+    <y>42</y>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
-      <name>A Linking Container That Looks Like a Group Box</name>
-      <y>36</y>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
       <foreground_color>
         <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
       </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
-      <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-68b7</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
+      <group_name></group_name>
       <height>26</height>
-      <border_width>1</border_width>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+        <PSNAME>SEPTUM_A</PSNAME>
+        <NGPSPSU>NGPSPSU_01</NGPSPSU>
+        <PV_ROOT>$(P)$(NGPSPSU)</PV_ROOT>
+      </macros>
+      <name>A Linking Container That Looks Like a Group Box</name>
+      <opi_file>power_supply_summary.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-68d5</wuid>
+      <x>12</x>
+      <y>36</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ13A</PSNAME>
@@ -1058,44 +1050,43 @@ $(pv_value)</tooltip>
         <PS_NUM>1</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
       <name>A Linking Container That Looks Like a Group Box_1</name>
-      <y>66</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-68a9</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-68b7</wuid>
+      <x>12</x>
+      <y>66</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ14A</PSNAME>
@@ -1103,44 +1094,43 @@ $(pv_value)</tooltip>
         <PS_NUM>2</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
       <name>A Linking Container That Looks Like a Group Box_2</name>
-      <y>96</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-67ca</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-68a9</wuid>
+      <x>12</x>
+      <y>96</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ15A</PSNAME>
@@ -1148,63 +1138,25 @@ $(pv_value)</tooltip>
         <PS_NUM>3</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
       <name>A Linking Container That Looks Like a Group Box_2</name>
-      <y>126</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.NativeButton" version="1.0">
-      <toggle_button>false</toggle_button>
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <push_action_index>0</push_action_index>
+      <opi_file>power_supply_summary.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-218be6bc:15d35f78119:-7ed4</wuid>
-      <pv_value />
-      <text>Barndoors</text>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>25</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <image></image>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
-      <pv_name></pv_name>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Button</widget_type>
-      <width>115</width>
-      <x>42</x>
-      <name>Button</name>
-      <y>6</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-67ca</wuid>
+      <x>12</x>
+      <y>126</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">
         <action type="OPEN_DISPLAY">
           <path>../slits_single_motor.opi</path>
@@ -1212,70 +1164,109 @@ $(pv_value)</tooltip>
             <include_parent_macros>true</include_parent_macros>
             <MOT>$(MM_HIFI)</MOT>
           </macros>
-          <replace>1</replace>
+          <mode>0</mode>
           <description></description>
         </action>
       </actions>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-      </font>
-    </widget>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0">
-    <border_style>13</border_style>
-    <tooltip></tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-7f86b513:15cbf58a3f3:-679c</wuid>
-    <transparent>false</transparent>
-    <lock_children>false</lock_children>
-    <scripts />
-    <height>133</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <macros>
-      <include_parent_macros>true</include_parent_macros>
-    </macros>
-    <visible>true</visible>
-    <border_color>
-      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Grouping Container</widget_type>
-    <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
-    </background_color>
-    <width>229</width>
-    <x>420</x>
-    <name>MUSR</name>
-    <y>270</y>
-    <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <show_scrollbar>true</show_scrollbar>
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-    </font>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
-      <opi_file>power_supply_summary.opi</opi_file>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
       <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-68d5</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
       <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>25</height>
+      <image></image>
+      <name>Button</name>
+      <push_action_index>0</push_action_index>
+      <pv_name></pv_name>
+      <pv_value />
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <style>1</style>
+      <text>Barndoors</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>115</width>
+      <wuid>-218be6bc:15d35f78119:-7ed4</wuid>
+      <x>42</x>
+      <y>6</y>
+    </widget>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <background_color>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>13</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fc>false</fc>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    </foreground_color>
+    <height>133</height>
+    <lock_children>false</lock_children>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <name>MUSR</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>true</show_scrollbar>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Grouping Container</widget_type>
+    <width>229</width>
+    <wuid>-7f86b513:15cbf58a3f3:-679c</wuid>
+    <x>420</x>
+    <y>234</y>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ13B</PSNAME>
@@ -1283,44 +1274,43 @@ $(pv_value)</tooltip>
         <PS_NUM>1</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
       <name>A Linking Container That Looks Like a Group Box</name>
-      <y>36</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-68b7</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-68d5</wuid>
+      <x>12</x>
+      <y>36</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ14B</PSNAME>
@@ -1328,63 +1318,25 @@ $(pv_value)</tooltip>
         <PS_NUM>2</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
       <name>A Linking Container That Looks Like a Group Box_1</name>
-      <y>66</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.NativeButton" version="1.0">
-      <toggle_button>false</toggle_button>
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <push_action_index>0</push_action_index>
+      <opi_file>power_supply_summary.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-218be6bc:15d35f78119:-7edb</wuid>
-      <pv_value />
-      <text>Barndoors</text>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>25</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <image></image>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
-      <pv_name></pv_name>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Button</widget_type>
-      <width>115</width>
-      <x>42</x>
-      <name>Button</name>
-      <y>6</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-68b7</wuid>
+      <x>12</x>
+      <y>66</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">
         <action type="OPEN_DISPLAY">
           <path>../slits_single_motor.opi</path>
@@ -1392,114 +1344,152 @@ $(pv_value)</tooltip>
             <include_parent_macros>true</include_parent_macros>
             <MOT>$(MM_MUSR)</MOT>
           </macros>
-          <replace>1</replace>
+          <mode>0</mode>
           <description></description>
         </action>
       </actions>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
       <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>25</height>
+      <image></image>
+      <name>Button</name>
+      <push_action_index>0</push_action_index>
+      <pv_name></pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <style>1</style>
+      <text>Barndoors</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>115</width>
+      <wuid>-218be6bc:15d35f78119:-7edb</wuid>
+      <x>42</x>
+      <y>6</y>
     </widget>
   </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0">
+  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <background_color>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+    </border_color>
     <border_style>13</border_style>
-    <tooltip></tooltip>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-7f86b513:15cbf58a3f3:-6773</wuid>
-    <transparent>false</transparent>
-    <lock_children>false</lock_children>
-    <scripts />
-    <height>193</height>
     <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fc>false</fc>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    </foreground_color>
+    <height>193</height>
+    <lock_children>false</lock_children>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <name>EMU</name>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <macros>
-      <include_parent_macros>true</include_parent_macros>
-    </macros>
-    <visible>true</visible>
-    <border_color>
-      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Grouping Container</widget_type>
-    <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
-    </background_color>
-    <width>229</width>
-    <x>420</x>
-    <name>EMU</name>
-    <y>402</y>
-    <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
+    <scripts />
     <show_scrollbar>true</show_scrollbar>
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-    </font>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
-      <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-68d5</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-        <PSNAME>SEPTUM_C</PSNAME>
-        <DFKPS>DFKPS_02</DFKPS>
-        <PV_ROOT>$(P)$(DFKPS)</PV_ROOT>
-      </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Grouping Container</widget_type>
+    <width>229</width>
+    <wuid>-7f86b513:15cbf58a3f3:-6773</wuid>
+    <x>420</x>
+    <y>366</y>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
       <background_color>
         <color red="240" green="240" blue="240" />
       </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
-      <name>A Linking Container That Looks Like a Group Box</name>
-      <y>36</y>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
       <foreground_color>
         <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
       </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
-      <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
-      <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-68b7</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
+      <group_name></group_name>
       <height>26</height>
-      <border_width>1</border_width>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+        <PSNAME>SEPTUM_C</PSNAME>
+        <NGPSPSU>NGPSPSU_02</NGPSPSU>
+        <PV_ROOT>$(P)$(NGPSPSU)</PV_ROOT>
+      </macros>
+      <name>A Linking Container That Looks Like a Group Box</name>
+      <opi_file>power_supply_summary.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-68d5</wuid>
+      <x>12</x>
+      <y>36</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ13C</PSNAME>
@@ -1507,44 +1497,43 @@ $(pv_value)</tooltip>
         <PS_NUM>1</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
       <name>A Linking Container That Looks Like a Group Box_1</name>
-      <y>66</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-68a9</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-68b7</wuid>
+      <x>12</x>
+      <y>66</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ14C</PSNAME>
@@ -1552,44 +1541,43 @@ $(pv_value)</tooltip>
         <PS_NUM>2</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
       <name>A Linking Container That Looks Like a Group Box_2</name>
-      <y>96</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0">
       <opi_file>power_supply_summary.opi</opi_file>
-      <border_style>0</border_style>
-      <tooltip></tooltip>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-7f86b513:15cbf58a3f3:-67ca</wuid>
-      <auto_size>true</auto_size>
-      <scripts />
-      <height>26</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-68a9</wuid>
+      <x>12</x>
+      <y>96</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>26</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PSNAME>UQ15C</PSNAME>
@@ -1597,63 +1585,25 @@ $(pv_value)</tooltip>
         <PS_NUM>3</PS_NUM>
         <PV_ROOT>$(P)GENESYS_$(IOC_NUM):$(PS_NUM)</PV_ROOT>
       </macros>
-      <visible>true</visible>
-      <group_name></group_name>
-      <border_color>
-        <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Linking Container</widget_type>
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <zoom_to_fit>false</zoom_to_fit>
-      <width>170</width>
-      <x>12</x>
       <name>A Linking Container That Looks Like a Group Box_2</name>
-      <y>126</y>
-      <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-      </foreground_color>
-      <actions hook="false" hook_all="false" />
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">ISIS_GroupBox_NEW</opifont.name>
-      </font>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.NativeButton" version="1.0">
-      <toggle_button>false</toggle_button>
-      <border_style>0</border_style>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <push_action_index>0</push_action_index>
+      <opi_file>power_supply_summary.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
       <rules />
-      <enabled>true</enabled>
-      <wuid>-218be6bc:15d35f78119:-7eeb</wuid>
-      <pv_value />
-      <text>Barndoors</text>
-      <scripts />
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <height>25</height>
-      <border_width>1</border_width>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <image></image>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
-      <pv_name></pv_name>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <widget_type>Button</widget_type>
-      <width>115</width>
-      <x>42</x>
-      <name>Button</name>
-      <y>6</y>
-      <foreground_color>
-        <color red="0" green="0" blue="0" />
-      </foreground_color>
+      <widget_type>Linking Container</widget_type>
+      <width>170</width>
+      <wuid>-7f86b513:15cbf58a3f3:-67ca</wuid>
+      <x>12</x>
+      <y>126</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">
         <action type="OPEN_DISPLAY">
           <path>../slits_single_motor.opi</path>
@@ -1661,184 +1611,222 @@ $(pv_value)</tooltip>
             <include_parent_macros>true</include_parent_macros>
             <MOT>$(MM_EMU)</MOT>
           </macros>
-          <replace>1</replace>
+          <mode>0</mode>
           <description></description>
         </action>
       </actions>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
       <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>25</height>
+      <image></image>
+      <name>Button</name>
+      <push_action_index>0</push_action_index>
+      <pv_name></pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <style>1</style>
+      <text>Barndoors</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>115</width>
+      <wuid>-218be6bc:15d35f78119:-7eeb</wuid>
+      <x>42</x>
+      <y>6</y>
     </widget>
   </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.polyline" version="1.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>2</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <arrows>2</arrows>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-39d58607:15d1c9da6d8:-7bc9</wuid>
-    <transparent>false</transparent>
-    <points>
-      <point x="330" y="420" />
-      <point x="330" y="420" />
-      <point x="330" y="420" />
-      <point x="425" y="420" />
-    </points>
-    <fill_arrow>true</fill_arrow>
-    <pv_value />
+  <widget typeId="org.csstudio.opibuilder.widgets.polyline" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
     <alpha>255</alpha>
-    <rotation_angle>0.0</rotation_angle>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>1</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>true</keep_wh_ratio>
-    </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
     <anti_alias>true</anti_alias>
-    <line_style>1</line_style>
     <arrow_length>20</arrow_length>
-    <widget_type>Polyline</widget_type>
+    <arrows>2</arrows>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
       <color red="30" green="144" blue="255" />
     </background_color>
-    <width>96</width>
-    <x>330</x>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fill_arrow>true</fill_arrow>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <height>1</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_style>1</line_style>
+    <line_width>2</line_width>
     <name>Polyline_4</name>
-    <y>420</y>
-    <fill_level>0.0</fill_level>
-    <foreground_color>
-      <color red="255" green="0" blue="0" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.polyline" version="1.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>2</line_width>
-    <horizontal_fill>true</horizontal_fill>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <arrows>2</arrows>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-39d58607:15d1c9da6d8:-7bbd</wuid>
-    <transparent>false</transparent>
     <points>
-      <point x="330" y="294" />
-      <point x="330" y="294" />
-      <point x="330" y="294" />
-      <point x="425" y="294" />
+      <point x="330" y="384" />
+      <point x="330" y="384" />
+      <point x="330" y="384" />
+      <point x="425" y="384" />
     </points>
-    <fill_arrow>true</fill_arrow>
+    <pv_name></pv_name>
     <pv_value />
-    <alpha>255</alpha>
     <rotation_angle>0.0</rotation_angle>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>1</height>
-    <border_width>1</border_width>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>true</keep_wh_ratio>
     </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
     <visible>true</visible>
-    <pv_name></pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>1</line_style>
-    <arrow_length>20</arrow_length>
     <widget_type>Polyline</widget_type>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color red="30" green="144" blue="255" />
-    </background_color>
     <width>96</width>
+    <wuid>-39d58607:15d1c9da6d8:-7bc9</wuid>
     <x>330</x>
-    <name>Polyline_5</name>
-    <y>294</y>
+    <y>384</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.polyline" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <arrow_length>20</arrow_length>
+    <arrows>2</arrows>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="30" green="144" blue="255" />
+    </background_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
       <color red="255" green="0" blue="0" />
     </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.polyline" version="1.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <line_width>2</line_width>
+    <height>1</height>
     <horizontal_fill>true</horizontal_fill>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <arrows>2</arrows>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-39d58607:15d1c9da6d8:-7ba9</wuid>
-    <transparent>false</transparent>
+    <line_style>1</line_style>
+    <line_width>2</line_width>
+    <name>Polyline_5</name>
     <points>
-      <point x="228" y="585" />
-      <point x="330" y="585" />
-      <point x="330" y="90" />
-      <point x="425" y="90" />
+      <point x="330" y="258" />
+      <point x="330" y="258" />
+      <point x="330" y="258" />
+      <point x="425" y="258" />
     </points>
-    <fill_arrow>true</fill_arrow>
+    <pv_name></pv_name>
     <pv_value />
-    <alpha>255</alpha>
     <rotation_angle>0.0</rotation_angle>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>496</height>
-    <border_width>1</border_width>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>true</keep_wh_ratio>
     </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
     <visible>true</visible>
-    <pv_name></pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <anti_alias>true</anti_alias>
-    <line_style>1</line_style>
-    <arrow_length>20</arrow_length>
     <widget_type>Polyline</widget_type>
+    <width>96</width>
+    <wuid>-39d58607:15d1c9da6d8:-7bbd</wuid>
+    <x>330</x>
+    <y>258</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.polyline" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>255</alpha>
+    <anti_alias>true</anti_alias>
+    <arrow_length>20</arrow_length>
+    <arrows>2</arrows>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
       <color red="30" green="144" blue="255" />
     </background_color>
-    <width>198</width>
-    <x>228</x>
-    <name>Polyline_6</name>
-    <y>90</y>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fill_arrow>true</fill_arrow>
     <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
       <color red="255" green="0" blue="0" />
     </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
+    <height>496</height>
+    <horizontal_fill>true</horizontal_fill>
+    <line_style>1</line_style>
+    <line_width>2</line_width>
+    <name>Polyline_6</name>
+    <points>
+      <point x="228" y="549" />
+      <point x="330" y="549" />
+      <point x="330" y="54" />
+      <point x="425" y="54" />
+    </points>
+    <pv_name></pv_name>
+    <pv_value />
+    <rotation_angle>0.0</rotation_angle>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>true</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Polyline</widget_type>
+    <width>198</width>
+    <wuid>-39d58607:15d1c9da6d8:-7ba9</wuid>
+    <x>228</x>
+    <y>54</y>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/muon_overviews/power_supply_summary.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/muon_overviews/power_supply_summary.opi
@@ -1,95 +1,135 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<display typeId="org.csstudio.opibuilder.Display" version="1.0">
-  <show_close_button>true</show_close_button>
-  <rules />
-  <wuid>-7f86b513:15cbf58a3f3:-69c1</wuid>
-  <show_grid>true</show_grid>
-  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
-  <scripts />
-  <height>600</height>
-  <macros>
-    <include_parent_macros>true</include_parent_macros>
-  </macros>
-  <boy_version>3.1.4.201301231545</boy_version>
-  <show_edit_range>true</show_edit_range>
-  <widget_type>Display</widget_type>
+<display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
+  <actions hook="false" hook_all="false" />
   <auto_scale_widgets>
     <auto_scale_widgets>false</auto_scale_widgets>
     <min_width>-1</min_width>
     <min_height>-1</min_height>
   </auto_scale_widgets>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
     <color red="240" green="240" blue="240" />
   </background_color>
-  <width>800</width>
-  <x>-1</x>
-  <name></name>
-  <grid_space>6</grid_space>
-  <show_ruler>true</show_ruler>
-  <y>-1</y>
-  <snap_to_geometry>true</snap_to_geometry>
+  <boy_version>5.1.0.201707071649</boy_version>
   <foreground_color>
     <color red="192" green="192" blue="192" />
   </foreground_color>
-  <actions hook="false" hook_all="false" />
-  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-    <rules />
-    <effect_3d>true</effect_3d>
+  <grid_space>6</grid_space>
+  <height>600</height>
+  <macros>
+    <include_parent_macros>true</include_parent_macros>
+  </macros>
+  <name></name>
+  <rules />
+  <scripts />
+  <show_close_button>true</show_close_button>
+  <show_edit_range>true</show_edit_range>
+  <show_grid>true</show_grid>
+  <show_ruler>true</show_ruler>
+  <snap_to_geometry>true</snap_to_geometry>
+  <widget_type>Display</widget_type>
+  <width>800</width>
+  <wuid>-7f86b513:15cbf58a3f3:-69c1</wuid>
+  <x>-1</x>
+  <y>-1</y>
+  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    </background_color>
     <bit>-1</bit>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <bulb_border>3</bulb_border>
+    <bulb_border_color>
+      <color red="150" green="150" blue="150" />
+    </bulb_border_color>
+    <data_type>0</data_type>
+    <effect_3d>true</effect_3d>
     <enabled>true</enabled>
-    <wuid>-7f86b513:15cbf58a3f3:-69a1</wuid>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    </foreground_color>
+    <height>25</height>
+    <name>LED</name>
+    <off_color>
+      <color name="ISIS_Green_LED_Off" red="0" green="102" blue="0" />
+    </off_color>
+    <off_label>OFF</off_label>
     <on_color>
       <color name="ISIS_Green_LED_On" red="0" green="255" blue="0" />
     </on_color>
-    <pv_value />
-    <scripts />
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <height>25</height>
     <on_label>ON</on_label>
-    <border_width>1</border_width>
+    <pv_name>$(PV_ROOT):POWER</pv_name>
+    <pv_value />
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>true</keep_wh_ratio>
     </scale_options>
+    <scripts />
+    <show_boolean_label>false</show_boolean_label>
+    <square_led>false</square_led>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
     <visible>true</visible>
-    <pv_name>$(PV_ROOT):POWER</pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
     <widget_type>LED</widget_type>
-    <off_color>
-      <color name="ISIS_Green_LED_Off" red="0" green="102" blue="0" />
-    </off_color>
+    <width>25</width>
+    <wuid>-7f86b513:15cbf58a3f3:-69a1</wuid>
+    <x>96</x>
+    <y>6</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
       <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </background_color>
-    <square_led>false</square_led>
-    <width>25</width>
-    <x>96</x>
-    <name>LED</name>
+    <bit>-1</bit>
+    <border_alarm_sensitive>true</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <bulb_border>3</bulb_border>
+    <bulb_border_color>
+      <color red="150" green="150" blue="150" />
+    </bulb_border_color>
     <data_type>0</data_type>
-    <y>6</y>
+    <effect_3d>true</effect_3d>
+    <enabled>false</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <actions hook="false" hook_all="false" />
-    <show_boolean_label>false</show_boolean_label>
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
+    <height>25</height>
+    <name>LED_1</name>
+    <off_color>
+      <color name="ISIS_Red_LED_Off" red="102" green="0" blue="0" />
+    </off_color>
     <off_label>OFF</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0">
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <tooltip>$(pv_name)
-$(pv_value)</tooltip>
+    <on_color>
+      <color name="ISIS_Red_LED_On" red="255" green="100" blue="100" />
+    </on_color>
+    <on_label>ON</on_label>
+    <pv_name></pv_name>
+    <pv_value />
     <rules>
       <rule name="Rule" prop_id="pv_value" out_exp="true">
         <exp bool_exp="pvInt0 != 0 || pvInt1 != 0 || pvInt2 != 0">
@@ -103,88 +143,24 @@ $(pv_value)</tooltip>
         <pv trig="true">$(PV_ROOT):VOLT.STAT</pv>
       </rule>
     </rules>
-    <effect_3d>true</effect_3d>
-    <bit>-1</bit>
-    <enabled>false</enabled>
-    <wuid>-7f86b513:15cbf58a3f3:-69a0</wuid>
-    <on_color>
-      <color name="ISIS_Red_LED_On" red="255" green="100" blue="100" />
-    </on_color>
-    <pv_value />
-    <scripts />
-    <border_alarm_sensitive>true</border_alarm_sensitive>
-    <height>25</height>
-    <on_label>ON</on_label>
-    <border_width>1</border_width>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>true</keep_wh_ratio>
     </scale_options>
-    <visible>true</visible>
-    <pv_name></pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>LED</widget_type>
-    <off_color>
-      <color name="ISIS_Red_LED_Off" red="102" green="0" blue="0" />
-    </off_color>
-    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-    <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
-    </background_color>
-    <square_led>false</square_led>
-    <width>25</width>
-    <x>150</x>
-    <name>LED_1</name>
-    <data_type>0</data_type>
-    <y>6</y>
-    <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-    </foreground_color>
-    <actions hook="false" hook_all="false" />
+    <scripts />
     <show_boolean_label>false</show_boolean_label>
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
-    </font>
-    <off_label>OFF</off_label>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.NativeButton" version="1.0">
-    <toggle_button>false</toggle_button>
-    <border_style>0</border_style>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <square_led>false</square_led>
     <tooltip>$(pv_name)
 $(pv_value)</tooltip>
-    <push_action_index>0</push_action_index>
-    <rules />
-    <enabled>true</enabled>
-    <wuid>-2541c3ca:15d0d8c2cc6:-783f</wuid>
-    <pv_value />
-    <text>$(PSNAME)</text>
-    <scripts />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <height>25</height>
-    <border_width>1</border_width>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <image></image>
     <visible>true</visible>
-    <pv_name></pv_name>
-    <border_color>
-      <color red="0" green="128" blue="255" />
-    </border_color>
-    <widget_type>Button</widget_type>
-    <width>73</width>
-    <x>6</x>
-    <name>Button</name>
+    <widget_type>LED</widget_type>
+    <width>25</width>
+    <wuid>-7f86b513:15cbf58a3f3:-69a0</wuid>
+    <x>150</x>
     <y>6</y>
-    <foreground_color>
-      <color red="0" green="0" blue="0" />
-    </foreground_color>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <actions hook="false" hook_all="false">
       <action type="EXECUTE_PYTHONSCRIPT">
         <path></path>
@@ -201,13 +177,53 @@ if "DFKPS" in root_macro:
 	ScriptUtil.openOPI(widget, "../danfysik.opi", 1, new_macros)
 elif "GENESYS" in root_macro:
 	ScriptUtil.openOPI(widget, "../genesys.opi", 1, new_macros)
-]]></scriptText>
+elif "NGPSPSU" in root_macro: 
+	ScriptUtil.openOPI(widget, "../ngpspsu.opi", 1, new_macros)
+elif "SEPRTR" in root_macro: 
+	ScriptUtil.openOPI(widget, "separator_status.opi", 1, new_macros)
+
+	]]></scriptText>
         <embedded>true</embedded>
         <description></description>
       </action>
     </actions>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
     <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0">Default</opifont.name>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>25</height>
+    <image></image>
+    <name>Button</name>
+    <push_action_index>0</push_action_index>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <style>1</style>
+    <text>$(PSNAME)</text>
+    <toggle_button>false</toggle_button>
+    <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+    <visible>true</visible>
+    <widget_type>Action Button</widget_type>
+    <width>73</width>
+    <wuid>-2541c3ca:15d0d8c2cc6:-783f</wuid>
+    <x>6</x>
+    <y>6</y>
   </widget>
 </display>


### PR DESCRIPTION
…eparator PSU opi, reordered front-end to uq9, sep b, sep e, uq10.

### Description of work

On the MUONFE OPI, the Septum_A and Septum_C buttons now link to the appropriate NGPSPSU opi screens. A new 'Sep E' button has been created which links to the Muon Separator PSU opi and the 'Separator' button has now been re-labelled Sep B. The top Muon Front End Overview title has been reviewed to accommodate the smaller screen size used. The order of the items in the left hand front end list has been edited so it now reads UQ9, Sep B, Sep E, UQ10 etc.

### Ticket

[#4333](https://github.com/ISISComputingGroup/IBEX/issues/4333)

### Acceptance criteria

- [x] Septum A button open correct OPI
- [x] Septum B button open correct OPI
- [x] Separator E and B open correct OPIs

### Documentation

Have added ticket information into [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

