### PR TITLE
Ticket 4257 - Jasco 4180: no errors for disconnected device

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/jsco4180.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/jsco4180.opi
@@ -1341,7 +1341,7 @@ $(pv_value)</tooltip>
             <background_color>
               <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
             </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <border_alarm_sensitive>true</border_alarm_sensitive>
             <border_color>
               <color name="ISIS_Border" red="0" green="0" blue="0" />
             </border_color>
@@ -1874,7 +1874,7 @@ $(pv_value)</tooltip>
           <background_color>
             <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
           </background_color>
-          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
           <border_color>
             <color name="ISIS_Border" red="0" green="0" blue="0" />
           </border_color>
@@ -1926,7 +1926,7 @@ $(pv_value)</tooltip>
           <background_color>
             <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
           </background_color>
-          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
           <border_color>
             <color name="ISIS_Border" red="0" green="0" blue="0" />
           </border_color>
@@ -2019,7 +2019,7 @@ $(pv_value)</tooltip>
           <background_color>
             <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
           </background_color>
-          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
           <border_color>
             <color name="ISIS_Border" red="0" green="0" blue="0" />
           </border_color>
@@ -2271,7 +2271,7 @@ $(pv_value)</tooltip>
           <background_color>
             <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
           </background_color>
-          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
           <border_color>
             <color name="ISIS_Border" red="0" green="0" blue="0" />
           </border_color>
@@ -2605,7 +2605,7 @@ $(pv_value)</tooltip>
           <background_color>
             <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
           </background_color>
-          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
           <border_color>
             <color name="ISIS_Border" red="0" green="0" blue="0" />
           </border_color>
@@ -2657,7 +2657,7 @@ $(pv_value)</tooltip>
           <background_color>
             <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
           </background_color>
-          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
           <border_color>
             <color name="ISIS_Border" red="0" green="0" blue="0" />
           </border_color>
@@ -2791,7 +2791,7 @@ $(pv_value)</tooltip>
           <background_color>
             <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
           </background_color>
-          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
           <border_color>
             <color name="ISIS_Border" red="0" green="0" blue="0" />
           </border_color>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/jsco4180.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/jsco4180.opi
@@ -386,7 +386,7 @@
             <background_color>
               <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
             </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <border_alarm_sensitive>true</border_alarm_sensitive>
             <border_color>
               <color name="ISIS_Border" red="0" green="0" blue="0" />
             </border_color>
@@ -438,7 +438,7 @@ $(pv_value)</tooltip>
             <background_color>
               <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
             </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <border_alarm_sensitive>true</border_alarm_sensitive>
             <border_color>
               <color name="ISIS_Border" red="0" green="0" blue="0" />
             </border_color>
@@ -536,7 +536,7 @@ $(pv_value)</tooltip>
             <background_color>
               <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
             </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <border_alarm_sensitive>true</border_alarm_sensitive>
             <border_color>
               <color name="ISIS_Border" red="0" green="0" blue="0" />
             </border_color>
@@ -588,7 +588,7 @@ $(pv_value)</tooltip>
             <background_color>
               <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
             </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <border_alarm_sensitive>true</border_alarm_sensitive>
             <border_color>
               <color name="ISIS_Border" red="0" green="0" blue="0" />
             </border_color>
@@ -1393,7 +1393,7 @@ $(pv_value)</tooltip>
             <background_color>
               <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
             </background_color>
-            <border_alarm_sensitive>false</border_alarm_sensitive>
+            <border_alarm_sensitive>true</border_alarm_sensitive>
             <border_color>
               <color name="ISIS_Border" red="0" green="0" blue="0" />
             </border_color>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/jsco4180.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/jsco4180.opi
@@ -438,7 +438,7 @@ $(pv_value)</tooltip>
             <background_color>
               <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
             </background_color>
-            <border_alarm_sensitive>true</border_alarm_sensitive>
+            <border_alarm_sensitive>false</border_alarm_sensitive>
             <border_color>
               <color name="ISIS_Border" red="0" green="0" blue="0" />
             </border_color>
@@ -588,7 +588,7 @@ $(pv_value)</tooltip>
             <background_color>
               <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
             </background_color>
-            <border_alarm_sensitive>true</border_alarm_sensitive>
+            <border_alarm_sensitive>false</border_alarm_sensitive>
             <border_color>
               <color name="ISIS_Border" red="0" green="0" blue="0" />
             </border_color>
@@ -1393,7 +1393,7 @@ $(pv_value)</tooltip>
             <background_color>
               <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
             </background_color>
-            <border_alarm_sensitive>true</border_alarm_sensitive>
+            <border_alarm_sensitive>false</border_alarm_sensitive>
             <border_color>
               <color name="ISIS_Border" red="0" green="0" blue="0" />
             </border_color>


### PR DESCRIPTION
### Description of work

Added alarm sensitive borders to JASCO 4180 stream records.

Some further alarms can be added using the `error_setter.template` but since the template also transfers values (with errors) extra work to change records is required (where record redirection is used).

### Ticket

[#4257](https://github.com/ISISComputingGroup/IBEX/issues/4257)

### Acceptance criteria

- [x] Alarms are shown on the OPI for read backs from the device.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

