### PR TITLE
Display interlocks for a model 8500 Danfysik.

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/danfysik.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/danfysik.opi
@@ -3853,10 +3853,10 @@ $(pv_value)</tooltip>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
-    <name>Model 8000 Interlocks</name>
+    <name>Model 8000/8500 Interlocks</name>
     <rules>
       <rule name="Rule" prop_id="visible" out_exp="false">
-        <exp bool_exp="pvStr0 == &quot;8000&quot;">
+        <exp bool_exp="pvStr0 == &quot;8000&quot; || pvStr0 == &quot;8500&quot;">
           <value>true</value>
         </exp>
         <pv trig="true">$(PV_ROOT)DEV_TYPE</pv>


### PR DESCRIPTION
### Description of work

Display interlocks on model 8500 as well as 8000.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4355

### Acceptance criteria

- Interlocks panel displays on both Danfysik 8000 and 8500 models.

### Unit tests

n/a

### System tests

n/a

### Documentation

n/a

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

