### PR TITLE
Ticket4033 itc

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
@@ -133,7 +133,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>61</height>
+    <height>108</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -294,6 +294,54 @@ $(pv_value)</tooltip>
       <x>228</x>
       <y>4</y>
     </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="14" style="1" pixels="false">ISIS_Header2_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="Major" red="255" green="0" blue="0" />
+      </foreground_color>
+      <height>37</height>
+      <horizontal_alignment>2</horizontal_alignment>
+      <name>Label_15</name>
+      <rules>
+        <rule name="Rule" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0 == 2">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT):CTRL</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_scrollbar>false</show_scrollbar>
+      <text>Device in local control mode</text>
+      <tooltip></tooltip>
+      <transparent>false</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Label</widget_type>
+      <width>348</width>
+      <wrap_words>true</wrap_words>
+      <wuid>2fcaa0b8:16b27b1782f:-7e21</wuid>
+      <x>0</x>
+      <y>36</y>
+    </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
     <actions hook="false" hook_all="false" />
@@ -333,8 +381,8 @@ $(pv_value)</tooltip>
     <widget_type>Grouping Container</widget_type>
     <width>327</width>
     <wuid>41e71551:163645d4a8c:-7ea7</wuid>
-    <x>7</x>
-    <y>132</y>
+    <x>11</x>
+    <y>179</y>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
       <auto_size>false</auto_size>
@@ -524,7 +572,7 @@ $(pv_value)</tooltip>
       <wrap_words>true</wrap_words>
       <wuid>41e71551:163645d4a8c:-7ba8</wuid>
       <x>-1</x>
-      <y>78</y>
+      <y>102</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -576,7 +624,7 @@ $(pv_value)</tooltip>
       <wrap_words>false</wrap_words>
       <wuid>41e71551:163645d4a8c:-7ba7</wuid>
       <x>91</x>
-      <y>78</y>
+      <y>102</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -617,7 +665,7 @@ $(pv_value)</tooltip>
       <wrap_words>true</wrap_words>
       <wuid>41e71551:163645d4a8c:-7b99</wuid>
       <x>-1</x>
-      <y>102</y>
+      <y>78</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -669,7 +717,7 @@ $(pv_value)</tooltip>
       <wrap_words>false</wrap_words>
       <wuid>41e71551:163645d4a8c:-7b98</wuid>
       <x>91</x>
-      <y>102</y>
+      <y>78</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
       <actions hook="false" hook_all="false" />
@@ -704,7 +752,7 @@ $(pv_value)</tooltip>
       <name>Text Input_1</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):HEATERV:SP</pv_name>
+      <pv_name>$(PV_ROOT):HEATERP:SP</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules />
@@ -1051,8 +1099,8 @@ $(pv_value)</tooltip>
     <widget_type>Grouping Container</widget_type>
     <width>269</width>
     <wuid>41e71551:163645d4a8c:-7e0e</wuid>
-    <x>332</x>
-    <y>132</y>
+    <x>336</x>
+    <y>179</y>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
       <auto_size>false</auto_size>
@@ -1747,8 +1795,8 @@ $(pv_value)</tooltip>
     <widget_type>Grouping Container</widget_type>
     <width>325</width>
     <wuid>41e71551:163645d4a8c:-7a7a</wuid>
-    <x>8</x>
-    <y>288</y>
+    <x>12</x>
+    <y>335</y>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />
       <alarm_pulsing>false</alarm_pulsing>
@@ -2668,53 +2716,5 @@ $(pv_value)</tooltip>
       <x>246</x>
       <y>52</y>
     </widget>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
-    <auto_size>false</auto_size>
-    <background_color>
-      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-    </background_color>
-    <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <opifont.name fontName="Segoe UI" height="14" style="1" pixels="false">ISIS_Header2_NEW</opifont.name>
-    </font>
-    <foreground_color>
-      <color name="Major" red="255" green="0" blue="0" />
-    </foreground_color>
-    <height>37</height>
-    <horizontal_alignment>0</horizontal_alignment>
-    <name>Label_15</name>
-    <rules>
-      <rule name="Rule" prop_id="visible" out_exp="false">
-        <exp bool_exp="pv0 == 2">
-          <value>true</value>
-        </exp>
-        <pv trig="true">$(PV_ROOT):CTRL</pv>
-      </rule>
-    </rules>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <show_scrollbar>false</show_scrollbar>
-    <text>Device in local control mode</text>
-    <tooltip></tooltip>
-    <transparent>false</transparent>
-    <vertical_alignment>1</vertical_alignment>
-    <visible>false</visible>
-    <widget_type>Label</widget_type>
-    <width>348</width>
-    <wrap_words>true</wrap_words>
-    <wuid>2fcaa0b8:16b27b1782f:-7e21</wuid>
-    <x>432</x>
-    <y>84</y>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
@@ -379,9 +379,9 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>327</width>
+    <width>325</width>
     <wuid>41e71551:163645d4a8c:-7ea7</wuid>
-    <x>11</x>
+    <x>6</x>
     <y>179</y>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -1099,7 +1099,7 @@ $(pv_value)</tooltip>
     <widget_type>Grouping Container</widget_type>
     <width>269</width>
     <wuid>41e71551:163645d4a8c:-7e0e</wuid>
-    <x>336</x>
+    <x>330</x>
     <y>179</y>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -1795,7 +1795,7 @@ $(pv_value)</tooltip>
     <widget_type>Grouping Container</widget_type>
     <width>325</width>
     <wuid>41e71551:163645d4a8c:-7a7a</wuid>
-    <x>12</x>
+    <x>6</x>
     <y>335</y>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/itc503/itc503.opi
@@ -2669,4 +2669,52 @@ $(pv_value)</tooltip>
       <y>52</y>
     </widget>
   </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="14" style="1" pixels="false">ISIS_Header2_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="Major" red="255" green="0" blue="0" />
+    </foreground_color>
+    <height>37</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label_15</name>
+    <rules>
+      <rule name="Rule" prop_id="visible" out_exp="false">
+        <exp bool_exp="pv0 == 2">
+          <value>true</value>
+        </exp>
+        <pv trig="true">$(PV_ROOT):CTRL</pv>
+      </rule>
+    </rules>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Device in local control mode</text>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>false</visible>
+    <widget_type>Label</widget_type>
+    <width>348</width>
+    <wrap_words>true</wrap_words>
+    <wuid>2fcaa0b8:16b27b1782f:-7e21</wuid>
+    <x>432</x>
+    <y>84</y>
+  </widget>
 </display>


### PR DESCRIPTION
### Description of work

Rearranges the heater set point to match the IOC.
Adds large text indicating the device is in local mode.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4033

### Acceptance criteria

- [x] Heater output is clearly set in %
- [x] It's obvious when the device is in local-only mode
- [x] Follows IBEX OPI standards

### Unit tests

N/A 

### System tests

N/A

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

