### PR TITLE
Ticket4264 reflectometry ordered positions

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -660,7 +660,7 @@ $(pv_value)</tooltip>
               <show_scrollbar>true</show_scrollbar>
               <tooltip></tooltip>
               <transparent>true</transparent>
-              <visible>false</visible>
+              <visible>true</visible>
               <widget_type>Grouping Container</widget_type>
               <width>263</width>
               <wuid>-66312240:1683d19d453:-7a23</wuid>
@@ -742,7 +742,7 @@ $(pv_value)</tooltip>
               <show_scrollbar>true</show_scrollbar>
               <tooltip></tooltip>
               <transparent>true</transparent>
-              <visible>true</visible>
+              <visible>false</visible>
               <widget_type>Grouping Container</widget_type>
               <width>263</width>
               <wuid>-66312240:1683d19d453:-79e3</wuid>
@@ -950,7 +950,7 @@ $(pv_value)</tooltip>
             <tooltip></tooltip>
             <visible>true</visible>
             <widget_type>Linking Container</widget_type>
-            <width>397</width>
+            <width>398</width>
             <wuid>660a6691:1677ec40d1b:-7ebd</wuid>
             <x>0</x>
             <y>39</y>
@@ -992,7 +992,7 @@ $(pv_value)</tooltip>
             <tooltip></tooltip>
             <visible>true</visible>
             <widget_type>Linking Container</widget_type>
-            <width>397</width>
+            <width>398</width>
             <wuid>-19dc714f:1677a2ed8a5:-7ece</wuid>
             <x>0</x>
             <y>0</y>
@@ -1034,7 +1034,7 @@ $(pv_value)</tooltip>
             <tooltip></tooltip>
             <visible>true</visible>
             <widget_type>Linking Container</widget_type>
-            <width>397</width>
+            <width>398</width>
             <wuid>2150758c:16990a9ebac:-6ddf</wuid>
             <x>0</x>
             <y>78</y>
@@ -1419,7 +1419,7 @@ $(pv_value)</tooltip>
           </scale_options>
           <scripts>
             <path pathString="setPositionMacros.py" checkConnect="true" sfe="false" seoe="false">
-              <pv trig="true">$(PV_ROOT)TRACKING_AXES</pv>
+              <pv trig="true">$(PV_ROOT)PARAM_INFO</pv>
             </path>
           </scripts>
           <show_scrollbar>true</show_scrollbar>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -321,7 +321,7 @@ $(pv_value)</tooltip>
         <show_scrollbar>true</show_scrollbar>
         <tooltip></tooltip>
         <transparent>true</transparent>
-        <visible>false</visible>
+        <visible>true</visible>
         <widget_type>Grouping Container</widget_type>
         <width>965</width>
         <wuid>4fbad31a:1436c3e166f:-6faf</wuid>
@@ -1381,7 +1381,7 @@ $(pv_value)</tooltip>
         <show_scrollbar>true</show_scrollbar>
         <tooltip></tooltip>
         <transparent>true</transparent>
-        <visible>true</visible>
+        <visible>false</visible>
         <widget_type>Grouping Container</widget_type>
         <width>965</width>
         <wuid>4fbad31a:1436c3e166f:-6fae</wuid>
@@ -1751,6 +1751,326 @@ $(pv_value)</tooltip>
             <x>6</x>
             <y>362</y>
           </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_9</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>7b2b8c8d:165c7bfd038:-7249</wuid>
+            <x>432</x>
+            <y>12</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_10</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>7b2b8c8d:165c7bfd038:-723e</wuid>
+            <x>432</x>
+            <y>62</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_11</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>7b2b8c8d:165c7bfd038:-7233</wuid>
+            <x>432</x>
+            <y>112</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_12</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>7b2b8c8d:165c7bfd038:-7228</wuid>
+            <x>432</x>
+            <y>162</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_13</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>7b2b8c8d:165c7bfd038:-721d</wuid>
+            <x>432</x>
+            <y>212</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_14</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>7b2b8c8d:165c7bfd038:-7212</wuid>
+            <x>432</x>
+            <y>262</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_15</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>7b2b8c8d:165c7bfd038:-7207</wuid>
+            <x>432</x>
+            <y>312</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_16</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>7b2b8c8d:165c7bfd038:-71fc</wuid>
+            <x>432</x>
+            <y>362</y>
+          </widget>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -1791,326 +2111,6 @@ $(pv_value)</tooltip>
           <wuid>-744b7940:165a9b5d31a:-6151</wuid>
           <x>12</x>
           <y>12</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>40</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>pos_15</name>
-          <opi_file>param_move.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>400</width>
-          <wuid>7b2b8c8d:165c7bfd038:-7207</wuid>
-          <x>492</x>
-          <y>358</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>40</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>pos_14</name>
-          <opi_file>param_move.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>400</width>
-          <wuid>7b2b8c8d:165c7bfd038:-7212</wuid>
-          <x>492</x>
-          <y>308</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>40</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>pos_13</name>
-          <opi_file>param_move.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>400</width>
-          <wuid>7b2b8c8d:165c7bfd038:-721d</wuid>
-          <x>492</x>
-          <y>258</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>40</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>pos_12</name>
-          <opi_file>param_move.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>400</width>
-          <wuid>7b2b8c8d:165c7bfd038:-7228</wuid>
-          <x>492</x>
-          <y>208</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>40</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>pos_11</name>
-          <opi_file>param_move.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>400</width>
-          <wuid>7b2b8c8d:165c7bfd038:-7233</wuid>
-          <x>492</x>
-          <y>158</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>40</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>pos_10</name>
-          <opi_file>param_move.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>400</width>
-          <wuid>7b2b8c8d:165c7bfd038:-723e</wuid>
-          <x>492</x>
-          <y>108</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>40</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>pos_9</name>
-          <opi_file>param_move.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>400</width>
-          <wuid>7b2b8c8d:165c7bfd038:-7249</wuid>
-          <x>492</x>
-          <y>58</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>40</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>pos_16</name>
-          <opi_file>param_move.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>400</width>
-          <wuid>7b2b8c8d:165c7bfd038:-71fc</wuid>
-          <x>492</x>
-          <y>408</y>
         </widget>
       </widget>
     </widget>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -321,7 +321,7 @@ $(pv_value)</tooltip>
         <show_scrollbar>true</show_scrollbar>
         <tooltip></tooltip>
         <transparent>true</transparent>
-        <visible>true</visible>
+        <visible>false</visible>
         <widget_type>Grouping Container</widget_type>
         <width>965</width>
         <wuid>4fbad31a:1436c3e166f:-6faf</wuid>
@@ -1381,7 +1381,7 @@ $(pv_value)</tooltip>
         <show_scrollbar>true</show_scrollbar>
         <tooltip></tooltip>
         <transparent>true</transparent>
-        <visible>false</visible>
+        <visible>true</visible>
         <widget_type>Grouping Container</widget_type>
         <width>965</width>
         <wuid>4fbad31a:1436c3e166f:-6fae</wuid>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -1751,326 +1751,6 @@ $(pv_value)</tooltip>
             <x>6</x>
             <y>362</y>
           </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>40</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-            </macros>
-            <name>pos_9</name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>3</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>false</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-7249</wuid>
-            <x>432</x>
-            <y>12</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>40</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-            </macros>
-            <name>pos_10</name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>3</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>false</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-723e</wuid>
-            <x>432</x>
-            <y>62</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>40</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-            </macros>
-            <name>pos_11</name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>3</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>false</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-7233</wuid>
-            <x>432</x>
-            <y>112</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>40</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-            </macros>
-            <name>pos_12</name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>3</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>false</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-7228</wuid>
-            <x>432</x>
-            <y>162</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>40</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-            </macros>
-            <name>pos_13</name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>3</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>false</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-721d</wuid>
-            <x>432</x>
-            <y>212</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>40</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-            </macros>
-            <name>pos_14</name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>3</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>false</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-7212</wuid>
-            <x>432</x>
-            <y>262</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>40</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-            </macros>
-            <name>pos_15</name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>3</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>false</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-7207</wuid>
-            <x>432</x>
-            <y>312</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>40</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-            </macros>
-            <name>pos_16</name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>3</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>false</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-71fc</wuid>
-            <x>432</x>
-            <y>362</y>
-          </widget>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -2111,6 +1791,326 @@ $(pv_value)</tooltip>
           <wuid>-744b7940:165a9b5d31a:-6151</wuid>
           <x>12</x>
           <y>12</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>40</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>pos_15</name>
+          <opi_file>param_move.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>false</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>400</width>
+          <wuid>7b2b8c8d:165c7bfd038:-7207</wuid>
+          <x>492</x>
+          <y>358</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>40</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>pos_14</name>
+          <opi_file>param_move.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>false</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>400</width>
+          <wuid>7b2b8c8d:165c7bfd038:-7212</wuid>
+          <x>492</x>
+          <y>308</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>40</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>pos_13</name>
+          <opi_file>param_move.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>false</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>400</width>
+          <wuid>7b2b8c8d:165c7bfd038:-721d</wuid>
+          <x>492</x>
+          <y>258</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>40</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>pos_12</name>
+          <opi_file>param_move.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>false</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>400</width>
+          <wuid>7b2b8c8d:165c7bfd038:-7228</wuid>
+          <x>492</x>
+          <y>208</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>40</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>pos_11</name>
+          <opi_file>param_move.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>false</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>400</width>
+          <wuid>7b2b8c8d:165c7bfd038:-7233</wuid>
+          <x>492</x>
+          <y>158</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>40</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>pos_10</name>
+          <opi_file>param_move.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>false</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>400</width>
+          <wuid>7b2b8c8d:165c7bfd038:-723e</wuid>
+          <x>492</x>
+          <y>108</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>40</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>pos_9</name>
+          <opi_file>param_move.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>false</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>400</width>
+          <wuid>7b2b8c8d:165c7bfd038:-7249</wuid>
+          <x>492</x>
+          <y>58</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>40</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>pos_16</name>
+          <opi_file>param_move.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>false</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>400</width>
+          <wuid>7b2b8c8d:165c7bfd038:-71fc</wuid>
+          <x>492</x>
+          <y>408</y>
         </widget>
       </widget>
     </widget>
@@ -2202,7 +2202,7 @@ $(pv_value)</tooltip>
       <width>967</width>
       <wuid>-744b7940:165a9b5d31a:-7632</wuid>
       <x>0</x>
-      <y>618</y>
+      <y>612</y>
     </widget>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -278,7 +278,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </tab_1_foreground_color>
       <tab_1_icon_path></tab_1_icon_path>
-      <tab_1_title>Components</tab_1_title>
+      <tab_1_title>All Parameters</tab_1_title>
       <tab_count>2</tab_count>
       <tooltip></tooltip>
       <visible>true</visible>
@@ -935,7 +935,7 @@ $(pv_value)</tooltip>
             <macros>
               <include_parent_macros>true</include_parent_macros>
               <PARAM_NAME>SM Angle</PARAM_NAME>
-              <PARAM_PV>PARAM:ANGLE_SM</PARAM_PV>
+              <PARAM_PV>PARAM:SMANGLE</PARAM_PV>
             </macros>
             <name></name>
             <opi_file>param_move.opi</opi_file>
@@ -1019,7 +1019,7 @@ $(pv_value)</tooltip>
             <macros>
               <include_parent_macros>true</include_parent_macros>
               <PARAM_NAME>SM In</PARAM_NAME>
-              <PARAM_PV>PARAM:INBEAM_SM</PARAM_PV>
+              <PARAM_PV>PARAM:SMINBEAM</PARAM_PV>
             </macros>
             <name></name>
             <opi_file>param_inout.opi</opi_file>
@@ -1038,6 +1038,48 @@ $(pv_value)</tooltip>
             <wuid>2150758c:16990a9ebac:-6ddf</wuid>
             <x>0</x>
             <y>78</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>30</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+              <PARAM_NAME>SM In</PARAM_NAME>
+              <PARAM_PV>PARAM:SAMPINBEAM</PARAM_PV>
+            </macros>
+            <name>_3</name>
+            <opi_file>param_inout.opi</opi_file>
+            <resize_behaviour>1</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>true</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>398</width>
+            <wuid>-74439178:16b93487e3a:-7ced</wuid>
+            <x>0</x>
+            <y>114</y>
           </widget>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
@@ -1370,7 +1412,7 @@ $(pv_value)</tooltip>
         <macros>
           <include_parent_macros>true</include_parent_macros>
         </macros>
-        <name>Components</name>
+        <name>All Parameters</name>
         <rules />
         <scale_options>
           <width_scalable>true</width_scalable>
@@ -1405,7 +1447,7 @@ $(pv_value)</tooltip>
           <foreground_color>
             <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
           </foreground_color>
-          <height>427</height>
+          <height>535</height>
           <lock_children>false</lock_children>
           <macros>
             <include_parent_macros>true</include_parent_macros>
@@ -1430,7 +1472,7 @@ $(pv_value)</tooltip>
           <width>931</width>
           <wuid>7b2b8c8d:165c7bfd038:-7a1c</wuid>
           <x>60</x>
-          <y>42</y>
+          <y>6</y>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
             <background_color>
@@ -1468,8 +1510,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>-744b7940:165a9b5d31a:-6596</wuid>
-            <x>6</x>
-            <y>12</y>
+            <x>0</x>
+            <y>1</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1508,8 +1550,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>-744b7940:165a9b5d31a:-61cf</wuid>
-            <x>6</x>
-            <y>62</y>
+            <x>0</x>
+            <y>51</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1548,8 +1590,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>-744b7940:165a9b5d31a:-61bd</wuid>
-            <x>6</x>
-            <y>112</y>
+            <x>0</x>
+            <y>101</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1588,8 +1630,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>-744b7940:165a9b5d31a:-61ae</wuid>
-            <x>6</x>
-            <y>162</y>
+            <x>0</x>
+            <y>151</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1628,8 +1670,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>-744b7940:165a9b5d31a:-619f</wuid>
-            <x>6</x>
-            <y>212</y>
+            <x>0</x>
+            <y>201</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1668,8 +1710,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>-744b7940:165a9b5d31a:-6190</wuid>
-            <x>6</x>
-            <y>262</y>
+            <x>0</x>
+            <y>251</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1708,8 +1750,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>-744b7940:165a9b5d31a:-6181</wuid>
-            <x>6</x>
-            <y>312</y>
+            <x>0</x>
+            <y>301</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1748,8 +1790,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>-744b7940:165a9b5d31a:-6172</wuid>
-            <x>6</x>
-            <y>362</y>
+            <x>0</x>
+            <y>351</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1788,8 +1830,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7249</wuid>
-            <x>486</x>
-            <y>12</y>
+            <x>0</x>
+            <y>397</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1828,8 +1870,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-723e</wuid>
-            <x>486</x>
-            <y>62</y>
+            <x>0</x>
+            <y>445</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1868,8 +1910,8 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7233</wuid>
-            <x>486</x>
-            <y>112</y>
+            <x>0</x>
+            <y>492</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1909,7 +1951,7 @@ $(pv_value)</tooltip>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7228</wuid>
             <x>486</x>
-            <y>162</y>
+            <y>1</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1949,7 +1991,7 @@ $(pv_value)</tooltip>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-721d</wuid>
             <x>486</x>
-            <y>212</y>
+            <y>51</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1989,7 +2031,7 @@ $(pv_value)</tooltip>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7212</wuid>
             <x>486</x>
-            <y>262</y>
+            <y>101</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2029,7 +2071,7 @@ $(pv_value)</tooltip>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7207</wuid>
             <x>486</x>
-            <y>312</y>
+            <y>151</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2069,48 +2111,248 @@ $(pv_value)</tooltip>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-71fc</wuid>
             <x>486</x>
-            <y>362</y>
+            <y>201</y>
           </widget>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <auto_size>false</auto_size>
-          <background_color>
-            <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="14" style="1" pixels="false">ISIS_Header2_NEW</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="0" green="0" blue="0" />
-          </foreground_color>
-          <height>31</height>
-          <horizontal_alignment>1</horizontal_alignment>
-          <name>Label</name>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <text>Positions relative to beam (mm)</text>
-          <tooltip></tooltip>
-          <transparent>true</transparent>
-          <vertical_alignment>1</vertical_alignment>
-          <visible>true</visible>
-          <widget_type>Label</widget_type>
-          <width>829</width>
-          <wrap_words>false</wrap_words>
-          <wuid>-744b7940:165a9b5d31a:-6151</wuid>
-          <x>63</x>
-          <y>12</y>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_17</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>-74439178:16b93487e3a:-7cb6</wuid>
+            <x>486</x>
+            <y>251</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_18</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>-74439178:16b93487e3a:-7ca5</wuid>
+            <x>486</x>
+            <y>301</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_19</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>-74439178:16b93487e3a:-7c94</wuid>
+            <x>486</x>
+            <y>351</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_20</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>-74439178:16b93487e3a:-7c83</wuid>
+            <x>486</x>
+            <y>397</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_21</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>-74439178:16b93487e3a:-7c72</wuid>
+            <x>486</x>
+            <y>445</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>40</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_22</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>400</width>
+            <wuid>-74439178:16b93487e3a:-7c61</wuid>
+            <x>486</x>
+            <y>492</y>
+          </widget>
         </widget>
       </widget>
     </widget>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -69,7 +69,7 @@
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>979</width>
+    <width>1051</width>
     <wuid>-16c8e940:165f1448c04:-7afd</wuid>
     <x>0</x>
     <y>0</y>
@@ -283,7 +283,7 @@ $(pv_value)</tooltip>
       <tooltip></tooltip>
       <visible>true</visible>
       <widget_type>Tabbed Container</widget_type>
-      <width>967</width>
+      <width>1045</width>
       <wuid>450885f3:157944e4d4b:-7436</wuid>
       <x>0</x>
       <y>36</y>
@@ -321,9 +321,9 @@ $(pv_value)</tooltip>
         <show_scrollbar>true</show_scrollbar>
         <tooltip></tooltip>
         <transparent>true</transparent>
-        <visible>true</visible>
+        <visible>false</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>965</width>
+        <width>1043</width>
         <wuid>4fbad31a:1436c3e166f:-6faf</wuid>
         <x>1</x>
         <y>1</y>
@@ -660,7 +660,7 @@ $(pv_value)</tooltip>
               <show_scrollbar>true</show_scrollbar>
               <tooltip></tooltip>
               <transparent>true</transparent>
-              <visible>true</visible>
+              <visible>false</visible>
               <widget_type>Grouping Container</widget_type>
               <width>263</width>
               <wuid>-66312240:1683d19d453:-7a23</wuid>
@@ -742,7 +742,7 @@ $(pv_value)</tooltip>
               <show_scrollbar>true</show_scrollbar>
               <tooltip></tooltip>
               <transparent>true</transparent>
-              <visible>false</visible>
+              <visible>true</visible>
               <widget_type>Grouping Container</widget_type>
               <width>263</width>
               <wuid>-66312240:1683d19d453:-79e3</wuid>
@@ -909,7 +909,7 @@ $(pv_value)</tooltip>
           <transparent>false</transparent>
           <visible>true</visible>
           <widget_type>Grouping Container</widget_type>
-          <width>354</width>
+          <width>432</width>
           <wuid>3a15ff6c:167a2ac2773:-7e19</wuid>
           <x>601</x>
           <y>12</y>
@@ -950,7 +950,7 @@ $(pv_value)</tooltip>
             <tooltip></tooltip>
             <visible>true</visible>
             <widget_type>Linking Container</widget_type>
-            <width>320</width>
+            <width>397</width>
             <wuid>660a6691:1677ec40d1b:-7ebd</wuid>
             <x>0</x>
             <y>39</y>
@@ -992,7 +992,7 @@ $(pv_value)</tooltip>
             <tooltip></tooltip>
             <visible>true</visible>
             <widget_type>Linking Container</widget_type>
-            <width>320</width>
+            <width>397</width>
             <wuid>-19dc714f:1677a2ed8a5:-7ece</wuid>
             <x>0</x>
             <y>0</y>
@@ -1034,7 +1034,7 @@ $(pv_value)</tooltip>
             <tooltip></tooltip>
             <visible>true</visible>
             <widget_type>Linking Container</widget_type>
-            <width>320</width>
+            <width>397</width>
             <wuid>2150758c:16990a9ebac:-6ddf</wuid>
             <x>0</x>
             <y>78</y>
@@ -1196,7 +1196,7 @@ $(pv_value)</tooltip>
           <transparent>false</transparent>
           <visible>true</visible>
           <widget_type>Grouping Container</widget_type>
-          <width>354</width>
+          <width>432</width>
           <wuid>28840e26:169d9726b77:-7720</wuid>
           <x>601</x>
           <y>396</y>
@@ -1381,9 +1381,9 @@ $(pv_value)</tooltip>
         <show_scrollbar>true</show_scrollbar>
         <tooltip></tooltip>
         <transparent>true</transparent>
-        <visible>false</visible>
+        <visible>true</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>965</width>
+        <width>1043</width>
         <wuid>4fbad31a:1436c3e166f:-6fae</wuid>
         <x>1</x>
         <y>1</y>
@@ -1427,10 +1427,10 @@ $(pv_value)</tooltip>
           <transparent>false</transparent>
           <visible>true</visible>
           <widget_type>Grouping Container</widget_type>
-          <width>835</width>
+          <width>931</width>
           <wuid>7b2b8c8d:165c7bfd038:-7a1c</wuid>
-          <x>6</x>
-          <y>48</y>
+          <x>60</x>
+          <y>42</y>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
             <background_color>
@@ -1788,7 +1788,7 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7249</wuid>
-            <x>432</x>
+            <x>486</x>
             <y>12</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
@@ -1828,7 +1828,7 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-723e</wuid>
-            <x>432</x>
+            <x>486</x>
             <y>62</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
@@ -1868,7 +1868,7 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7233</wuid>
-            <x>432</x>
+            <x>486</x>
             <y>112</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
@@ -1908,7 +1908,7 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7228</wuid>
-            <x>432</x>
+            <x>486</x>
             <y>162</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
@@ -1948,7 +1948,7 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-721d</wuid>
-            <x>432</x>
+            <x>486</x>
             <y>212</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
@@ -1988,7 +1988,7 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7212</wuid>
-            <x>432</x>
+            <x>486</x>
             <y>262</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
@@ -2028,7 +2028,7 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-7207</wuid>
-            <x>432</x>
+            <x>486</x>
             <y>312</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
@@ -2068,7 +2068,7 @@ $(pv_value)</tooltip>
             <widget_type>Linking Container</widget_type>
             <width>400</width>
             <wuid>7b2b8c8d:165c7bfd038:-71fc</wuid>
-            <x>432</x>
+            <x>486</x>
             <y>362</y>
           </widget>
         </widget>
@@ -2109,7 +2109,7 @@ $(pv_value)</tooltip>
           <width>829</width>
           <wrap_words>false</wrap_words>
           <wuid>-744b7940:165a9b5d31a:-6151</wuid>
-          <x>12</x>
+          <x>63</x>
           <y>12</y>
         </widget>
       </widget>
@@ -2199,7 +2199,7 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
       <visible>true</visible>
       <widget_type>Action Button</widget_type>
-      <width>967</width>
+      <width>1045</width>
       <wuid>-744b7940:165a9b5d31a:-7632</wuid>
       <x>0</x>
       <y>612</y>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_inout.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_inout.opi
@@ -6,7 +6,7 @@
     <min_width>-1</min_width>
     <min_height>-1</min_height>
   </auto_scale_widgets>
-  <auto_zoom_to_fit_all>true</auto_zoom_to_fit_all>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
     <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
@@ -52,7 +52,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>30</height>
+    <height>29</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -65,12 +65,12 @@
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
     <scripts />
-    <show_scrollbar>false</show_scrollbar>
+    <show_scrollbar>true</show_scrollbar>
     <tooltip></tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>391</width>
+    <width>319</width>
     <wuid>21a0ac39:169e7b419e1:-7e27</wuid>
     <x>0</x>
     <y>0</y>
@@ -120,7 +120,7 @@ $(pv_value)</tooltip>
       <widget_type>Action Button</widget_type>
       <width>39</width>
       <wuid>21a0ac39:169e7b419e1:-7e25</wuid>
-      <x>348</x>
+      <x>276</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -172,7 +172,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>21a0ac39:169e7b419e1:-7e24</wuid>
-      <x>204</x>
+      <x>139</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -224,7 +224,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>21a0ac39:169e7b419e1:-7e22</wuid>
-      <x>146</x>
+      <x>81</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
@@ -270,7 +270,7 @@ $(pv_value)</tooltip>
       <widget_type>Choice Button</widget_type>
       <width>77</width>
       <wuid>-4a9cdc4b:169e3e25b89:-7e0b</wuid>
-      <x>261</x>
+      <x>196</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -292,7 +292,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
       <height>20</height>
-      <horizontal_alignment>0</horizontal_alignment>
+      <horizontal_alignment>2</horizontal_alignment>
       <name>Label</name>
       <rules />
       <scale_options>
@@ -307,10 +307,10 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>141</width>
+      <width>70</width>
       <wrap_words>false</wrap_words>
       <wuid>21a0ac39:169e7b419e1:-7e26</wuid>
-      <x>6</x>
+      <x>0</x>
       <y>4</y>
     </widget>
   </widget>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_inout.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_inout.opi
@@ -6,7 +6,7 @@
     <min_width>-1</min_width>
     <min_height>-1</min_height>
   </auto_scale_widgets>
-  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <auto_zoom_to_fit_all>true</auto_zoom_to_fit_all>
   <background_color>
     <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
@@ -52,7 +52,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>29</height>
+    <height>30</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -65,55 +65,15 @@
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
     <scripts />
-    <show_scrollbar>true</show_scrollbar>
+    <show_scrollbar>false</show_scrollbar>
     <tooltip></tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>319</width>
+    <width>391</width>
     <wuid>21a0ac39:169e7b419e1:-7e27</wuid>
     <x>0</x>
     <y>0</y>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false" />
-      <auto_size>false</auto_size>
-      <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
-      </font>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <height>20</height>
-      <horizontal_alignment>2</horizontal_alignment>
-      <name>Label</name>
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts />
-      <text>$(PARAM_NAME):</text>
-      <tooltip></tooltip>
-      <transparent>true</transparent>
-      <vertical_alignment>1</vertical_alignment>
-      <visible>true</visible>
-      <widget_type>Label</widget_type>
-      <width>70</width>
-      <wrap_words>false</wrap_words>
-      <wuid>21a0ac39:169e7b419e1:-7e26</wuid>
-      <x>0</x>
-      <y>4</y>
-    </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">
         <action type="WRITE_PV">
@@ -160,7 +120,7 @@ $(pv_value)</tooltip>
       <widget_type>Action Button</widget_type>
       <width>39</width>
       <wuid>21a0ac39:169e7b419e1:-7e25</wuid>
-      <x>276</x>
+      <x>348</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -212,7 +172,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>21a0ac39:169e7b419e1:-7e24</wuid>
-      <x>139</x>
+      <x>204</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -264,7 +224,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>21a0ac39:169e7b419e1:-7e22</wuid>
-      <x>81</x>
+      <x>146</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
@@ -310,8 +270,48 @@ $(pv_value)</tooltip>
       <widget_type>Choice Button</widget_type>
       <width>77</width>
       <wuid>-4a9cdc4b:169e3e25b89:-7e0b</wuid>
-      <x>196</x>
+      <x>261</x>
       <y>0</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>Label</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <text>$(PARAM_NAME):</text>
+      <tooltip></tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>141</width>
+      <wrap_words>false</wrap_words>
+      <wuid>21a0ac39:169e7b419e1:-7e26</wuid>
+      <x>6</x>
+      <y>4</y>
     </widget>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_inout.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_inout.opi
@@ -70,7 +70,7 @@
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>319</width>
+    <width>397</width>
     <wuid>21a0ac39:169e7b419e1:-7e27</wuid>
     <x>0</x>
     <y>0</y>
@@ -120,7 +120,7 @@ $(pv_value)</tooltip>
       <widget_type>Action Button</widget_type>
       <width>39</width>
       <wuid>21a0ac39:169e7b419e1:-7e25</wuid>
-      <x>276</x>
+      <x>351</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -172,7 +172,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>21a0ac39:169e7b419e1:-7e24</wuid>
-      <x>139</x>
+      <x>214</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -224,7 +224,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>21a0ac39:169e7b419e1:-7e22</wuid>
-      <x>81</x>
+      <x>156</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
@@ -270,7 +270,7 @@ $(pv_value)</tooltip>
       <widget_type>Choice Button</widget_type>
       <width>77</width>
       <wuid>-4a9cdc4b:169e3e25b89:-7e0b</wuid>
-      <x>196</x>
+      <x>271</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -307,11 +307,87 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>70</width>
+      <width>127</width>
       <wrap_words>false</wrap_words>
-      <wuid>21a0ac39:169e7b419e1:-7e26</wuid>
-      <x>0</x>
+      <wuid>-13168dce:16b323bd04e:-73cb</wuid>
+      <x>17</x>
       <y>4</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.symbol.bool.BoolMonitorWidget" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <align_to_nearest_second>false</align_to_nearest_second>
+      <auto_size>true</auto_size>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color red="225" green="225" blue="225" />
+      </background_color>
+      <bit>-1</bit>
+      <boolean_label_position>0</boolean_label_position>
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <crop_bottom>0</crop_bottom>
+      <crop_left>0</crop_left>
+      <crop_right>0</crop_right>
+      <crop_top>0</crop_top>
+      <data_type>0</data_type>
+      <degree>0</degree>
+      <enabled>false</enabled>
+      <flip_horizontal>false</flip_horizontal>
+      <flip_vertical>false</flip_vertical>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">Default Bold</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color red="0" green="202" blue="0" />
+      </foreground_color>
+      <height>21</height>
+      <image_file></image_file>
+      <name>Boolean Symbol Monitor</name>
+      <no_animation>false</no_animation>
+      <off_color>
+        <color red="255" green="255" blue="255" />
+      </off_color>
+      <off_label></off_label>
+      <on_color>
+        <color red="0" green="202" blue="0" />
+      </on_color>
+      <on_label>M</on_label>
+      <permutation_matrix>
+        <row>
+          <col>1.0</col>
+          <col>0.0</col>
+        </row>
+        <row>
+          <col>0.0</col>
+          <col>1.0</col>
+        </row>
+      </permutation_matrix>
+      <pv_name>$(PV_ROOT)$(PREFIXED_PV):IN_MODE</pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_boolean_label>true</show_boolean_label>
+      <stretch_to_fit>false</stretch_to_fit>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <transparency>false</transparency>
+      <visible>true</visible>
+      <widget_type>Boolean Symbol Monitor</widget_type>
+      <width>18</width>
+      <wuid>-13168dce:16b323bd04e:-7291</wuid>
+      <x>0</x>
+      <y>3</y>
     </widget>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
@@ -6,7 +6,7 @@
     <min_width>-1</min_width>
     <min_height>-1</min_height>
   </auto_scale_widgets>
-  <auto_zoom_to_fit_all>true</auto_zoom_to_fit_all>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
     <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
@@ -52,7 +52,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>30</height>
+    <height>29</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -65,12 +65,12 @@
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
     <scripts />
-    <show_scrollbar>false</show_scrollbar>
+    <show_scrollbar>true</show_scrollbar>
     <tooltip></tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>391</width>
+    <width>319</width>
     <wuid>-16c8e940:165f1448c04:-7e27</wuid>
     <x>0</x>
     <y>0</y>
@@ -120,7 +120,7 @@ $(pv_value)</tooltip>
       <widget_type>Action Button</widget_type>
       <width>39</width>
       <wuid>-744b7940:165a9b5d31a:-7a6a</wuid>
-      <x>345</x>
+      <x>276</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -172,7 +172,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>-e03d447:166346877c1:-7bdd</wuid>
-      <x>204</x>
+      <x>139</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
@@ -243,7 +243,7 @@ $(pv_value)</tooltip>
       <widget_type>Text Input</widget_type>
       <width>73</width>
       <wuid>-e03d447:166346877c1:-7bdc</wuid>
-      <x>267</x>
+      <x>198</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -295,7 +295,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>-5cc9c870:167650cec59:-7fdd</wuid>
-      <x>146</x>
+      <x>81</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -317,7 +317,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
       <height>20</height>
-      <horizontal_alignment>0</horizontal_alignment>
+      <horizontal_alignment>2</horizontal_alignment>
       <name>Label</name>
       <rules />
       <scale_options>
@@ -332,10 +332,10 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>145</width>
+      <width>70</width>
       <wrap_words>false</wrap_words>
       <wuid>-744b7940:165a9b5d31a:-67c9</wuid>
-      <x>6</x>
+      <x>0</x>
       <y>4</y>
     </widget>
   </widget>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
@@ -70,7 +70,7 @@
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>319</width>
+    <width>397</width>
     <wuid>-16c8e940:165f1448c04:-7e27</wuid>
     <x>0</x>
     <y>0</y>
@@ -120,7 +120,7 @@ $(pv_value)</tooltip>
       <widget_type>Action Button</widget_type>
       <width>39</width>
       <wuid>-744b7940:165a9b5d31a:-7a6a</wuid>
-      <x>276</x>
+      <x>351</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -172,7 +172,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>-e03d447:166346877c1:-7bdd</wuid>
-      <x>139</x>
+      <x>214</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
@@ -243,7 +243,7 @@ $(pv_value)</tooltip>
       <widget_type>Text Input</widget_type>
       <width>73</width>
       <wuid>-e03d447:166346877c1:-7bdc</wuid>
-      <x>198</x>
+      <x>273</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -295,7 +295,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>-5cc9c870:167650cec59:-7fdd</wuid>
-      <x>81</x>
+      <x>156</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -332,11 +332,87 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>70</width>
+      <width>126</width>
       <wrap_words>false</wrap_words>
       <wuid>-744b7940:165a9b5d31a:-67c9</wuid>
-      <x>0</x>
+      <x>17</x>
       <y>4</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.symbol.bool.BoolMonitorWidget" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <align_to_nearest_second>false</align_to_nearest_second>
+      <auto_size>true</auto_size>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color red="225" green="225" blue="225" />
+      </background_color>
+      <bit>-1</bit>
+      <boolean_label_position>0</boolean_label_position>
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <crop_bottom>0</crop_bottom>
+      <crop_left>0</crop_left>
+      <crop_right>0</crop_right>
+      <crop_top>0</crop_top>
+      <data_type>0</data_type>
+      <degree>0</degree>
+      <enabled>true</enabled>
+      <flip_horizontal>false</flip_horizontal>
+      <flip_vertical>false</flip_vertical>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">Default Bold</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color red="0" green="202" blue="0" />
+      </foreground_color>
+      <height>21</height>
+      <image_file></image_file>
+      <name>Boolean Symbol Monitor</name>
+      <no_animation>false</no_animation>
+      <off_color>
+        <color red="255" green="255" blue="255" />
+      </off_color>
+      <off_label></off_label>
+      <on_color>
+        <color red="0" green="202" blue="0" />
+      </on_color>
+      <on_label>M</on_label>
+      <permutation_matrix>
+        <row>
+          <col>1.0</col>
+          <col>0.0</col>
+        </row>
+        <row>
+          <col>0.0</col>
+          <col>1.0</col>
+        </row>
+      </permutation_matrix>
+      <pv_name>$(PV_ROOT)$(PREFIXED_PV):IN_MODE</pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_boolean_label>true</show_boolean_label>
+      <stretch_to_fit>false</stretch_to_fit>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <transparency>false</transparency>
+      <visible>true</visible>
+      <widget_type>Boolean Symbol Monitor</widget_type>
+      <width>18</width>
+      <wuid>-13168dce:16b323bd04e:-727f</wuid>
+      <x>0</x>
+      <y>3</y>
     </widget>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
@@ -6,7 +6,7 @@
     <min_width>-1</min_width>
     <min_height>-1</min_height>
   </auto_scale_widgets>
-  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <auto_zoom_to_fit_all>true</auto_zoom_to_fit_all>
   <background_color>
     <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
@@ -52,7 +52,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>29</height>
+    <height>30</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -65,55 +65,15 @@
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
     <scripts />
-    <show_scrollbar>true</show_scrollbar>
+    <show_scrollbar>false</show_scrollbar>
     <tooltip></tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>319</width>
+    <width>391</width>
     <wuid>-16c8e940:165f1448c04:-7e27</wuid>
     <x>0</x>
     <y>0</y>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false" />
-      <auto_size>false</auto_size>
-      <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
-      </font>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <height>20</height>
-      <horizontal_alignment>2</horizontal_alignment>
-      <name>Label</name>
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts />
-      <text>$(PARAM_NAME):</text>
-      <tooltip></tooltip>
-      <transparent>true</transparent>
-      <vertical_alignment>1</vertical_alignment>
-      <visible>true</visible>
-      <widget_type>Label</widget_type>
-      <width>70</width>
-      <wrap_words>false</wrap_words>
-      <wuid>-744b7940:165a9b5d31a:-67c9</wuid>
-      <x>0</x>
-      <y>4</y>
-    </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">
         <action type="WRITE_PV">
@@ -160,7 +120,7 @@ $(pv_value)</tooltip>
       <widget_type>Action Button</widget_type>
       <width>39</width>
       <wuid>-744b7940:165a9b5d31a:-7a6a</wuid>
-      <x>276</x>
+      <x>345</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -212,7 +172,7 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>-e03d447:166346877c1:-7bdd</wuid>
-      <x>139</x>
+      <x>204</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
@@ -283,7 +243,7 @@ $(pv_value)</tooltip>
       <widget_type>Text Input</widget_type>
       <width>73</width>
       <wuid>-e03d447:166346877c1:-7bdc</wuid>
-      <x>198</x>
+      <x>267</x>
       <y>4</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -335,7 +295,47 @@ $(pv_value)</tooltip>
       <width>56</width>
       <wrap_words>false</wrap_words>
       <wuid>-5cc9c870:167650cec59:-7fdd</wuid>
-      <x>81</x>
+      <x>146</x>
+      <y>4</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>Label</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <text>$(PARAM_NAME):</text>
+      <tooltip></tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>145</width>
+      <wrap_words>false</wrap_words>
+      <wuid>-744b7940:165a9b5d31a:-67c9</wuid>
+      <x>6</x>
       <y>4</y>
     </widget>
   </widget>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
@@ -47,4 +47,3 @@ for item in range(len(params)):
     reload_widget(pos, params[item]["type"])
     pos += 1
     
-#reload_widgets(pos)

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
@@ -3,25 +3,20 @@ import json
 import zlib
 
 
-def reload_widgets(count):
-    """
-    Reload all the position widgets. We have 'count' of them.
-    Args:
-        Count: widget to reload
-    """
-    for index in range(1, count + 1):
-        reload_widget(display.getWidget("pos_" + str(index)))
-
-
-def reload_widget(widget):
+def reload_widget(index, param_type):
     """
     We have to reload the widget to update the macros. Done by unsetting and resetting the
     target OPI.
     Args:
         widget: wdidget to reload
     """
+    widget = display.getWidget("pos_" + str(index))
+
     widget.setPropertyValue("opi_file", "null.opi")
-    widget.setPropertyValue("opi_file", "param_move.opi")
+    if param_type == "in_out":
+        widget.setPropertyValue("opi_file", "param_inout.opi")
+    else:
+        widget.setPropertyValue("opi_file", "param_move.opi")
 
 
 def _add_macros(widget_index, name, value):
@@ -46,9 +41,10 @@ params = json.loads(value)
 
 pos = 1
 for item in range(len(params)):
-    for pv, name in params[item].items():
-        _add_macros(pos, "PARAM_PV", pv)
-        _add_macros(pos, "PARAM_NAME", name)
-        pos += 1
 
-reload_widgets(pos)
+    _add_macros(pos, "PARAM_PV", params[item]["prepended_alias"])
+    _add_macros(pos, "PARAM_NAME",  params[item]["param_name"])
+    reload_widget(pos, params[item]["type"])
+    pos += 1
+    
+#reload_widgets(pos)

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
@@ -45,9 +45,10 @@ value = zlib.decompress(value.decode("hex"))
 params = json.loads(value)
 
 pos = 1
-for pv, name in params.items():
-    _add_macros(pos, "PARAM_PV", pv)
-    _add_macros(pos, "PARAM_NAME", name)
-    pos += 1
+for item in range(len(params)):
+    for pv, name in params[item].items():
+        _add_macros(pos, "PARAM_PV", pv)
+        _add_macros(pos, "PARAM_NAME", name)
+        pos += 1
 
 reload_widgets(pos)


### PR DESCRIPTION
### Description of work

This ticket is part of the work to provide the parameters found on the 'Components: Positions relative to beam' screen on the opi in the same order in which they are found in the config. The work also provides an indication as to whether the parameter is in the mode or not. 

[#4264](https://github.com/ISISComputingGroup/IBEX/issues/4264)

### To test

- [x] Run the refl IOC. Check the parameter order in the config, confirm that they are in the same order on the OPI. 

- [x] Change the mode on the OPI. Confirm that the correct parameters have the 'M' (in the mode) indicator next to them in relation to those in the config.

### Acceptance criteria

- [x] All parameters have an IN_MODE PV.

- [x] When the mode is changed, the appropriate parameters in that mode are set to being IN_MODE = YES.

- [x] The parameters retain the order in which they are provided in the config. 


### Documentation

Have created an entry in:
https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

