### PR TITLE
Ticket 4299: More details screen now has motor name as title

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
@@ -19,7 +19,7 @@
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <name></name>
+  <name>$(NAME)</name>
   <rules />
   <scripts />
   <show_close_button>true</show_close_button>


### PR DESCRIPTION
### Ticket

See https://github.com/ISISComputingGroup/IBEX/issues/4299

To test:
* Open more details screen on motor OPI
* Confirm it has the name of the motor as the tab title

### Unit tests

N/A

### System tests

N/A

### Documentation
N/A
---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

