### PR TITLE
Ticket 3784 - Updated PV names

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/tti355.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/tti355.opi
@@ -960,7 +960,7 @@ $(pv_value)</tooltip>
       </scale_options>
       <scripts />
       <show_scrollbar>false</show_scrollbar>
-      <text>Set point:</text>
+      <text>Max:</text>
       <tooltip></tooltip>
       <transparent>false</transparent>
       <vertical_alignment>1</vertical_alignment>
@@ -1315,7 +1315,7 @@ $(PV_ROOT)CURRENT</tooltip>
         <color name="ISIS_Green_LED_On" red="0" green="255" blue="0" />
       </on_color>
       <on_label>ON</on_label>
-      <pv_name>$(PV_ROOT)OUTPUT</pv_name>
+      <pv_name>$(PV_ROOT)OUTPUTSTATUS</pv_name>
       <pv_value />
       <rules />
       <scale_options>
@@ -1363,7 +1363,7 @@ $(pv_value)</tooltip>
       <image></image>
       <name>Pump Output On</name>
       <push_action_index>0</push_action_index>
-      <pv_name>$(PV_ROOT)OUTPUT:SP</pv_name>
+      <pv_name>$(PV_ROOT)OUTPUTSTATUS:SP</pv_name>
       <pv_value />
       <rules />
       <scale_options>
@@ -1412,7 +1412,7 @@ $(pv_value)</tooltip>
       <image></image>
       <name>Pump Output Off</name>
       <push_action_index>0</push_action_index>
-      <pv_name>$(PV_ROOT)OUTPUT:SP</pv_name>
+      <pv_name>$(PV_ROOT)OUTPUTSTATUS:SP</pv_name>
       <pv_value />
       <rules />
       <scale_options>


### PR DESCRIPTION
### Description of work

1. PV name changes: Forgot to commit these to the branch before merging into master; master currently has a broken OPI in that the ON, OFF `OUTPUTSTATUS` buttons are pointing at the wrong record. `OUTPUTSTATUS` was updated to match against the Kepco.

2. Label change: Changed to have a more clear description as per a conversation with John.

### Ticket

[#3784](https://github.com/ISISComputingGroup/IBEX/issues/3784)


