### PR TITLE
Ticket4345 macro value not editable in table

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/TargetPropertiesViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/TargetPropertiesViewModelTest.java
@@ -2,7 +2,7 @@
 
 /*
  * This file is part of the ISIS IBEX application.
- * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * Copyright (C) 2012-2019 Science & Technology Facilities Council.
  * All rights reserved.
  *
  * This program is distributed in the hope that it will be useful.
@@ -59,56 +59,52 @@ public class TargetPropertiesViewModelTest {
     }
 
     @Test
-    public void WHEN_no_property_is_selected_THEN_value_and_description_blank() {
+    public void WHEN_no_property_is_selected_THEN_description_blank() {
         // Act
         viewModel.setTableSelection(null);
 
         // Assert
-        assertEquals("", viewModel.getValueText());
         assertEquals("", viewModel.getDescriptionText());
     }
 
     @Test
-    public void WHEN_property_is_selected_THEN_value_and_description_change() {
+    public void WHEN_property_is_selected_THEN_description_changes() {
         // Act
         viewModel.setTableSelection(property1);
 
         // Assert
-        assertEquals(propertyValue1, viewModel.getValueText());
         assertEquals(propertyDescription1, viewModel.getDescriptionText());
     }
 
     @Test
-    public void WHEN_no_available_properties_THEN_table_and_text_box_are_disabled() {
+    public void WHEN_no_available_properties_THEN_table_is_disabled() {
         // Act
         viewModel.setProperties(new ArrayList<PropertyDescription>());
 
         // Assert
         assertEquals(false, viewModel.getTableEnabled());
-        assertEquals(false, viewModel.getValueTextEnabled());
     }
 
     @Test
     public void WHEN_changing_the_selected_property_on_the_viewmodel_THEN_value_changes_on_target() {
         // Act
         viewModel.setTableSelection(property1);
-        viewModel.setValueText("Hello");
+        property1.setValue("Hello");
         viewModel.setDescriptionText("Hello again.");
 
         // Assert
-        assertEquals("Hello", viewModel.getValueText());
+        assertEquals("Hello", property1.getValue());
         assertEquals("Hello", property1.getValue());
         assertEquals("Hello again.", viewModel.getDescriptionText());
     }
 
     @Test
-    public void WHEN_set_properties_to_empty_THEN_value_changes_on_target() {
+    public void WHEN_set_properties_to_empty_THEN_description_changes_on_target() {
         // Act
         viewModel.setProperties(new ArrayList<PropertyDescription>());
         
 
         // Assert
-        assertEquals("", viewModel.getValueText());
         assertEquals("", viewModel.getDescriptionText());
     }
 
@@ -118,7 +114,7 @@ public class TargetPropertiesViewModelTest {
         viewModel.setProperties(Arrays.asList(property1));
 
         // Assert
-        assertEquals(propertyValue1, viewModel.getValueText());
+        assertEquals(propertyValue1, property1.getValue());
         assertEquals(propertyDescription1, viewModel.getDescriptionText());
     }
 

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/META-INF/MANIFEST.MF
@@ -18,5 +18,6 @@ Require-Bundle: org.eclipse.ui,
  uk.ac.stfc.isis.ibex.ui.targets;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.apache.logging.log4j
+Import-Package: org.apache.logging.log4j,
+ uk.ac.stfc.isis.ibex.ui.widgets
 Export-Package: uk.ac.stfc.isis.ibex.ui.devicescreens

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/dialogs/TargetPropertiesTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/dialogs/TargetPropertiesTable.java
@@ -1,6 +1,6 @@
  /*
  * This file is part of the ISIS IBEX application.
- * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * Copyright (C) 2012-2019 Science & Technology Facilities Council.
  * All rights reserved.
  *
  * This program is distributed in the hope that it will be useful.
@@ -21,12 +21,14 @@
  */
 package uk.ac.stfc.isis.ibex.ui.devicescreens.dialogs;
 
+import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
 import uk.ac.stfc.isis.ibex.devicescreens.desc.PropertyDescription;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundTable;
+import uk.ac.stfc.isis.ibex.ui.widgets.StringEditingSupport;
 
 /**
  * A table that holds the properties for a target.
@@ -65,10 +67,23 @@ public class TargetPropertiesTable extends DataboundTable<PropertyDescription> {
     }
 
     private void value() {
-        createColumn("Value", 4, new DataboundCellLabelProvider<PropertyDescription>(observeProperty("value")) {
+        TableViewerColumn value = createColumn("Value", 4, new DataboundCellLabelProvider<PropertyDescription>(observeProperty("value")) {
             @Override
 			protected String stringFromRow(PropertyDescription row) {
                 return row.getValue();
+            }
+        });
+        
+        value.setEditingSupport(new StringEditingSupport<PropertyDescription>(viewer(), PropertyDescription.class) {
+
+            @Override
+            protected String valueFromRow(PropertyDescription row) {
+                return row.getValue();
+            }
+
+            @Override
+            protected void setValueForRow(PropertyDescription row, String value) {
+                row.setValue(value);
             }
         });
     }

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/dialogs/TargetPropertiesWidget.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/dialogs/TargetPropertiesWidget.java
@@ -1,6 +1,6 @@
 
 /*
- * This file is part of the ISIS IBEX application. Copyright (C) 2012-2016
+ * This file is part of the ISIS IBEX application. Copyright (C) 2012-2019
  * Science & Technology Facilities Council. All rights reserved.
  *
  * This program is distributed in the hope that it will be useful. This program
@@ -50,8 +50,6 @@ public class TargetPropertiesWidget extends Composite {
 
     /** The properties table. */
     private TargetPropertiesTable table;
-
-    private Text valueText;
 
     private Text txtDescription;
 	
@@ -103,13 +101,6 @@ public class TargetPropertiesWidget extends Composite {
         gdTable.minimumHeight = TABLE_HEIGHT;
         table.setLayoutData(gdTable);
 
-        Label lblValue = new Label(controlComposite, SWT.NONE);
-        lblValue.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-        lblValue.setText("Value");
-
-        valueText = new Text(controlComposite, SWT.BORDER);
-        valueText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-
         Label lblPropertyDescription = new Label(controlComposite, SWT.NONE);
         lblPropertyDescription.setLayoutData(new GridData(SWT.RIGHT, SWT.TOP, false, false, 1, 1));
         lblPropertyDescription.setText("Description");
@@ -125,11 +116,6 @@ public class TargetPropertiesWidget extends Composite {
 
     private void bind() {
         DataBindingContext bindingContext = new DataBindingContext();
-        
-        bindingContext.bindValue(SWTObservables.observeText(valueText, SWT.Modify),
-                BeanProperties.value("valueText").observe(viewModel));
-        bindingContext.bindValue(SWTObservables.observeEnabled(valueText),
-                BeanProperties.value("valueTextEnabled").observe(viewModel));
 
         bindingContext.bindValue(SWTObservables.observeText(txtDescription),
                 BeanProperties.value("descriptionText").observe(viewModel));

--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/models/TargetPropertiesViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens/src/uk/ac/stfc/isis/ibex/ui/devicescreens/models/TargetPropertiesViewModel.java
@@ -1,6 +1,6 @@
  /*
  * This file is part of the ISIS IBEX application.
- * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * Copyright (C) 2012-2019 Science & Technology Facilities Council.
  * All rights reserved.
  *
  * This program is distributed in the hope that it will be useful.
@@ -36,13 +36,10 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
 public class TargetPropertiesViewModel extends ModelObject {
     private EditDeviceScreensDescriptionViewModel viewModel;
 
-    private Boolean valueTextEnabled = false;
     private Boolean tableEnabled = false;
 
-    private String valueText;
     private String descriptionText;
 
-    private PropertyDescription tableSelection;
     private List<PropertyDescription> properties;
 
     /**
@@ -96,7 +93,6 @@ public class TargetPropertiesViewModel extends ModelObject {
             setTableSelection(null);
         }
         setTableEnabled(hasProperties);
-        setValueTextEnabled(hasProperties);
         firePropertyChange("properties", properties, properties = newProperties);
     }
 
@@ -119,11 +115,8 @@ public class TargetPropertiesViewModel extends ModelObject {
         if (selected != null) {
             String descText = viewModel.getTargetScreen().getMacroDescription(selected.getKey());
             setDescriptionText(descText);
-            updateValueText(selected.getValue());
-            tableSelection = selected;
         } else {
             setDescriptionText("");
-            updateValueText("");
         }
     }
 
@@ -138,45 +131,6 @@ public class TargetPropertiesViewModel extends ModelObject {
      */
     public Boolean getTableEnabled() {
         return tableEnabled;
-    }
-
-    private void setValueTextEnabled(Boolean enabled) {
-        firePropertyChange("valueTextEnabled", valueTextEnabled, valueTextEnabled = enabled);
-    }
-
-    /**
-     * Get whether the value text box is enabled or not. (Used in databinding,
-     * do not delete)
-     * 
-     * @return True if the value is enabled
-     */
-    public Boolean getValueTextEnabled() {
-        return valueTextEnabled;
-    }
-
-    /**
-     * Set the text in the value text box. (Used in databinding, do not delete)
-     * 
-     * @param text
-     *            The text to set the textbox to.
-     */
-    public void setValueText(String text) {
-        tableSelection.setValue(text);
-        updateValueText(text);
-    }
-
-    private void updateValueText(String text) {
-        firePropertyChange("valueText", valueText, valueText = text);
-    }
-
-    /**
-     * Get the value within the value textbox. (Used in databinding, do not
-     * delete)
-     * 
-     * @return The value in the text box.
-     */
-    public String getValueText() {
-        return valueText;
     }
 
     /**


### PR DESCRIPTION

### Description of work

Changed the configure device screen macro value table to work in the same way as the edit synoptic dialog, so the values can be edited directly in the table. Removed the counter-intuitive text box which this functionality makes redundant.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4345

### Acceptance criteria

- [x] Values can be edited in the displayed table.

### Unit tests

Removed everything to do with the old value text box, and replaced with an alternative where relevant.

### Documentation
The [relevant documentation](https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Create-and-Manage-Device-Screens) on this still accurately describes the new functionality, despite the changes.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

