### PR TITLE
Ticket4537 fail build if icon red square

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/plugin.xml
@@ -11,7 +11,7 @@
     </property>
     <property
           name="windowImages"
-          value="../uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web16.gif,../uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web32.gif,../uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web48.gif,../uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web64.gif">
+          value="platform:/plugin/uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web16.gif,platform:/plugin/uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web32.gif,platform:/plugin/uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web48.gif,platform:/plugin/uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web64.gif">
     </property>
     <property
           name="applicationCSS"

--- a/build/check_build.py
+++ b/build/check_build.py
@@ -1,13 +1,18 @@
 import sys
 import os
-import fnmatch
+import xml.etree.ElementTree
 
 SUCCESS = 0
 INCORRECT_ARGS = 1
 NO_BUILD_PROPERTIES = 2
 ICONS_NOT_INCLUDED = 3
+ICON_LOCATION_POINTER_WRONG = 4
 
 exceptions = ["ibex.client.product", "ibex.example", "uk.ac.stfc.isis.ibex.e4.client.product", "uk.ac.stfc.isis.scriptgenerator.client.product"]
+icon_location = "platform:/plugin/uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web16.gif," \
+                "platform:/plugin/uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web32.gif," \
+                "platform:/plugin/uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web48.gif," \
+                "platform:/plugin/uk.ac.stfc.isis.ibex.e4.product/icons/IBEX-icon-web64.gif"
 
 # Walks only a certain number of levels through the directory
 def walklevel(some_dir, level=1):
@@ -36,6 +41,12 @@ def check_icons_in_build_properties(root):
     return True
 
 
+def check_icon_location_pointer_correct(root):
+    tree = xml.etree.ElementTree.parse(os.path.join(root, "plugin.xml"))
+    root = tree.getroot()
+    return len(root.findall(".//property[@value='{}']".format(icon_location))) == 1
+
+
 def main(build_root_path):
     try:
         os.chdir(build_root_path)
@@ -51,6 +62,10 @@ def main(build_root_path):
             if not check_icons_in_build_properties(root):
                 print("ICONS FOLDER NOT INCLUDED IN BUILD PROPERTIES: " + str(root))
                 return ICONS_NOT_INCLUDED
+        if root.endswith("uk.ac.stfc.isis.ibex.e4.client"):
+            if not check_icon_location_pointer_correct(root):
+                print("RED SQUARE ERROR: ICON LOCATION INCORRECT IN {}".format(os.path.join(root, "plugin.xml")))
+                return ICON_LOCATION_POINTER_WRONG
     return SUCCESS
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description of work

- Added a check which fails the build if the icon location pointer is incorrect
- Corrected the icon location

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4537

### Acceptance criteria

- [x] Build passes if location is correct
- [x] Build fails if icon is red square

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

