### PR TITLE
Ticket4605 Fixed switch to new config not working

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewConfigHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewConfigHandler.java
@@ -71,11 +71,10 @@ public class NewConfigHandler extends DisablingConfigHandler<Configuration> {
             if (editDialog.doAsComponent()) {
                 SERVER.saveAsComponent().uncheckedWrite(editDialog.getComponent());
             } else {
+                SERVER.saveAs().uncheckedWrite(editDialog.getConfig());
                 if (editDialog.switchConfigOnSaveAs()) {
-                    SERVER.setCurrentConfig().uncheckedWrite(editDialog.getConfig());
+                    SERVER.load().uncheckedWrite(editDialog.getConfig().name());
                     Configurations.getInstance().addNameToRecentlyLoadedConfigList(editDialog.getConfig().getName());
-                } else {
-                    SERVER.saveAs().uncheckedWrite(editDialog.getConfig());
                 }
             }
         }


### PR DESCRIPTION
### Description of work

The behaviour of `setCurrentConfig()` changed as a result of block server changes, so its use here was now incorrect. Replaced by saving the new config and then loading it.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4605

### Acceptance criteria

- [x] When creating a new config, switch to the new config now loads the new config as expected

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

