### PR TITLE
Add warning for motor-off deadband

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
@@ -6674,11 +6674,11 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>79</width>
+      <width>67</width>
       <wrap_words>true</wrap_words>
       <wuid>152f697f:16915c86179:-7ee4</wuid>
       <x>0</x>
-      <y>15</y>
+      <y>6</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
       <actions hook="true" hook_all="false" />
@@ -6701,8 +6701,8 @@ $(pv_value)</tooltip>
       <foreground_color>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
-      <height>53</height>
-      <horizontal>false</horizontal>
+      <height>25</height>
+      <horizontal>true</horizontal>
       <items_from_pv>true</items_from_pv>
       <name>ChoiceBtn_1</name>
       <pv_name>$(M)_AUTOONOFF_CMD</pv_name>
@@ -6721,10 +6721,10 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
       <visible>true</visible>
       <widget_type>Choice Button</widget_type>
-      <width>66</width>
+      <width>84</width>
       <wuid>152f697f:16915c86179:-7f06</wuid>
-      <x>366</x>
-      <y>5</y>
+      <x>348</x>
+      <y>9</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -6764,8 +6764,8 @@ $(pv_value)</tooltip>
       <width>79</width>
       <wrap_words>true</wrap_words>
       <wuid>152f697f:16915c86179:-7f42</wuid>
-      <x>276</x>
-      <y>16</y>
+      <x>264</x>
+      <y>6</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -6822,8 +6822,8 @@ $(pv_value)</tooltip>
       <widget_type>LED</widget_type>
       <width>25</width>
       <wuid>152f697f:16915c86179:-7ecd</wuid>
-      <x>90</x>
-      <y>19</y>
+      <x>72</x>
+      <y>10</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -6843,8 +6843,8 @@ $(pv_value)</tooltip>
       <foreground_color>
         <color red="192" green="192" blue="192" />
       </foreground_color>
-      <height>53</height>
-      <lock_children>true</lock_children>
+      <height>29</height>
+      <lock_children>false</lock_children>
       <macros>
         <include_parent_macros>true</include_parent_macros>
       </macros>
@@ -6861,10 +6861,10 @@ $(pv_value)</tooltip>
       <transparent>false</transparent>
       <visible>true</visible>
       <widget_type>Grouping Container</widget_type>
-      <width>102</width>
+      <width>145</width>
       <wuid>39f5d54c:16953be7b09:-7eda</wuid>
-      <x>144</x>
-      <y>5</y>
+      <x>108</x>
+      <y>8</y>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <actions hook="false" hook_all="false">
           <action type="WRITE_PV">
@@ -6903,16 +6903,16 @@ $(pv_value)</tooltip>
         </scale_options>
         <scripts />
         <style>1</style>
-        <text>Switch ON</text>
+        <text>Energise</text>
         <toggle_button>false</toggle_button>
         <tooltip>$(pv_name)
 $(pv_value)</tooltip>
         <visible>true</visible>
         <widget_type>Action Button</widget_type>
-        <width>102</width>
+        <width>70</width>
         <wuid>152f697f:16915c86179:-7efa</wuid>
-        <x>0</x>
-        <y>28</y>
+        <x>78</x>
+        <y>0</y>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
         <actions hook="false" hook_all="false">
@@ -6952,17 +6952,66 @@ $(pv_value)</tooltip>
         </scale_options>
         <scripts />
         <style>1</style>
-        <text>Switch OFF</text>
+        <text>De-energise</text>
         <toggle_button>false</toggle_button>
         <tooltip>$(pv_name)
 $(pv_value)</tooltip>
         <visible>true</visible>
         <widget_type>Action Button</widget_type>
-        <width>102</width>
+        <width>70</width>
         <wuid>152f697f:16915c86179:-7ed9</wuid>
         <x>0</x>
         <y>0</y>
       </widget>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Check_Border" red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Arial" height="9" style="0" pixels="false">ISIS_Label_Small</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Shutter_Moving" red="255" green="150" blue="0" />
+      </foreground_color>
+      <height>16</height>
+      <horizontal_alignment>1</horizontal_alignment>
+      <name>Label_9</name>
+      <rules>
+        <rule name="Visibility" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0&lt;-0.001 || pv1==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(M)_CP_SP</pv>
+          <pv trig="true">$(M)_AUTOONOFF_STATUS</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_scrollbar>false</show_scrollbar>
+      <text>Motor off deadband is not small enough, motor may deenergise after move.</text>
+      <tooltip></tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>432</width>
+      <wrap_words>true</wrap_words>
+      <wuid>508aa22e:16c6b3dfde0:-7aa8</wuid>
+      <x>0</x>
+      <y>40</y>
     </widget>
   </widget>
 </display>


### PR DESCRIPTION
### Description of work

Motor deenergise warning 

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4602

### Acceptance criteria

1. Warning should appear for galil motors whose motor off deadband (see galil engineering view) is greater than -0.001 (i.e. 0 is not small enough) and who has automatically de-engise No.

### Unit tests

OPI not needed

### System tests

Not needed

### Documentation

https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Galil-default-parameters
https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Motors-Trouble-Shooting#the-axis-will-not-move-a-message-gets-put-in-the-log-of-begin-not-valid-with-motor-off

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

