### PR TITLE
Ticket3359 Added drag and drop to NICOS script queue

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosQueueContainer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosQueueContainer.java
@@ -1,12 +1,41 @@
+
+/*
+ * This file is part of the ISIS IBEX application. Copyright (C) 2012-2019
+ * Science & Technology Facilities Council. All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful. This program
+ * and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution. EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM AND
+ * ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND. See the Eclipse Public License v1.0 for more
+ * details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0 along with
+ * this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
 package uk.ac.stfc.isis.ibex.ui.nicos;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.annotation.PostConstruct;
 
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.jface.util.LocalSelectionTransfer;
+import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerDropAdapter;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DragSourceAdapter;
+import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.dnd.TransferData;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
@@ -43,6 +72,7 @@ public class NicosQueueContainer {
 	private final DataBindingContext bindingContext = new DataBindingContext();
 	private ScriptStatusViewModel scriptStatusViewModel;
 	private final QueueScriptViewModel queueScriptViewModel;
+	private DataboundTable<QueuedScript> queuedScriptsViewer;
 	
 	/**
 	 * Default constructor.
@@ -92,7 +122,7 @@ public class NicosQueueContainer {
         lblQueuedScriptsSubLabel.setText("(double-click name to view / edit contents)");
         lblQueuedScriptsSubLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 2, 1));
         
-        DataboundTable<QueuedScript> queuedScriptsViewer = new DataboundTable<QueuedScript>(parent, SWT.NONE, SWT.V_SCROLL) {
+        queuedScriptsViewer = new DataboundTable<QueuedScript>(parent, SWT.NONE, SWT.V_SCROLL) {
 			@Override
 			protected void addColumns() {
 				createColumn("Name", 100, new DataboundCellLabelProvider<QueuedScript>(observeProperty("name")) {
@@ -122,6 +152,7 @@ public class NicosQueueContainer {
                 queueScriptViewModel.setSelectedScript(queuedScriptsViewer.firstSelectedRow()));
 
         createQueuedScriptMenu(queuedScriptsViewer.viewer());
+        addDragAndDrop(queuedScriptsViewer.viewer());
         
         Composite moveComposite = new Composite(parent, SWT.NONE);
 	    moveComposite.setLayout(new GridLayout(1, false));
@@ -166,6 +197,52 @@ public class NicosQueueContainer {
         
         bindingContext.bindValue(WidgetProperties.enabled().observe(btnScriptDown), 
         		BeanProperties.value("downButtonEnabled").observe(queueScriptViewModel));
+	}
+	
+	private void addDragAndDrop(TableViewer viewer) {
+	    // support drag and drop
+        int operations = DND.DROP_MOVE;
+        Transfer[] transferTypes = new Transfer[] {LocalSelectionTransfer.getTransfer()};
+        viewer.addDragSupport(operations, transferTypes, new DragSourceAdapter());
+                
+        viewer.addDropSupport(operations, transferTypes, new ViewerDropAdapter(viewer) {
+            
+            @Override
+            public boolean validateDrop(Object target, int operation, TransferData transferType) {
+                // Cannot drop a script onto itself
+                return queuedScriptsViewer.firstSelectedRow() != (QueuedScript) determineTarget(getCurrentEvent());
+            }
+            
+            @Override
+            public boolean performDrop(Object data) {
+                QueuedScript sourceScript = queuedScriptsViewer.firstSelectedRow();
+                List<QueuedScript> queue = new ArrayList<>(queueScriptViewModel.getQueuedScripts());
+                
+                QueuedScript targetScript = (QueuedScript) determineTarget(getCurrentEvent());
+                int location = determineLocation(getCurrentEvent());
+                
+                // If not dropped on to anything, put on the end of the list
+                if (targetScript == null) {
+                    targetScript = queue.get(queue.size() - 1);
+                    location = LOCATION_AFTER;
+                }
+                
+                if (location == LOCATION_BEFORE || location == LOCATION_AFTER || location == LOCATION_ON) {
+                    queue.remove(sourceScript);
+                }
+                
+                int targetPosition = queue.indexOf(targetScript);
+                
+                if (location == LOCATION_AFTER) {
+                    targetPosition++;
+                }
+                
+                queue.add(targetPosition, sourceScript);
+                
+                queueScriptViewModel.sendReorderedList(queue);
+                return true;
+            }
+        });
 	}
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/models/QueueScriptViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/models/QueueScriptViewModel.java
@@ -1,6 +1,6 @@
  /*
  * This file is part of the ISIS IBEX application.
- * Copyright (C) 2012-2016 Science & Technology Facilities Council.
+ * Copyright (C) 2012-2019 Science & Technology Facilities Council.
  * All rights reserved.
  *
  * This program is distributed in the hope that it will be useful.
@@ -250,5 +250,13 @@ public class QueueScriptViewModel extends ModelObject {
      */
     public void saveSelected(Shell shell) {
     	(new SaveScriptAction(shell, selectedScript)).execute();
+    }
+
+    /**
+     * The currently queued scripts.
+     * @return the queued scripts
+     */
+    public List<QueuedScript> getQueuedScripts() {
+        return model.getQueuedScripts();
     }
 }


### PR DESCRIPTION
### Description of work

Added the ability to drag and drop scripts in the queue.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3359

### Acceptance criteria

- [x] Queued scripts can be dragged and dropped to reorder them, and this behaves sensibly and reliably

### Unit tests

N/A

### System tests

N/A

### Documentation
N/A

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

