### PR TITLE
Ticket4647 Fixed bug with being unable to reorder blocks in groups

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/DoubleListEditor.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/DoubleListEditor.java
@@ -1,7 +1,7 @@
 
 /*
 * This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* Copyright (C) 2012-2019 Science & Technology Facilities Council.
 * All rights reserved.
 *
 * This program is distributed in the hope that it will be useful.
@@ -28,8 +28,6 @@ import org.eclipse.jface.databinding.viewers.ObservableMapLabelProvider;
 import org.eclipse.jface.databinding.viewers.ViewerProperties;
 import org.eclipse.jface.viewers.ListViewer;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -42,6 +40,7 @@ import org.eclipse.wb.swt.ResourceManager;
 
 /**
  * The double list editor control.
+ * @param <T> the type of item in the list
  */
 @SuppressWarnings({ "checkstyle:magicnumber", "checkstyle:localvariablename" })
 public class DoubleListEditor<T> extends Composite {
@@ -179,7 +178,7 @@ public class DoubleListEditor<T> extends Composite {
 		String temp = selectedList.getItem(swappingIndex);
 		selectedList.setItem(swappingIndex, selected);
 		selectedList.setItem(selectIndex, temp);
-		selectedList.select(swappingIndex);
+		selectedList.setSelection(swappingIndex);
 		setUpDownEnabled(swappingIndex);
 	}
 	


### PR DESCRIPTION
### Description of work

As title.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4647

### Acceptance criteria

- [ ] Can reorder blocks in a group using the "move down" button.

### Unit tests

N/A

### System tests

N/A

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

