### PR TITLE
Add OPI

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/edwardstic.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/edwardstic.opi
@@ -225,7 +225,7 @@ $(pv_value)</tooltip>
       <name>Text Update</name>
       <precision>2</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):GAUGE1:P</pv_name>
+      <pv_name>$(PV_ROOT):GAUGE1:PRESSURE</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules />
@@ -319,7 +319,7 @@ $(pv_value)</tooltip>
       <name>Text Update</name>
       <precision>2</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):GAUGE2:P</pv_name>
+      <pv_name>$(PV_ROOT):GAUGE2:PRESSURE</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules />
@@ -413,7 +413,7 @@ $(pv_value)</tooltip>
       <name>Text Update</name>
       <precision>2</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT):GAUGE3:P</pv_name>
+      <pv_name>$(PV_ROOT):GAUGE3:PRESSURE</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules />

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/edwardstic.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/edwardstic.opi
@@ -548,26 +548,26 @@ $(pv_value)</tooltip>
       <plot_area_background_color>
         <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
       </plot_area_background_color>
-      <pv_name>$(PV_ROOT):GAUGE2:P</pv_name>
+      <pv_name>$(PV_ROOT):GAUGE1:PRESSURE</pv_name>
       <pv_value />
       <rules>
         <rule name="Gauge1Visibility" prop_id="trace_0_visible" out_exp="false">
           <exp bool_exp="pv0==0">
             <value>false</value>
           </exp>
-          <pv trig="true">$(PV_ROOT):GAUGE1VISIBLE.VAL</pv>
+          <pv trig="true">$(PV_ROOT):GAUGE1VISIBLE</pv>
         </rule>
         <rule name="Gauge2Visibility" prop_id="trace_1_visible" out_exp="false">
           <exp bool_exp="pv0==0">
             <value>false</value>
           </exp>
-          <pv trig="true">$(PV_ROOT):GAUGE2VISIBLE.VAL</pv>
+          <pv trig="true">$(PV_ROOT):GAUGE2VISIBLE</pv>
         </rule>
         <rule name="Gauge3Visibility" prop_id="trace_2_visible" out_exp="false">
           <exp bool_exp="pv0==0">
             <value>false</value>
           </exp>
-          <pv trig="true">$(PV_ROOT):GAUGE3VISIBLE.VAL</pv>
+          <pv trig="true">$(PV_ROOT):GAUGE3VISIBLE</pv>
         </rule>
         <rule name="Gauge1DisablePV" prop_id="trace_0_y_pv" out_exp="false">
           <exp bool_exp="pv0==0">
@@ -585,7 +585,7 @@ $(pv_value)</tooltip>
           <exp bool_exp="pv0==0">
             <value>$(PV_ROOT):DISABLE</value>
           </exp>
-          <pv trig="true">$(PV_ROOT):GAUGE2VISIBLE</pv>
+          <pv trig="true">$(PV_ROOT):GAUGE3VISIBLE</pv>
         </rule>
       </rules>
       <scale_options>
@@ -622,7 +622,7 @@ $(trace_0_y_pv_value)</tooltip>
       <trace_0_x_pv></trace_0_x_pv>
       <trace_0_x_pv_value />
       <trace_0_y_axis_index>1</trace_0_y_axis_index>
-      <trace_0_y_pv>$(PV_ROOT):GAUGE1:P</trace_0_y_pv>
+      <trace_0_y_pv>$(PV_ROOT):GAUGE1:PRESSURE</trace_0_y_pv>
       <trace_0_y_pv_value />
       <trace_1_anti_alias>true</trace_1_anti_alias>
       <trace_1_buffer_size>1000</trace_1_buffer_size>
@@ -643,7 +643,7 @@ $(trace_0_y_pv_value)</tooltip>
       <trace_1_x_pv></trace_1_x_pv>
       <trace_1_x_pv_value />
       <trace_1_y_axis_index>1</trace_1_y_axis_index>
-      <trace_1_y_pv>$(PV_ROOT):GAUGE2:P</trace_1_y_pv>
+      <trace_1_y_pv>$(PV_ROOT):GAUGE2:PRESSURE</trace_1_y_pv>
       <trace_1_y_pv_value />
       <trace_2_anti_alias>true</trace_2_anti_alias>
       <trace_2_buffer_size>1000</trace_2_buffer_size>
@@ -664,7 +664,7 @@ $(trace_0_y_pv_value)</tooltip>
       <trace_2_x_pv></trace_2_x_pv>
       <trace_2_x_pv_value />
       <trace_2_y_axis_index>1</trace_2_y_axis_index>
-      <trace_2_y_pv>$(PV_ROOT):GAUGE3:P</trace_2_y_pv>
+      <trace_2_y_pv>$(PV_ROOT):GAUGE3:PRESSURE</trace_2_y_pv>
       <trace_2_y_pv_value />
       <trace_count>3</trace_count>
       <transparent>true</transparent>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/edwardstic.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/edwardstic.opi
@@ -1,0 +1,681 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
+  <actions hook="false" hook_all="false" />
+  <auto_scale_widgets>
+    <auto_scale_widgets>false</auto_scale_widgets>
+    <min_width>-1</min_width>
+    <min_height>-1</min_height>
+  </auto_scale_widgets>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <background_color>
+    <color red="240" green="240" blue="240" />
+  </background_color>
+  <boy_version>5.1.0.201707071649</boy_version>
+  <foreground_color>
+    <color red="192" green="192" blue="192" />
+  </foreground_color>
+  <grid_space>6</grid_space>
+  <height>600</height>
+  <macros>
+    <include_parent_macros>true</include_parent_macros>
+    <PV_ROOT>$(P)$(EDTIC)</PV_ROOT>
+  </macros>
+  <name></name>
+  <rules />
+  <scripts />
+  <show_close_button>true</show_close_button>
+  <show_edit_range>true</show_edit_range>
+  <show_grid>true</show_grid>
+  <show_ruler>true</show_ruler>
+  <snap_to_geometry>true</snap_to_geometry>
+  <widget_type>Display</widget_type>
+  <width>800</width>
+  <wuid>-24607194:16cf16f9ce1:-8000</wuid>
+  <x>-1</x>
+  <y>-1</y>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color name="ISIS_Title_Background_NEW" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="18" style="1" pixels="false">ISIS_Header1_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>37</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>Edwards Turbo Instrument Controller</text>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>439</width>
+    <wrap_words>true</wrap_words>
+    <wuid>-24607194:16cf16f9ce1:-7f86</wuid>
+    <x>0</x>
+    <y>0</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="14" style="1" pixels="false">ISIS_Header2_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+    </foreground_color>
+    <height>37</height>
+    <horizontal_alignment>0</horizontal_alignment>
+    <name>Label_1</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>false</show_scrollbar>
+    <text>$(NAME)</text>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>775</width>
+    <wrap_words>true</wrap_words>
+    <wuid>-24607194:16cf16f9ce1:-7f85</wuid>
+    <x>0</x>
+    <y>36</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <background_color>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>13</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fc>false</fc>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    </foreground_color>
+    <height>61</height>
+    <lock_children>false</lock_children>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <name>Gauges</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>true</show_scrollbar>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Grouping Container</widget_type>
+    <width>775</width>
+    <wuid>-24607194:16cf16f9ce1:-7f84</wuid>
+    <x>0</x>
+    <y>492</y>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>2</horizontal_alignment>
+      <name>Label_2</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_scrollbar>false</show_scrollbar>
+      <text>Gauge 1:</text>
+      <tooltip>$(pv_name)&#xD;
+$(pv_value)</tooltip>
+      <transparent>false</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>70</width>
+      <wrap_words>true</wrap_words>
+      <wuid>-24607194:16cf16f9ce1:-7f83</wuid>
+      <x>42</x>
+      <y>6</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <auto_size>false</auto_size>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <format_type>2</format_type>
+      <height>20</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>Text Update</name>
+      <precision>2</precision>
+      <precision_from_pv>true</precision_from_pv>
+      <pv_name>$(PV_ROOT):GAUGE1:P</pv_name>
+      <pv_value />
+      <rotation_angle>0.0</rotation_angle>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_units>true</show_units>
+      <text>######</text>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Text Update</widget_type>
+      <width>64</width>
+      <wrap_words>false</wrap_words>
+      <wuid>-24607194:16cf16f9ce1:-7f82</wuid>
+      <x>120</x>
+      <y>6</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>2</horizontal_alignment>
+      <name>Label_17</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_scrollbar>false</show_scrollbar>
+      <text>Gauge 2:</text>
+      <tooltip>$(pv_name)&#xD;
+$(pv_value)</tooltip>
+      <transparent>false</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>70</width>
+      <wrap_words>true</wrap_words>
+      <wuid>-24607194:16cf16f9ce1:-7f80</wuid>
+      <x>285</x>
+      <y>6</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <auto_size>false</auto_size>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <format_type>2</format_type>
+      <height>20</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>Text Update</name>
+      <precision>2</precision>
+      <precision_from_pv>true</precision_from_pv>
+      <pv_name>$(PV_ROOT):GAUGE2:P</pv_name>
+      <pv_value />
+      <rotation_angle>0.0</rotation_angle>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_units>true</show_units>
+      <text>######</text>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Text Update</widget_type>
+      <width>64</width>
+      <wrap_words>false</wrap_words>
+      <wuid>-24607194:16cf16f9ce1:-7f7f</wuid>
+      <x>363</x>
+      <y>6</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>2</horizontal_alignment>
+      <name>Label_17</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_scrollbar>false</show_scrollbar>
+      <text>Gauge 3:</text>
+      <tooltip>$(pv_name)&#xD;
+$(pv_value)</tooltip>
+      <transparent>false</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>70</width>
+      <wrap_words>true</wrap_words>
+      <wuid>-24607194:16cf16f9ce1:-7f7e</wuid>
+      <x>528</x>
+      <y>6</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <auto_size>false</auto_size>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <format_type>2</format_type>
+      <height>20</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>Text Update</name>
+      <precision>2</precision>
+      <precision_from_pv>true</precision_from_pv>
+      <pv_name>$(PV_ROOT):GAUGE3:P</pv_name>
+      <pv_value />
+      <rotation_angle>0.0</rotation_angle>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_units>true</show_units>
+      <text>######</text>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Text Update</widget_type>
+      <width>64</width>
+      <wrap_words>false</wrap_words>
+      <wuid>-24607194:16cf16f9ce1:-7f7d</wuid>
+      <x>606</x>
+      <y>6</y>
+    </widget>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <background_color>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>13</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fc>false</fc>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    </foreground_color>
+    <height>421</height>
+    <lock_children>false</lock_children>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <name>Graph</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <show_scrollbar>true</show_scrollbar>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Grouping Container</widget_type>
+    <width>775</width>
+    <wuid>-24607194:16cf16f9ce1:-7f78</wuid>
+    <x>0</x>
+    <y>72</y>
+    <widget typeId="org.csstudio.opibuilder.widgets.xyGraph" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <axis_0_auto_scale>true</axis_0_auto_scale>
+      <axis_0_auto_scale_threshold>0.0</axis_0_auto_scale_threshold>
+      <axis_0_axis_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </axis_0_axis_color>
+      <axis_0_axis_title>Time</axis_0_axis_title>
+      <axis_0_dash_grid_line>true</axis_0_dash_grid_line>
+      <axis_0_grid_color>
+        <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
+      </axis_0_grid_color>
+      <axis_0_log_scale>false</axis_0_log_scale>
+      <axis_0_maximum>120.0</axis_0_maximum>
+      <axis_0_minimum>0.0</axis_0_minimum>
+      <axis_0_scale_font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GraphScale_NEW</opifont.name>
+      </axis_0_scale_font>
+      <axis_0_scale_format></axis_0_scale_format>
+      <axis_0_show_grid>true</axis_0_show_grid>
+      <axis_0_time_format>5</axis_0_time_format>
+      <axis_0_title_font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_GraphLabels_NEW</opifont.name>
+      </axis_0_title_font>
+      <axis_0_visible>true</axis_0_visible>
+      <axis_1_auto_scale>true</axis_1_auto_scale>
+      <axis_1_auto_scale_threshold>0.0</axis_1_auto_scale_threshold>
+      <axis_1_axis_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </axis_1_axis_color>
+      <axis_1_axis_title>Pressure</axis_1_axis_title>
+      <axis_1_dash_grid_line>true</axis_1_dash_grid_line>
+      <axis_1_grid_color>
+        <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
+      </axis_1_grid_color>
+      <axis_1_log_scale>true</axis_1_log_scale>
+      <axis_1_maximum>50.0</axis_1_maximum>
+      <axis_1_minimum>0.0</axis_1_minimum>
+      <axis_1_scale_font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GraphScale_NEW</opifont.name>
+      </axis_1_scale_font>
+      <axis_1_scale_format></axis_1_scale_format>
+      <axis_1_show_grid>true</axis_1_show_grid>
+      <axis_1_time_format>0</axis_1_time_format>
+      <axis_1_title_font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_GraphLabels_NEW</opifont.name>
+      </axis_1_title_font>
+      <axis_1_visible>true</axis_1_visible>
+      <axis_count>2</axis_count>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>391</height>
+      <name>XY Graph</name>
+      <plot_area_background_color>
+        <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
+      </plot_area_background_color>
+      <pv_name>$(PV_ROOT):GAUGE2:P</pv_name>
+      <pv_value />
+      <rules>
+        <rule name="Gauge1Visibility" prop_id="trace_0_visible" out_exp="false">
+          <exp bool_exp="pv0==0">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT):GAUGE1VISIBLE.VAL</pv>
+        </rule>
+        <rule name="Gauge2Visibility" prop_id="trace_1_visible" out_exp="false">
+          <exp bool_exp="pv0==0">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT):GAUGE2VISIBLE.VAL</pv>
+        </rule>
+        <rule name="Gauge3Visibility" prop_id="trace_2_visible" out_exp="false">
+          <exp bool_exp="pv0==0">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT):GAUGE3VISIBLE.VAL</pv>
+        </rule>
+        <rule name="Gauge1DisablePV" prop_id="trace_0_y_pv" out_exp="false">
+          <exp bool_exp="pv0==0">
+            <value>$(PV_ROOT):DISABLE</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT):GAUGE1VISIBLE</pv>
+        </rule>
+        <rule name="Gauge2DisablePV" prop_id="trace_1_y_pv" out_exp="false">
+          <exp bool_exp="pv0==0">
+            <value>$(PV_ROOT):DISABLE</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT):GAUGE2VISIBLE</pv>
+        </rule>
+        <rule name="Gauge3DisablePV" prop_id="trace_2_y_pv" out_exp="false">
+          <exp bool_exp="pv0==0">
+            <value>$(PV_ROOT):DISABLE</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT):GAUGE2VISIBLE</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_legend>true</show_legend>
+      <show_plot_area_border>false</show_plot_area_border>
+      <show_toolbar>false</show_toolbar>
+      <title></title>
+      <title_font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_GraphLabels_NEW</opifont.name>
+      </title_font>
+      <tooltip>$(trace_0_y_pv)
+$(trace_0_y_pv_value)</tooltip>
+      <trace_0_anti_alias>true</trace_0_anti_alias>
+      <trace_0_buffer_size>1000</trace_0_buffer_size>
+      <trace_0_concatenate_data>true</trace_0_concatenate_data>
+      <trace_0_line_width>1</trace_0_line_width>
+      <trace_0_name>Gauge 1</trace_0_name>
+      <trace_0_plot_mode>0</trace_0_plot_mode>
+      <trace_0_point_size>4</trace_0_point_size>
+      <trace_0_point_style>0</trace_0_point_style>
+      <trace_0_trace_color>
+        <color name="ISIS_Trace_1_NEW" red="0" green="0" blue="255" />
+      </trace_0_trace_color>
+      <trace_0_trace_type>0</trace_0_trace_type>
+      <trace_0_update_delay>100</trace_0_update_delay>
+      <trace_0_update_mode>4</trace_0_update_mode>
+      <trace_0_visible>true</trace_0_visible>
+      <trace_0_x_axis_index>0</trace_0_x_axis_index>
+      <trace_0_x_pv></trace_0_x_pv>
+      <trace_0_x_pv_value />
+      <trace_0_y_axis_index>1</trace_0_y_axis_index>
+      <trace_0_y_pv>$(PV_ROOT):GAUGE1:P</trace_0_y_pv>
+      <trace_0_y_pv_value />
+      <trace_1_anti_alias>true</trace_1_anti_alias>
+      <trace_1_buffer_size>1000</trace_1_buffer_size>
+      <trace_1_concatenate_data>true</trace_1_concatenate_data>
+      <trace_1_line_width>1</trace_1_line_width>
+      <trace_1_name>Gauge 2</trace_1_name>
+      <trace_1_plot_mode>0</trace_1_plot_mode>
+      <trace_1_point_size>4</trace_1_point_size>
+      <trace_1_point_style>0</trace_1_point_style>
+      <trace_1_trace_color>
+        <color name="ISIS_Trace_2_NEW" red="196" green="0" blue="0" />
+      </trace_1_trace_color>
+      <trace_1_trace_type>0</trace_1_trace_type>
+      <trace_1_update_delay>100</trace_1_update_delay>
+      <trace_1_update_mode>4</trace_1_update_mode>
+      <trace_1_visible>true</trace_1_visible>
+      <trace_1_x_axis_index>0</trace_1_x_axis_index>
+      <trace_1_x_pv></trace_1_x_pv>
+      <trace_1_x_pv_value />
+      <trace_1_y_axis_index>1</trace_1_y_axis_index>
+      <trace_1_y_pv>$(PV_ROOT):GAUGE2:P</trace_1_y_pv>
+      <trace_1_y_pv_value />
+      <trace_2_anti_alias>true</trace_2_anti_alias>
+      <trace_2_buffer_size>1000</trace_2_buffer_size>
+      <trace_2_concatenate_data>true</trace_2_concatenate_data>
+      <trace_2_line_width>1</trace_2_line_width>
+      <trace_2_name>Gauge 3</trace_2_name>
+      <trace_2_plot_mode>0</trace_2_plot_mode>
+      <trace_2_point_size>4</trace_2_point_size>
+      <trace_2_point_style>0</trace_2_point_style>
+      <trace_2_trace_color>
+        <color name="ISIS_Trace_3_NEW" red="0" green="226" blue="0" />
+      </trace_2_trace_color>
+      <trace_2_trace_type>0</trace_2_trace_type>
+      <trace_2_update_delay>100</trace_2_update_delay>
+      <trace_2_update_mode>4</trace_2_update_mode>
+      <trace_2_visible>true</trace_2_visible>
+      <trace_2_x_axis_index>0</trace_2_x_axis_index>
+      <trace_2_x_pv></trace_2_x_pv>
+      <trace_2_x_pv_value />
+      <trace_2_y_axis_index>1</trace_2_y_axis_index>
+      <trace_2_y_pv>$(PV_ROOT):GAUGE3:P</trace_2_y_pv>
+      <trace_2_y_pv_value />
+      <trace_count>3</trace_count>
+      <transparent>true</transparent>
+      <trigger_pv>$(P)CS:IOC:$(EDTIC):DEVIOS:HEARTBEAT</trigger_pv>
+      <trigger_pv_value />
+      <visible>true</visible>
+      <widget_type>XY Graph</widget_type>
+      <width>745</width>
+      <wuid>-24607194:16cf16f9ce1:-7f77</wuid>
+      <x>0</x>
+      <y>0</y>
+    </widget>
+  </widget>
+</display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -2183,5 +2183,23 @@
         </macros>
       </value>
     </entry>
+    <entry>
+      <key>Edwards Turbo Instrument Controller</key>
+      <value>
+      	<type>PUMP</type>
+      	<path>edwardstic.opi</path>
+      	<description>The OPI for the Edwards Turbo Instrument Controller</description>
+        <categories>
+          <category>Gas and liquid handling systems</category>
+        </categories>
+        <macros>
+          <macro>
+            <name>EDTIC</name>
+            <description>The EDTIC PV prefix (e.g. EDTIC_01)</description>
+          	<default>EDTIC_01</default>
+          </macro>
+        </macros>
+      </value>
+    </entry>
   </opis>
 </descriptions>


### PR DESCRIPTION
### Description of work

Adds OPI for edwards turbo instrument controller

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4011

### Acceptance criteria

- [ ] The value of each gauge is readable on the OPI
- [ ] Each gauge can be turned off in the IOC. The OPI graph will not display disabled traces but the graph does not read disabled
- [ ] OPI tests pass

### Unit tests

N/A, this is only an OPI

### System tests

N/A, this is only an OPI

### Documentation
This is the documentation for the device:

https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Edwards-Turbo-Instrument-Controller

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

