### PR TITLE
Add python argument not to import entire site module to each interpreter

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
+++ b/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
@@ -18,6 +18,7 @@
       <vmArgs>-Xms40m 
 -Xmx512m
 -Dpython.console.encoding=UTF-8
+-Dpython.import.site=false
 -XX:+CreateCoredumpOnCrash
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts


### PR DESCRIPTION
### Description of work

Make jaws manager much faster. The option I've added tells jython not to load all "site packages" (i.e. modules we've pip installed) every time it starts. I've checked the OPIs which use non-standard scripts, and they appear to load correctly with this option enabled.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4668

### Acceptance criteria

On master, point at NIMROD and open their jaws manager screen. Time this (on my machine it takes 10+ seconds).

On this branch, do the same. Should be less than 1s (not really measurable manually)

### Unit tests

n/a, configuration change only

### System tests

If anyone has ideas about how to automatically system test this I'm open to ideas. I think using squish will be hard because:
- Getting into the OPI layers from squish is fiddly
- It will be very prone to race conditions

I will add a manual system test once this is merged

### Documentation

n/a

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

