### PR TITLE
Config now can be created without having to fill in macro values for IOCs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/tests/MacroViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/tests/MacroViewModelTest.java
@@ -98,7 +98,7 @@ public class MacroViewModelTest {
         
         boolean useDefault = macroViewModel.getUseDefault();
         
-        assertFalse(useDefault);
+        assertTrue(useDefault);
     }
     
     @Test
@@ -129,7 +129,7 @@ public class MacroViewModelTest {
         
         macroViewModel.setUseDefault(true);
         
-        assertEquals(null, m.getValue());
+        assertEquals("", m.getValue());
     }
     
     @Test
@@ -160,7 +160,7 @@ public class MacroViewModelTest {
         
         macroViewModel.setUseDefault(true);
         
-        assertEquals(null, m.getValue());
+        assertEquals("", m.getValue());
     }
     
     @Test
@@ -170,6 +170,6 @@ public class MacroViewModelTest {
         
         macroViewModel.setUseDefault(true);
         
-        assertEquals(null, m.getValue());
+        assertEquals("", m.getValue());
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroViewModel.java
@@ -105,10 +105,10 @@ public class MacroViewModel extends ModelObject {
 	 * @return macro value for displaying to the user
 	 */
 	public String getDisplayValue() {
-		String macroDispalyVal = "(default)";
+		String macroDisplayVal = "(default)";
 		if (macro.getValue() != "") {
-			macroDispalyVal = macro.getValue();
+			macroDisplayVal = macro.getValue();
 		}
-		return macroDispalyVal;
+		return macroDisplayVal;
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroViewModel.java
@@ -11,37 +11,37 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
  */
 public class MacroViewModel extends ModelObject {
 	private final Macro macro;
-	
+
 	/**
 	 * Whether the default value should be used or not.
 	 */
 	private boolean useDefault;
-	
+
 	/**
 	 * Constructor. Sets the use default based on provided macro.
+	 * 
 	 * @param macro The underlying macro for this view model.
 	 */
 	public MacroViewModel(Macro macro) {
 		this.macro = macro;
 		macro.addPropertyChangeListener("value", passThrough());
-
-		setUseDefault(macro.getValue() == null);
+		setUseDefault((macro.getValue() == null) || (macro.getValue().equals("")));
 	}
-	
-	 /**
-     * @return macro description
-     */
+
+	/**
+	 * @return macro description
+	 */
 	public String getDescription() {
 		return macro.getDescription();
 	}
-	
+
 	/**
 	 * @return macro name
 	 */
 	public String getName() {
 		return macro.getName();
 	}
-	
+
 	/**
 	 * Set Macro value.
 	 * 
@@ -50,57 +50,58 @@ public class MacroViewModel extends ModelObject {
 	public void setValue(String value) {
 		macro.setValue(value);
 	}
-	
+
 	/**
-     * @return macro regex pattern
-     */
+	 * @return macro regex pattern
+	 */
 	public String getPattern() {
 		return macro.getPattern();
 	}
 
-    /**
-     * @return whether the default value should be used or not
-     */
-    public boolean getUseDefault() {
-        return useDefault;
-    }
+	/**
+	 * @return whether the default value should be used or not
+	 */
+	public boolean getUseDefault() {
+		return useDefault;
+	}
 
-    /**
-     * Sets whether the default value is being used. 
-     * 
-     * The underlying macro value must be set to null if the default is being used.
-     * If we were using the default and now we're not set the value to empty string.
-     * 
-     * @param useDefault whether the default value should be used or not
-     */
-    public void setUseDefault(boolean useDefault) {
-    	if (useDefault) {
-    		macro.setValue(null);
-    	} else if (this.useDefault) {
-    		macro.setValue("");
-    	}
-        firePropertyChange("useDefault", this.useDefault, this.useDefault = useDefault);
-    }
-	
-    /**
-     * @return default macro value for displaying to the user
-     */
-    public String getDisplayDefault() {
-    	HasDefault hasDefault = macro.getHasDefault();
-    	String macroDefaultValue = macro.getDefaultValue();
-        if (hasDefault == HasDefault.YES) {
-            return macroDefaultValue.equals("") ? "(default is the empty string)" : macroDefaultValue;
-        } else if (hasDefault == HasDefault.NO) {
-            return "(no default)";
-        } else {
-            return "(default unknown)";
-        }
-    }
-	
+	/**
+	 * 
+	 * Sets whether the default value should be used or not
+	 * If the value is null we now need to set it to empty string or else it will not be
+	 * sent over to the block server.
+	 * @param useDefault whether the default value should be used or not
+	 */
+	public void setUseDefault(boolean useDefault) {
+		if (useDefault) {
+			macro.setValue("");
+		}
+		firePropertyChange("useDefault", this.useDefault, this.useDefault = useDefault);
+	}
+
+	/**
+	 * @return default macro value for displaying to the user
+	 */
+	public String getDisplayDefault() {
+		HasDefault hasDefault = macro.getHasDefault();
+		String macroDefaultValue = macro.getDefaultValue();
+		if (hasDefault == HasDefault.YES) {
+			return macroDefaultValue.equals("") ? "(default is the empty string)" : macroDefaultValue;
+		} else if (hasDefault == HasDefault.NO) {
+			return "(no default)";
+		} else {
+			return "(default unknown)";
+		}
+	}
+
 	/**
 	 * @return macro value for displaying to the user
 	 */
 	public String getDisplayValue() {
-	    return Optional.ofNullable(macro.getValue()).orElse("(default)");
+		String macroDispalyVal = "(default)";
+		if (macro.getValue() != "") {
+			macroDispalyVal = macro.getValue();
+		}
+		return macroDispalyVal;
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroViewModel.java
@@ -50,6 +50,13 @@ public class MacroViewModel extends ModelObject {
 	public void setValue(String value) {
 		macro.setValue(value);
 	}
+	
+	/**
+	 * @return macro value.
+	 */
+	public String getValue() {
+		return macro.getValue();
+	}
 
 	/**
 	 * @return macro regex pattern


### PR DESCRIPTION
### Description of work

Creating config without having to fill in macro values was causing an error and not end up saving the config. The config can now be saved without having to fill in the macro values and no errors from the block server.

### Ticket

[#4904] (https://github.com/ISISComputingGroup/IBEX/issues/4904)

### Acceptance criteria

-[ ] Does saving the config without macro values filled in for IOCs give any error on the block server?
-[ ] Does saving the config without macro values filled in actually save the config?

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

