### PR TITLE
Disable concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,6 +94,7 @@ pipeline {
   options {
     buildDiscarder(logRotator(numToKeepStr:'10'))
     timeout(time: 60, unit: 'MINUTES')
+    disableConcurrentBuilds()
   }
 }
 


### PR DESCRIPTION
### Description of work

Add disableConcurrentBuilds() (as in genie python) - may be cause of all these extra builds? No sure why it would start happening now though

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

