### PR TITLE
Separate out activation of bundle from start of Python process

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: uk.ac.stfc.isis.ibex.scriptgenerator.tests
 Bundle-Version: 1.0.0.qualifier
+Fragment-Host: uk.ac.stfc.isis.ibex.scriptgenerator;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.mockito;bundle-version="1.9.5",
@@ -11,6 +12,5 @@ Require-Bundle: org.junit;bundle-version="4.11.0",
  org.hamcrest.generator;bundle-version="1.3.0",
  org.hamcrest.integration;bundle-version="1.3.0",
  org.hamcrest.library;bundle-version="1.3.0",
- org.hamcrest.text;bundle-version="1.1.0",
- uk.ac.stfc.isis.ibex.scriptgenerator;bundle-version="1.0.0"
+ org.hamcrest.text;bundle-version="1.1.0"
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.scriptgenerator.tests

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Tests
 Bundle-SymbolicName: uk.ac.stfc.isis.ibex.scriptgenerator.tests
 Bundle-Version: 1.0.0.qualifier
-Fragment-Host: uk.ac.stfc.isis.ibex.scriptgenerator;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.mockito;bundle-version="1.9.5",
@@ -12,5 +11,6 @@ Require-Bundle: org.junit;bundle-version="4.11.0",
  org.hamcrest.generator;bundle-version="1.3.0",
  org.hamcrest.integration;bundle-version="1.3.0",
  org.hamcrest.library;bundle-version="1.3.0",
- org.hamcrest.text;bundle-version="1.1.0"
+ org.hamcrest.text;bundle-version="1.1.0",
+ uk.ac.stfc.isis.ibex.scriptgenerator;bundle-version="1.0.0"
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.scriptgenerator.tests

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/Activator.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/Activator.java
@@ -45,6 +45,7 @@ public class Activator implements BundleActivator {
 	@Override
 	public void start(BundleContext bundleContext) throws Exception {
 		Activator.context = bundleContext;
+		MODEL = new ScriptGeneratorSingleton();
 	}
 
 	/*
@@ -66,6 +67,6 @@ public class Activator implements BundleActivator {
     	return MODEL; 
     }
 
-    private static ScriptGeneratorSingleton MODEL = new ScriptGeneratorSingleton();
+    private static ScriptGeneratorSingleton MODEL;
 
 }

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/Activator.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/Activator.java
@@ -29,6 +29,7 @@ import org.osgi.framework.BundleContext;
 public class Activator implements BundleActivator {
 
 	private static BundleContext context;
+	private static ScriptGeneratorSingleton MODEL;
 	
 	/**
      * 
@@ -66,7 +67,4 @@ public class Activator implements BundleActivator {
     public static ScriptGeneratorSingleton getModel() { 
     	return MODEL; 
     }
-
-    private static ScriptGeneratorSingleton MODEL;
-
 }

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -120,7 +120,8 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	private static final Logger LOG = IsisLog.getLogger(ScriptGeneratorSingleton.class);
 	
 	/**
-	 * The constructor, will create a config loader and load an initial config.
+	 * The constructor, will create without a config loader and without loading
+	 * an initial config.
 	 */
 	public ScriptGeneratorSingleton() {
 	    

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -122,7 +122,9 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	/**
 	 * The constructor, will create a config loader and load an initial config.
 	 */
-	public ScriptGeneratorSingleton() {}
+	public ScriptGeneratorSingleton() {
+	    
+	}
 	
 	/**
 	 * Pass a python interface to run with, then create a config loader and load an initial config.
@@ -137,7 +139,8 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	}
 	
 	/**
-	 * Called by the constructors to set up the class.
+	 * Called by the constructor with three arguments during tests or in the View
+	 * Model constructor to set up the class.
 	 * Set up listeners for the generator.
 	 */
 	public void setUp() {
@@ -173,7 +176,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	}
 	
 	/**
-     * Create the config loader.
+     * Creates the config loader.
      */
     public void createConfigLoader() {
         pythonInterface = new PythonInterface();

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -121,6 +121,14 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	private static final Logger LOG = IsisLog.getLogger(ScriptGeneratorSingleton.class);
 	
 	/**
+	 * Create the config loader.
+	 */
+	public void createConfigLoader() {
+		pythonInterface = new PythonInterface();
+		configLoader = new ConfigLoader(pythonInterface);
+	}
+	
+	/**
 	 * Get the config loader.
 	 * 
 	 * @return The config loader
@@ -132,11 +140,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	/**
 	 * The constructor, will create a config loader and load an initial config.
 	 */
-	public ScriptGeneratorSingleton() {
-		pythonInterface = new PythonInterface();
-		configLoader = new ConfigLoader(pythonInterface);
-		setUp();
-	}
+	public ScriptGeneratorSingleton() {}
 	
 	/**
 	 * Pass a python interface to run with, then create a config loader and load an initial config.
@@ -154,7 +158,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	 * Called by the constructors to set up the class.
 	 * Set up listeners for the generator.
 	 */
-	private void setUp() {
+	public void setUp() {
 		generator = new GeneratorContext(pythonInterface);
 		// If the validity error message property of the generator is changed update the
 		// validity errors in the scriptGeneratorTable

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Logger;
 
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 import uk.ac.stfc.isis.ibex.scriptgenerator.generation.GeneratorContext;
 import uk.ac.stfc.isis.ibex.scriptgenerator.generation.UnsupportedLanguageException;
@@ -36,8 +37,6 @@ import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ConfigLoader;
 import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.PythonInterface;
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ActionsTable;
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
-import uk.ac.stfc.isis.ibex.scriptgenerator.ActionParameter;
-import uk.ac.stfc.isis.ibex.logger.IsisLog;
 
 /**
  * The Model of the script generator responsible for generating scripts, checking parameter validity, loading configs
@@ -121,23 +120,6 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	private static final Logger LOG = IsisLog.getLogger(ScriptGeneratorSingleton.class);
 	
 	/**
-	 * Create the config loader.
-	 */
-	public void createConfigLoader() {
-		pythonInterface = new PythonInterface();
-		configLoader = new ConfigLoader(pythonInterface);
-	}
-	
-	/**
-	 * Get the config loader.
-	 * 
-	 * @return The config loader
-	 */
-	public ConfigLoader getConfigLoader() {
-		return configLoader;
-	}
-	
-	/**
 	 * The constructor, will create a config loader and load an initial config.
 	 */
 	public ScriptGeneratorSingleton() {}
@@ -189,6 +171,23 @@ public class ScriptGeneratorSingleton extends ModelObject {
 		
 		setActionParameters(configLoader.getParameters());
 	}
+	
+	/**
+     * Create the config loader.
+     */
+    public void createConfigLoader() {
+        pythonInterface = new PythonInterface();
+        configLoader = new ConfigLoader(pythonInterface);
+    }
+    
+    /**
+     * Get the config loader.
+     * 
+     * @return The config loader
+     */
+    public ConfigLoader getConfigLoader() {
+        return configLoader;
+    }
 	
 	/**
 	 * Convert the VALIDITY_ERROR_MESSAGE_PROPERTY return to the Map<Integer, String> representation.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
@@ -188,6 +188,7 @@ public class PythonInterface extends ModelObject {
 	 * @throws IOException If actionLoaderPythonScript not found.
 	 */
 	public void setUpPythonThread(String actionLoaderPythonScript) throws IOException {
+		LOG.info("Launching python process");
 		clientServer = createClientServer();
 		pythonProcess = startPythonProcess(clientServer, python3InterpreterPath(), actionLoaderPythonScript);
 		new Thread(listenToErrors).start();

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -107,7 +107,10 @@ public class ScriptGeneratorViewModel {
 	 *   begins listening to property changes in the model.
 	 */
 	public ScriptGeneratorViewModel() {
+		// Set up the model
 		scriptGeneratorModel = Activator.getModel();
+		scriptGeneratorModel.createConfigLoader();
+		scriptGeneratorModel.setUp();
 		// Listen to whether the language support is changed
 		// notify the user if the language is not supported
 		scriptGeneratorModel.addPropertyChangeListener(LANGUAGE_SUPPORT_PROPERTY, evt -> {


### PR DESCRIPTION
### Description of work

Script generator pipeline was failling because it could not find Python when running tests, but it shouldn't be trying to start it. Stopping it from running these in tests.

### Ticket

*Link to Ticket*

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

