### PR TITLE
added new macro value validator check for validating length of macro

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroValueValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroValueValidator.java
@@ -64,7 +64,7 @@ public class MacroValueValidator extends ModelObject implements IValidator<Strin
 	 */
 	public static final String MAXIMUM_CHARACTER_LENGTH_LIMIT_MESSAGE = "Value cannot be longer than 255 characters";
 	
-	private final int MAXIMUM_CHARACTER_LIMIT = 1000;
+	private final int MAXIMUM_CHARACTER_LIMIT = 256;
 
 	private final Label messageDisplayer;
 	private MacroViewModel macro;

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroValueValidator.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroValueValidator.java
@@ -59,7 +59,13 @@ public class MacroValueValidator extends ModelObject implements IValidator<Strin
      * The message that is displayed when the regex pattern is invalid.
      */
 	public static final String PATTERN_INVALID = "Macro regex pattern invalid";
+	/**
+	 * The message that is displayed when the value is longer than 255 character
+	 */
+	public static final String MAXIMUM_CHARACTER_LENGTH_LIMIT_MESSAGE = "Value cannot be longer than 255 characters";
 	
+	private final int MAXIMUM_CHARACTER_LIMIT = 1000;
+
 	private final Label messageDisplayer;
 	private MacroViewModel macro;
 	private boolean nameIsValid = true;
@@ -92,6 +98,9 @@ public class MacroValueValidator extends ModelObject implements IValidator<Strin
             } else if (!matchesPattern(text)) {
 				setShowWarningIcon(true);
 				returnStatus = setError(PATTERN_MISMATCH_MESSAGE);
+			} else if (text.length() >= MAXIMUM_CHARACTER_LIMIT) {
+				setShowWarningIcon(true);
+				returnStatus = setError(MAXIMUM_CHARACTER_LENGTH_LIMIT_MESSAGE);
 			} else {
 				returnStatus = setNoError();
 			}


### PR DESCRIPTION
### Description of work

GUI Now validates the length of macro too

### Ticket

[#4934](https://github.com/ISISComputingGroup/IBEX/issues/4934)

### Acceptance criteria

- [x] GUI displays a warning when the macro value is too longer than 40 characters for the following:

    - IOC = DFKPS, Macro = CALIB_FILE
    - IOC = CCD100, Macro = DEV_NAME
    - IOC = TRITON, Macro = RAMP_FILE_NAME
 
- [x] The new Default length for the Macro Value is 256 characters

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

