### PR TITLE
Script gen run script

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/defined_actions/templates/generator_template.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/defined_actions/templates/generator_template.py
@@ -1,6 +1,6 @@
 {% include inserted_config %}
 
-def do_run():
+def runscript():
     config = DoRun()
     {% for action in script_generator_actions -%}
     config.run(**{{ action }})

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/defined_actions/test_generator.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/defined_actions/test_generator.py
@@ -78,7 +78,7 @@ class DoRun(ActionDefinition):
             return None
 
 
-def do_run():
+def runscript():
     config = DoRun()
     config.run(**{'param1': '1', 'param2': '2'})
     config.run(**{'param1': '1', 'param2': '2'})


### PR DESCRIPTION
The muons wanted do_run to be renamed to runscript. As this is so early on and the name seemed generic enough we decided to swap this out.