### PR TITLE
Link to shadow instead of github

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/fermi_chopper.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/fermi_chopper.opi
@@ -4162,7 +4162,7 @@ $(pv_value)</tooltip>
               <path/>
               <scriptText>import webbrowser
 
-webbrowser.open("https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/FZJ_Fermi_chopper")
+webbrowser.open("http://shadow.nd.rl.ac.uk/ibex_user_manual/FZJ-Fermi-Chopper")
 </scriptText>
               <embedded>true</embedded>
               <description/>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/kepco.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/kepco.opi
@@ -499,7 +499,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="true" hook_all="false">
         <action type="OPEN_WEBPAGE">
-          <hyperlink>https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Kepco</hyperlink>
+          <hyperlink>http://shadow.nd.rl.ac.uk/ibex_user_manual/Kepco-Power-Supply</hyperlink>
           <description>Kepco IOC specific information</description>
         </action>
       </actions>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/matplotlib.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/matplotlib.opi
@@ -71,7 +71,7 @@
         <path/>
         <scriptText>import webbrowser
 
-webbrowser.open("https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Matplotlib")
+webbrowser.open("http://shadow.nd.rl.ac.uk/ibex_user_manual/Matplotlib")
 </scriptText>
         <embedded>true</embedded>
         <description/>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/template.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/template.opi
@@ -4049,7 +4049,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="true" hook_all="false">
         <action type="OPEN_WEBPAGE">
-          <hyperlink>https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Kepco</hyperlink>
+          <hyperlink>http://shadow.nd.rl.ac.uk/ibex_user_manual/Kepco-Power-Supply</hyperlink>
           <description>Kepco IOC specific information</description>
         </action>
       </actions>


### PR DESCRIPTION
### Description of work

Device specific documentation has been migrated off of github to the internal user manual. This PR is to update the links in relevant OPIs accordingly.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5112

### Acceptance criteria

Links to info pages from Matplotlib, Fermi Chopper and Kepco OPIs still work and lead to pages in the user manual.