### PR TITLE
groups with all hidden blocks behave correctly

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/GroupsPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/GroupsPanel.java
@@ -151,7 +151,7 @@ public class GroupsPanel extends Composite {
 	 */
 	public synchronized void updateGroups(final Optional<List<DisplayGroup>> groups) {
 		
-		this.displayGroups = HiddenGroupFilter.getVisibleGroups(groups, showHiddenBlocks);
+		this.displayGroups = groups;
 		
 		display.syncExec(new Runnable() {
 			@Override
@@ -194,7 +194,8 @@ public class GroupsPanel extends Composite {
 	}
 	
 	private void addGroups() {
-		for (DisplayGroup group : displayGroups.orElseThrow(IllegalStateException::new)) {
+		Optional<List<DisplayGroup>> visibleGroups = HiddenGroupFilter.getVisibleGroups(displayGroups, showHiddenBlocks);
+		for (DisplayGroup group : visibleGroups.orElseThrow(IllegalStateException::new)) {
 		    groups.add(groupWidget(group));
 		}
 	}


### PR DESCRIPTION
### Description of work

Fixed the visibility of groups containing all hidden blocks. Found (again) during manual system testing.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/3334

### Acceptance criteria

- When there are other blocks that are visible in the config, and show hidden is `false`, Groups containing all hidden blocks now _do not_ get displayed as a blank group in the panel
- When there are no other blocks that are visible in the config, and show hidden is `true`, Groups containing all hidden blocks now _do_ get displayed in the panel

### Unit tests

/

### System tests

/

### Documentation

/

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

