### PR TITLE
Ticket5116 dae spectra plots ns

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plot.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plot.opi
@@ -284,15 +284,7 @@ $(trace_0_y_pv_value)</tooltip>
     <y>-6</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.combo" version="1.0.0">
-    <actions hook="false" hook_all="false">
-      <action type="EXECUTE_PYTHONSCRIPT">
-        <path>spectra_plots_mode.py</path>
-        <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
-]]></scriptText>
-        <embedded>false</embedded>
-        <description></description>
-      </action>
-    </actions>
+    <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
@@ -313,10 +305,7 @@ $(trace_0_y_pv_value)</tooltip>
       <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>32</height>
-    <items>
-      <s>counts/us</s>
-      <s>counts</s>
-    </items>
+    <items />
     <items_from_pv>false</items_from_pv>
     <name>Combo</name>
     <pv_name>$(MODE_PV$(NUMBER))</pv_name>
@@ -330,6 +319,7 @@ $(trace_0_y_pv_value)</tooltip>
     <scripts>
       <path pathString="spectra_plots_mode.py" checkConnect="true" sfe="false" seoe="false">
         <pv trig="true">$(P)DAE:SPEC:1:1:Y.EGU</pv>
+        <pv trig="false">$(MODE_PV$(NUMBER))</pv>
       </path>
     </scripts>
     <tooltip>$(pv_name)

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plot.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plot.opi
@@ -58,7 +58,7 @@
       <opifont.name fontName="Segoe UI" height="11" style="1" pixels="false">Header 3</opifont.name>
     </axis_0_title_font>
     <axis_0_visible>true</axis_0_visible>
-    <axis_1_auto_scale>false</axis_1_auto_scale>
+    <axis_1_auto_scale>true</axis_1_auto_scale>
     <axis_1_auto_scale_threshold>0.0</axis_1_auto_scale_threshold>
     <axis_1_axis_color>
       <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
@@ -68,7 +68,7 @@
     <axis_1_grid_color>
       <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
     </axis_1_grid_color>
-    <axis_1_log_scale>true</axis_1_log_scale>
+    <axis_1_log_scale>false</axis_1_log_scale>
     <axis_1_maximum>0.0</axis_1_maximum>
     <axis_1_minimum>0.0</axis_1_minimum>
     <axis_1_scale_font>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plot.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plot.opi
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
-  <actions hook="false" hook_all="false"/>
+  <actions hook="false" hook_all="false" />
   <auto_scale_widgets>
     <auto_scale_widgets>true</auto_scale_widgets>
     <min_width>-1</min_width>
@@ -8,11 +8,11 @@
   </auto_scale_widgets>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
-    <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
+    <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
   <boy_version>5.1.0.201707071649</boy_version>
   <foreground_color>
-    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
+    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
   <height>600</height>
@@ -20,8 +20,8 @@
     <include_parent_macros>true</include_parent_macros>
   </macros>
   <name>$(NAME)</name>
-  <rules/>
-  <scripts/>
+  <rules />
+  <scripts />
   <show_close_button>true</show_close_button>
   <show_edit_range>true</show_edit_range>
   <show_grid>true</show_grid>
@@ -33,17 +33,17 @@
   <x>-1</x>
   <y>-1</y>
   <widget typeId="org.csstudio.opibuilder.widgets.xyGraph" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
     <axis_0_auto_scale>true</axis_0_auto_scale>
     <axis_0_auto_scale_threshold>0.0</axis_0_auto_scale_threshold>
     <axis_0_axis_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </axis_0_axis_color>
-    <axis_0_axis_title>Time of flight (μs)</axis_0_axis_title>
+    <axis_0_axis_title>Time of flight (us)</axis_0_axis_title>
     <axis_0_dash_grid_line>false</axis_0_dash_grid_line>
     <axis_0_grid_color>
-      <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200"/>
+      <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
     </axis_0_grid_color>
     <axis_0_log_scale>false</axis_0_log_scale>
     <axis_0_maximum>0.0</axis_0_maximum>
@@ -58,17 +58,17 @@
       <opifont.name fontName="Segoe UI" height="11" style="1" pixels="false">Header 3</opifont.name>
     </axis_0_title_font>
     <axis_0_visible>true</axis_0_visible>
-    <axis_1_auto_scale>true</axis_1_auto_scale>
+    <axis_1_auto_scale>false</axis_1_auto_scale>
     <axis_1_auto_scale_threshold>0.0</axis_1_auto_scale_threshold>
     <axis_1_axis_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </axis_1_axis_color>
-    <axis_1_axis_title>Counts / μs</axis_1_axis_title>
+    <axis_1_axis_title>counts/us</axis_1_axis_title>
     <axis_1_dash_grid_line>false</axis_1_dash_grid_line>
     <axis_1_grid_color>
-      <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200"/>
+      <color name="ISIS_Textbox_Readonly_Background" red="200" green="200" blue="200" />
     </axis_1_grid_color>
-    <axis_1_log_scale>false</axis_1_log_scale>
+    <axis_1_log_scale>true</axis_1_log_scale>
     <axis_1_maximum>0.0</axis_1_maximum>
     <axis_1_minimum>0.0</axis_1_minimum>
     <axis_1_scale_font>
@@ -84,27 +84,27 @@
     <axis_count>2</axis_count>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </background_color>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>439</height>
     <name>Spectra plot</name>
     <plot_area_background_color>
-      <color name="ISIS_Textbox_Background" red="255" green="255" blue="255"/>
+      <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
     </plot_area_background_color>
-    <pv_name/>
-    <pv_value/>
-    <rules/>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
@@ -115,12 +115,14 @@
         <pv trig="true">$(SPECTRUM_PV$(NUMBER))</pv>
         <pv trig="true">$(PERIOD_PV$(NUMBER))</pv>
         <pv trig="true">$(MODE_PV$(NUMBER))</pv>
+        <pv trig="true">$(P)DAE:SPEC:1:1:X.EGU</pv>
+        <pv trig="true">$(P)DAE:SPEC:1:1:Y.EGU</pv>
       </path>
     </scripts>
     <show_legend>false</show_legend>
     <show_plot_area_border>false</show_plot_area_border>
     <show_toolbar>true</show_toolbar>
-    <title/>
+    <title></title>
     <title_font>
       <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_GraphLabels_NEW</opifont.name>
     </title_font>
@@ -135,7 +137,7 @@ $(trace_0_y_pv_value)</tooltip>
     <trace_0_point_size>4</trace_0_point_size>
     <trace_0_point_style>0</trace_0_point_style>
     <trace_0_trace_color>
-      <color name="ISIS_Trace_1_NEW" red="0" green="0" blue="255"/>
+      <color name="ISIS_Trace_1_NEW" red="0" green="0" blue="255" />
     </trace_0_trace_color>
     <trace_0_trace_type>0</trace_0_trace_type>
     <trace_0_update_delay>100</trace_0_update_delay>
@@ -143,14 +145,14 @@ $(trace_0_y_pv_value)</tooltip>
     <trace_0_visible>true</trace_0_visible>
     <trace_0_x_axis_index>0</trace_0_x_axis_index>
     <trace_0_x_pv>$(P)DAE:SPEC:1:1:X</trace_0_x_pv>
-    <trace_0_x_pv_value/>
+    <trace_0_x_pv_value />
     <trace_0_y_axis_index>1</trace_0_y_axis_index>
     <trace_0_y_pv>$(P)DAE:SPEC:1:1:Y</trace_0_y_pv>
-    <trace_0_y_pv_value/>
+    <trace_0_y_pv_value />
     <trace_count>1</trace_count>
     <transparent>false</transparent>
     <trigger_pv>$(P)CS:IOC:INSTETC_01:DEVIOS:HEARTBEAT</trigger_pv>
-    <trigger_pv_value/>
+    <trigger_pv_value />
     <visible>true</visible>
     <widget_type>XY Graph</widget_type>
     <width>1005</width>
@@ -159,13 +161,13 @@ $(trace_0_y_pv_value)</tooltip>
     <y>18</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <auto_size>false</auto_size>
     <background_color>
-      <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
     </background_color>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -174,21 +176,21 @@ $(trace_0_y_pv_value)</tooltip>
       <opifont.name fontName="Segoe UI" height="11" style="1" pixels="false">Header 3</opifont.name>
     </font>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>20</height>
     <horizontal_alignment>2</horizontal_alignment>
     <name>Label</name>
-    <rules/>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <show_scrollbar>false</show_scrollbar>
     <text>Spectrum:</text>
-    <tooltip/>
+    <tooltip></tooltip>
     <transparent>false</transparent>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
@@ -200,13 +202,13 @@ $(trace_0_y_pv_value)</tooltip>
     <y>-6</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <auto_size>false</auto_size>
     <background_color>
-      <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
     </background_color>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -215,21 +217,21 @@ $(trace_0_y_pv_value)</tooltip>
       <opifont.name fontName="Segoe UI" height="11" style="1" pixels="false">Header 3</opifont.name>
     </font>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>20</height>
     <horizontal_alignment>2</horizontal_alignment>
     <name>Label_2</name>
-    <rules/>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <show_scrollbar>false</show_scrollbar>
     <text>Period:</text>
-    <tooltip/>
+    <tooltip></tooltip>
     <transparent>false</transparent>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
@@ -241,13 +243,13 @@ $(trace_0_y_pv_value)</tooltip>
     <y>-6</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <auto_size>false</auto_size>
     <background_color>
-      <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
+      <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
     </background_color>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -256,21 +258,21 @@ $(trace_0_y_pv_value)</tooltip>
       <opifont.name fontName="Segoe UI" height="11" style="1" pixels="false">Header 3</opifont.name>
     </font>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>20</height>
     <horizontal_alignment>2</horizontal_alignment>
     <name>Label_3</name>
-    <rules/>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <show_scrollbar>false</show_scrollbar>
     <text>Mode:</text>
-    <tooltip/>
+    <tooltip></tooltip>
     <transparent>false</transparent>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
@@ -282,15 +284,23 @@ $(trace_0_y_pv_value)</tooltip>
     <y>-6</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.combo" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false">
+      <action type="EXECUTE_PYTHONSCRIPT">
+        <path>spectra_plots_mode.py</path>
+        <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+]]></scriptText>
+        <embedded>false</embedded>
+        <description></description>
+      </action>
+    </actions>
     <alarm_pulsing>false</alarm_pulsing>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color name="ISIS_Textbox_Background" red="255" green="255" blue="255"/>
+      <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
     </background_color>
     <border_alarm_sensitive>true</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -300,7 +310,7 @@ $(trace_0_y_pv_value)</tooltip>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>32</height>
     <items>
@@ -310,14 +320,18 @@ $(trace_0_y_pv_value)</tooltip>
     <items_from_pv>false</items_from_pv>
     <name>Combo</name>
     <pv_name>$(MODE_PV$(NUMBER))</pv_name>
-    <pv_value/>
-    <rules/>
+    <pv_value />
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>false</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts>
+      <path pathString="spectra_plots_mode.py" checkConnect="true" sfe="false" seoe="false">
+        <pv trig="true">$(P)DAE:SPEC:1:1:Y.EGU</pv>
+      </path>
+    </scripts>
     <tooltip>$(pv_name)
 $(pv_value)</tooltip>
     <visible>true</visible>
@@ -328,15 +342,15 @@ $(pv_value)</tooltip>
     <y>-13</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.spinner" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color red="255" green="255" blue="255"/>
+      <color red="255" green="255" blue="255" />
     </background_color>
     <border_alarm_sensitive>true</border_alarm_sensitive>
     <border_color>
-      <color red="0" green="128" blue="255"/>
+      <color red="0" green="128" blue="255" />
     </border_color>
     <border_style>3</border_style>
     <border_width>1</border_width>
@@ -347,7 +361,7 @@ $(pv_value)</tooltip>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color red="0" green="0" blue="0"/>
+      <color red="0" green="0" blue="0" />
     </foreground_color>
     <format>0</format>
     <height>20</height>
@@ -361,14 +375,14 @@ $(pv_value)</tooltip>
     <precision>3</precision>
     <precision_from_pv>false</precision_from_pv>
     <pv_name>$(SPECTRUM_PV$(NUMBER))</pv_name>
-    <pv_value/>
-    <rules/>
+    <pv_value />
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <show_text>true</show_text>
     <step_increment>1.0</step_increment>
     <tooltip>$(pv_name)
@@ -383,15 +397,15 @@ $(pv_value)</tooltip>
     <y>-6</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.spinner" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <alarm_pulsing>false</alarm_pulsing>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color red="255" green="255" blue="255"/>
+      <color red="255" green="255" blue="255" />
     </background_color>
     <border_alarm_sensitive>true</border_alarm_sensitive>
     <border_color>
-      <color red="0" green="128" blue="255"/>
+      <color red="0" green="128" blue="255" />
     </border_color>
     <border_style>3</border_style>
     <border_width>1</border_width>
@@ -402,7 +416,7 @@ $(pv_value)</tooltip>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color red="0" green="0" blue="0"/>
+      <color red="0" green="0" blue="0" />
     </foreground_color>
     <format>0</format>
     <height>20</height>
@@ -416,14 +430,14 @@ $(pv_value)</tooltip>
     <precision>3</precision>
     <precision_from_pv>false</precision_from_pv>
     <pv_name>$(PERIOD_PV$(NUMBER))</pv_name>
-    <pv_value/>
-    <rules/>
+    <pv_value />
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <show_text>true</show_text>
     <step_increment>1.0</step_increment>
     <tooltip>$(pv_name)
@@ -438,10 +452,10 @@ $(pv_value)</tooltip>
     <y>-6</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -451,25 +465,25 @@ $(pv_value)</tooltip>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>1</height>
-    <image/>
+    <image></image>
     <name>Dummy</name>
     <push_action_index>0</push_action_index>
-    <pv_name/>
-    <pv_value/>
-    <rules/>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <style>1</style>
-    <text/>
+    <text></text>
     <toggle_button>false</toggle_button>
-    <tooltip/>
+    <tooltip></tooltip>
     <visible>true</visible>
     <widget_type>Action Button</widget_type>
     <width>1</width>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plots_mode.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plots_mode.py
@@ -1,0 +1,17 @@
+from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+
+yAxisUnitsPv = pvs[0]
+
+def main():
+
+    if yAxisUnitsPv.isConnected():
+        modes = [PVUtil.getString(yAxisUnitsPv)]
+    else:
+        modes = ["counts/us"]
+
+    modes.append("counts")
+
+    widget.setPropertyValue("items", modes)
+
+main()

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plots_mode.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plots_mode.py
@@ -1,17 +1,23 @@
 from org.csstudio.opibuilder.scriptUtil import PVUtil
 
-
 yAxisUnitsPv = pvs[0]
+modePv = pvs[1]
 
 def main():
 
     if yAxisUnitsPv.isConnected():
-        modes = [PVUtil.getString(yAxisUnitsPv)]
+        # Remove cnt from start of string and add counts to make it more readable 
+        y_axis_title = "counts/" + PVUtil.getString(yAxisUnitsPv).split("/")[1]
     else:
-        modes = ["counts/us"]
+        y_axis_title = "counts/us"
 
-    modes.append("counts")
+    # The initial value
+    old_value = y_axis_title if "/" in PVUtil.getString(modePv) else PVUtil.getString(modePv)
 
-    widget.setPropertyValue("items", modes)
+    # Set the possible items in the combobox
+    widget.setPropertyValue("items", [ y_axis_title, "counts" ])
+
+    # Set the initial value
+    PVUtil.writePV(modePv.getName(), old_value)
 
 main()

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plots_script.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plots_script.py
@@ -6,6 +6,8 @@ pvInt1 = PVUtil.getLong(pvs[1])
 spectrumPv = pvs[0]
 periodPv = pvs[1]
 modePv = pvs[2]
+xAxisUnitsPv = pvs[3]
+yAxisUnitsPv = pvs[4]
 
 def main():
 
@@ -25,13 +27,22 @@ def main():
 
     if modePv.isConnected() and PVUtil.getString(modePv).lower() == "counts":
         mode = "YC"
-        axis_title = "Counts"
+        y_axis_title = "counts"
     else:
         mode = "Y"
-        axis_title = "Counts/us"
+        if yAxisUnitsPv.isConnected():
+            y_axis_title = PVUtil.getString(yAxisUnitsPv)
+        else:
+            y_axis_title = "counts/us"
+
+    if xAxisUnitsPv.isConnected():
+        x_axis_title = "Time of flight (" + PVUtil.getString(xAxisUnitsPv) + ")"
+    else:
+        x_axis_title = "Time of flight (us)"
         
     widget.setPropertyValue("trace_0_x_pv","$(P)DAE:SPEC:" + str(period) + ":" + str(spectrum) + ":X")
     widget.setPropertyValue("trace_0_y_pv","$(P)DAE:SPEC:" + str(period) + ":" + str(spectrum) + ":" + mode)
-    widget.setPropertyValue("axis_1_axis_title", axis_title)
+    widget.setPropertyValue("axis_0_axis_title", x_axis_title)
+    widget.setPropertyValue("axis_1_axis_title", y_axis_title)
 
 main()

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plots_script.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/spectra_plots_script.py
@@ -1,5 +1,6 @@
 from org.csstudio.opibuilder.scriptUtil import PVUtil
 
+
 pvInt0 = PVUtil.getLong(pvs[0])
 pvInt1 = PVUtil.getLong(pvs[1])
 
@@ -31,7 +32,8 @@ def main():
     else:
         mode = "Y"
         if yAxisUnitsPv.isConnected():
-            y_axis_title = PVUtil.getString(yAxisUnitsPv)
+            # Remove cnt from start of string and add counts to make it more readable 
+            y_axis_title = "counts/" + PVUtil.getString(yAxisUnitsPv).split("/")[1]
         else:
             y_axis_title = "counts/us"
 


### PR DESCRIPTION
### Description of work

Add GUI logic to display counts or counts/ns (on Muons) or counts/us (on Neutrons). Builds on https://github.com/ISISComputingGroup/EPICS-isisdae/pull/64 which serves the EGU field correctly. 

First test counts/us and counts are specified correctly on the spectra plots axis (by changing the mode on the drop down box) for your "Neutron" instrument. Then perform changes specified in https://github.com/ISISComputingGroup/IBEX/issues/5116#issuecomment-581141361 and do the same.

Ensure that the value persists by building the client, running the built client and changing the mode of the spectra plots. Then close the client and reopen, check that the changes are persisted in the spectra plots axes.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5116

### Acceptance criteria

- The x axis is labelled as nanoseconds on muon instruments
- The x axis remains labelled as microseconds for neutron instruments
- The drop down box has the ability to switch between the two correct labels
- The drop down box and axis labels are persisted

### Unit tests

OPI changes, can't unit test.

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

