### PR TITLE
Add link to manual in script generator

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
@@ -6,6 +6,7 @@ uk.ac.stfc.isis.ibex.preferences/show_values_of_invalid_blocks=false
 uk.ac.stfc.isis.ibex.preferences/script_generator_config_folder=C:/ScriptGeneratorConfigs/
 uk.ac.stfc.isis.ibex.preferences/script_generation_folder=C:/Scripts/
 uk.ac.stfc.isis.ibex.preferences/hide_config_error_table=false
+uk.ac.stfc.isis.ibex.preferences/script_generator_manual_url=http://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator,https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Using-the-Script-Generator
 
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = false
 org.eclipse.ui/LOCK_TRIM = true

--- a/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
+++ b/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
@@ -188,6 +188,16 @@ public class PreferenceSupplier {
     private static final String SCRIPT_GENERATOR_CONFIG_FOLDER = "script_generator_config_folder";
     
     /**
+     * The default URL for the Script Generator manual page
+     */
+    private static final String DEFAULT_SCRIPT_GENERATOR_MANUAL_URL = "http://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator";
+    
+    /**
+     * Defines the URL of the Script Generator page on the user manual
+     */
+    private static final String SCRIPT_GENERATOR_MANUAL_URL = "script_generator_manual_url";
+    
+    /**
      * The default of whether to hide the config error table or not.
      */
     private static final boolean DEFAULT_HIDE_CONFIG_ERRORS = false;
@@ -291,6 +301,15 @@ public class PreferenceSupplier {
 	public String scriptGeneratorConfigFolders() {
 		return getString(SCRIPT_GENERATOR_CONFIG_FOLDER, DEFAULT_SCRIPT_GENERATOR_CONFIG_FOLDER);
 	}
+	
+    /**
+     * Get a list of URLs pointing to the Script Generator page on the user manual
+     * 
+     * @return a comma-separated list of URLs
+     */
+    public String scriptGeneratorManualURL() {
+        return getString(SCRIPT_GENERATOR_MANUAL_URL, DEFAULT_SCRIPT_GENERATOR_MANUAL_URL);
+    }
 	
 	/**
 	 * Get whether to hide the script gen config error table.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -22,6 +22,8 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -149,6 +151,8 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	
 	private static final Logger LOG = IsisLog.getLogger(ScriptGeneratorSingleton.class);
 	
+	private final Optional<URL> userManualUrl = loadUserManualUrl();
+	
 	
 	/**
 	 * The constructor, will create without a config loader and without loading
@@ -227,6 +231,35 @@ public class ScriptGeneratorSingleton extends ModelObject {
 		
 		setActionParameters(configLoader.getParameters());
 	}
+	
+	private Optional<URL> loadUserManualUrl() {
+	    String preferenceProperty = preferenceSupplier.scriptGeneratorManualURL();
+	    
+	    // Loop through all URLs in the preference property
+	    // and return the first one reachable from the user's network
+	    for (String url : preferenceProperty.split(",")) {
+	        try {
+	            URL possibleUrl = new URL(url);
+	            
+	            HttpURLConnection connection = (HttpURLConnection) possibleUrl.openConnection();
+	            connection.setRequestMethod("GET");
+	            connection.connect();
+	            int responseCode = connection.getResponseCode();
+	            if (responseCode >= 200 && responseCode < 300) {
+	                return Optional.of(possibleUrl);
+	            }
+	        } catch (IOException ex) {
+	            LOG.debug("Invalid URL for user manual was found: " + url);
+	        }
+	    };
+	    
+	    LOG.warn("No valid URLs for the user manual were found");
+	    return Optional.empty();
+	}
+	
+    public Optional<URL> getUserManualUrl() {
+        return userManualUrl;
+    }
 	
 	/**
      * Creates the config loader.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -151,8 +151,6 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	
 	private static final Logger LOG = IsisLog.getLogger(ScriptGeneratorSingleton.class);
 	
-	private final Optional<URL> userManualUrl = loadUserManualUrl();
-	
 	
 	/**
 	 * The constructor, will create without a config loader and without loading
@@ -232,7 +230,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 		setActionParameters(configLoader.getParameters());
 	}
 	
-	private Optional<URL> loadUserManualUrl() {
+	public Optional<URL> getUserManualUrl() {
 	    String preferenceProperty = preferenceSupplier.scriptGeneratorManualURL();
 	    
 	    // Loop through all URLs in the preference property
@@ -256,10 +254,6 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	    LOG.warn("No valid URLs for the user manual were found");
 	    return Optional.empty();
 	}
-	
-    public Optional<URL> getUserManualUrl() {
-        return userManualUrl;
-    }
 	
 	/**
      * Creates the config loader.

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -193,7 +193,11 @@ public class ScriptGeneratorView {
             
             CompletableFuture.supplyAsync(() -> scriptGeneratorViewModel.getUserManualUrl())
                 .thenAccept(url -> {
-                    DISPLAY.asyncExec(() -> setupLinkButton(manualButton, url));
+                    DISPLAY.asyncExec(() -> {
+                        if (!manualButton.isDisposed()) {
+                            setupLinkButton(manualButton, url);
+                        }
+                    });
                 });
 
             // The composite to contain the button to check validity

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -23,6 +23,7 @@ package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import javax.annotation.PostConstruct;
@@ -97,20 +98,6 @@ public class ScriptGeneratorView {
             + System.getProperty("line.separator")
             + "Have they been located in the correct place or is this not your preferred location?", 
             preferences.scriptGeneratorConfigFolders());
-
-    /**
-     * The URL of the Script Generator page on the user manual
-     */
-    private static final URL SCRIPT_GENERATOR_DOCS_URL;
-    static {
-        URL temp = null;
-        try {
-            temp = new URL("http://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator");
-        } catch (MalformedURLException ex) {
-            LoggerUtils.logErrorWithStackTrace(LOGGER, "Failed to parse user manual URL", ex);;
-        }
-        SCRIPT_GENERATOR_DOCS_URL = temp;
-    }
 
     /**
      * Create a button to manipulate the rows of the script generator table and
@@ -201,14 +188,20 @@ public class ScriptGeneratorView {
             final Button manualButton = new Button(manualButtonComposite, SWT.NONE);
             manualButton.setText("Open Manual");
             manualButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-            manualButton.addListener(SWT.Selection, e -> {
-                try {
-                    IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser();
-                    browser.openURL(SCRIPT_GENERATOR_DOCS_URL);
-                } catch (PartInitException ex) {
-                    LoggerUtils.logErrorWithStackTrace(LOGGER, "Failed to open user manual in browser", ex);
-                }
-            });
+            
+            try {
+                URL userManualUrl = scriptGeneratorViewModel.getUserManualUrl().get();
+                manualButton.addListener(SWT.Selection, e -> {
+                    try {
+                        IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser();
+                        browser.openURL(userManualUrl);
+                    } catch (PartInitException ex) {
+                        LoggerUtils.logErrorWithStackTrace(LOGGER, "Failed to open user manual in browser", ex);
+                    }
+                });
+            } catch (NoSuchElementException ex) {
+                manualButton.setEnabled(false);
+            }
 
             // The composite to contain the button to check validity
             Composite validityComposite = new Composite(topBarComposite, SWT.NONE);

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -199,7 +199,7 @@ public class ScriptGeneratorView {
 
             // Button to open the user manual in a button
             final Button manualButton = new Button(manualButtonComposite, SWT.NONE);
-            manualButton.setText("Open manual");
+            manualButton.setText("Open Manual");
             manualButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
             manualButton.addListener(SWT.Selection, e -> {
                 try {

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -20,11 +20,14 @@
 package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
 
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
 
 import javax.annotation.PostConstruct;
 
+import org.apache.logging.log4j.Logger;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ComboViewer;
@@ -43,8 +46,13 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.browser.IWebBrowser;
 import org.eclipse.wb.swt.ResourceManager;
 
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
 import uk.ac.stfc.isis.ibex.preferences.PreferenceSupplier;
 
 /**
@@ -54,6 +62,7 @@ import uk.ac.stfc.isis.ibex.preferences.PreferenceSupplier;
  */
 @SuppressWarnings("checkstyle:magicnumber")
 public class ScriptGeneratorView {
+    private static final Logger LOGGER = IsisLog.getLogger(ScriptGeneratorView.class);
 	
 	private static PreferenceSupplier preferences = new PreferenceSupplier();
 	
@@ -88,6 +97,20 @@ public class ScriptGeneratorView {
 			+ System.getProperty("line.separator")
 			+ "Have they been located in the correct place or is this not your preferred location?", 
 			preferences.scriptGeneratorConfigFolders());
+	
+	/**
+	 * The URL of the Script Generator page on the user manual
+	 */
+	private static final URL SCRIPT_GENERATOR_DOCS_URL;
+	static {
+		URL temp = null;
+		try {
+			temp = new URL("http://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator");
+		} catch (MalformedURLException ex) {
+			LoggerUtils.logErrorWithStackTrace(LOGGER, "Failed to parse user manual URL", ex);;
+		}
+		SCRIPT_GENERATOR_DOCS_URL = temp;
+	}
 	
 	/**
 	 * Create a button to manipulate the rows of the script generator table and
@@ -169,6 +192,24 @@ public class ScriptGeneratorView {
 						() -> helpText.setText("")
 					);
 			
+	        // Composite for the Open Manual button
+	        Composite manualButtonComposite = new Composite(topBarComposite, SWT.NONE);
+	        manualButtonComposite.setLayout(new GridLayout(1, false));
+	        manualButtonComposite.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+
+	        // Button to open the user manual in a button
+	        final Button manualButton = new Button(manualButtonComposite, SWT.NONE);
+	        manualButton.setText("Open manual");
+	        manualButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+	        manualButton.addListener(SWT.Selection, e -> {
+	            try {
+	                IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser();
+	                browser.openURL(SCRIPT_GENERATOR_DOCS_URL);
+	            } catch (PartInitException ex) {
+	                LoggerUtils.logErrorWithStackTrace(LOGGER, "Failed to open user manual in browser", ex);
+	            }
+	        });
+
 			// The composite to contain the button to check validity
 			Composite validityComposite = new Composite(topBarComposite, SWT.NONE);
 			validityComposite.setLayout(new GridLayout(1, false));

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -1,21 +1,21 @@
 
 /*
-* This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2019 Science & Technology Facilities Council.
-* All rights reserved.
-*
-* This program is distributed in the hope that it will be useful.
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v1.0 which accompanies this distribution.
-* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
-* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
-* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
-*
-* You should have received a copy of the Eclipse Public License v1.0
-* along with this program; if not, you can obtain a copy from
-* https://www.eclipse.org/org/documents/epl-v10.php or 
-* http://opensource.org/licenses/eclipse-1.0.php
-*/
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2019 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
 
 package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
 
@@ -63,319 +63,319 @@ import uk.ac.stfc.isis.ibex.preferences.PreferenceSupplier;
 @SuppressWarnings("checkstyle:magicnumber")
 public class ScriptGeneratorView {
     private static final Logger LOGGER = IsisLog.getLogger(ScriptGeneratorView.class);
-	
-	private static PreferenceSupplier preferences = new PreferenceSupplier();
-	
-	private DataBindingContext bindingContext;
-	
-	private static final Display DISPLAY = Display.getDefault();
 
-	/**
-	 * A clear colour for use in other script generator table columns when a row is valid.
-	 */
-	private static final Color clearColor = DISPLAY.getSystemColor(SWT.COLOR_WHITE);
-	
-	/**
-	 * The UI table of script generator contents.
-	 */
-	private ActionsViewTable table;
-	
-	/**
-	 * The drop down box to manipulate which config is being used and load ActionParameters accordingly.
-	 */
-	private ComboViewer configSelector;
-	
-	/**
-	 * The ViewModel the View is updated by.
-	 */
-	private ScriptGeneratorViewModel scriptGeneratorViewModel;
-	
-	/**
-	 * The string to display if there is no configs to select.
-	 */
-	private static final String NO_CONFIGS_MESSAGE = String.format("\u26A0 Warning: Could not load any configs from %s"
-			+ System.getProperty("line.separator")
-			+ "Have they been located in the correct place or is this not your preferred location?", 
-			preferences.scriptGeneratorConfigFolders());
-	
-	/**
-	 * The URL of the Script Generator page on the user manual
-	 */
-	private static final URL SCRIPT_GENERATOR_DOCS_URL;
-	static {
-		URL temp = null;
-		try {
-			temp = new URL("http://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator");
-		} catch (MalformedURLException ex) {
-			LoggerUtils.logErrorWithStackTrace(LOGGER, "Failed to parse user manual URL", ex);;
-		}
-		SCRIPT_GENERATOR_DOCS_URL = temp;
-	}
-	
-	/**
-	 * Create a button to manipulate the rows of the script generator table and
-	 *  move them up and down.
-	 * 
-	 * @param parent The composite the button will live in.
-	 * @param icon The icon to display on the button.
-	 * @param direction The direction of the button "up" or "down".
-	 * @return The created button.
-	 */
-	private Button createMoveRowButton(Composite parent, String icon, String direction) {
+    private static PreferenceSupplier preferences = new PreferenceSupplier();
+
+    private DataBindingContext bindingContext;
+
+    private static final Display DISPLAY = Display.getDefault();
+
+    /**
+     * A clear colour for use in other script generator table columns when a row is valid.
+     */
+    private static final Color clearColor = DISPLAY.getSystemColor(SWT.COLOR_WHITE);
+
+    /**
+     * The UI table of script generator contents.
+     */
+    private ActionsViewTable table;
+
+    /**
+     * The drop down box to manipulate which config is being used and load ActionParameters accordingly.
+     */
+    private ComboViewer configSelector;
+
+    /**
+     * The ViewModel the View is updated by.
+     */
+    private ScriptGeneratorViewModel scriptGeneratorViewModel;
+
+    /**
+     * The string to display if there is no configs to select.
+     */
+    private static final String NO_CONFIGS_MESSAGE = String.format("\u26A0 Warning: Could not load any configs from %s"
+            + System.getProperty("line.separator")
+            + "Have they been located in the correct place or is this not your preferred location?", 
+            preferences.scriptGeneratorConfigFolders());
+
+    /**
+     * The URL of the Script Generator page on the user manual
+     */
+    private static final URL SCRIPT_GENERATOR_DOCS_URL;
+    static {
+        URL temp = null;
+        try {
+            temp = new URL("http://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator");
+        } catch (MalformedURLException ex) {
+            LoggerUtils.logErrorWithStackTrace(LOGGER, "Failed to parse user manual URL", ex);;
+        }
+        SCRIPT_GENERATOR_DOCS_URL = temp;
+    }
+
+    /**
+     * Create a button to manipulate the rows of the script generator table and
+     *  move them up and down.
+     * 
+     * @param parent The composite the button will live in.
+     * @param icon The icon to display on the button.
+     * @param direction The direction of the button "up" or "down".
+     * @return The created button.
+     */
+    private Button createMoveRowButton(Composite parent, String icon, String direction) {
         Button moveButton =  new Button(parent, SWT.NONE);
-		GridData gdBtnMoveRow = new GridData(SWT.LEFT, SWT.BOTTOM, false, false, 1, 1);
-		gdBtnMoveRow.widthHint = 25;
-		moveButton.setLayoutData(gdBtnMoveRow);
-		moveButton.setImage(ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui", "icons/" + icon));
+        GridData gdBtnMoveRow = new GridData(SWT.LEFT, SWT.BOTTOM, false, false, 1, 1);
+        gdBtnMoveRow.widthHint = 25;
+        moveButton.setLayoutData(gdBtnMoveRow);
+        moveButton.setImage(ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui", "icons/" + icon));
         moveButton.setToolTipText("Move selected row " + direction);
         return moveButton;
-	}
-	
-	/**
-	 * Container for the UI objects.
-	 * 
-	 * @param parent the parent composite.
-	 */
-	@PostConstruct
-	public void createPartControl(Composite parent) {
-		
-		scriptGeneratorViewModel = new ScriptGeneratorViewModel();
-		
-		GridData gdQueueContainer = new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1);
-		gdQueueContainer.heightHint = 300;
-		parent.setLayoutData(gdQueueContainer);
-		parent.setLayout(new GridLayout(1, false));
-		
-		if(scriptGeneratorViewModel.configsLoaded()) {
-			
-			// A composite to contain the elements at the top of the script generator
-			Composite topBarComposite = new Composite(parent, SWT.NONE);
-			topBarComposite.setLayout(new GridLayout(6, false));
-			topBarComposite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-			
-			// Composite to contain help strings from configs
-	        Composite configComposite = new Composite(topBarComposite, SWT.NONE);
-	        configComposite.setLayout(new GridLayout(5, false));
-	        configComposite.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, true, 1, 1));
-	        
-	        // The label for the config selector drop down
- 			Label configSelectorLabel = new Label(configComposite, SWT.NONE);
- 			configSelectorLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true, 1, 1));
- 			configSelectorLabel.setText("Config:");
- 	
- 			// Drop-down box to select between configs.
- 			configSelector = setUpConfigSelector(configComposite);
- 			
- 			// Separate help and selector
- 			new Label(configComposite, SWT.SEPARATOR | SWT.VERTICAL);
-	        
- 			// Label for config help
-	        Label helpLabel = new Label(configComposite, SWT.NONE);
-			helpLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-			helpLabel.setText("Config Help: ");
-			
-			// Display help for the config
-			Text helpText = new Text(configComposite, SWT.BORDER | SWT.READ_ONLY | SWT.WRAP | SWT.MULTI | SWT.V_SCROLL);
-			var helpTextDataLayout = new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false, 1, 1);
-			helpTextDataLayout.widthHint = 400;
-			helpTextDataLayout.heightHint = 100;
-			helpText.setLayoutData(helpTextDataLayout);
-			helpText.setBackground(clearColor);
-			// Display the correct starting text
-			scriptGeneratorViewModel.getConfig().ifPresentOrElse(
-						config -> {
-							Optional.ofNullable(config.getHelp()).ifPresentOrElse(
-								helpString -> helpText.setText(helpString),
-								() -> helpText.setText("")
-							);
-						},
-						() -> helpText.setText("")
-					);
-			
-	        // Composite for the Open Manual button
-	        Composite manualButtonComposite = new Composite(topBarComposite, SWT.NONE);
-	        manualButtonComposite.setLayout(new GridLayout(1, false));
-	        manualButtonComposite.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+    }
 
-	        // Button to open the user manual in a button
-	        final Button manualButton = new Button(manualButtonComposite, SWT.NONE);
-	        manualButton.setText("Open manual");
-	        manualButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-	        manualButton.addListener(SWT.Selection, e -> {
-	            try {
-	                IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser();
-	                browser.openURL(SCRIPT_GENERATOR_DOCS_URL);
-	            } catch (PartInitException ex) {
-	                LoggerUtils.logErrorWithStackTrace(LOGGER, "Failed to open user manual in browser", ex);
-	            }
-	        });
+    /**
+     * Container for the UI objects.
+     * 
+     * @param parent the parent composite.
+     */
+    @PostConstruct
+    public void createPartControl(Composite parent) {
 
-			// The composite to contain the button to check validity
-			Composite validityComposite = new Composite(topBarComposite, SWT.NONE);
-			validityComposite.setLayout(new GridLayout(1, false));
-			validityComposite.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-			
-			// Button to check validity errors
-			final Button btnGetValidityErrors = new Button(validityComposite, SWT.NONE);
-	        btnGetValidityErrors.setText("Get Validity Errors");
-	        btnGetValidityErrors.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-	        btnGetValidityErrors.addListener(SWT.Selection, e -> {
-	        	scriptGeneratorViewModel.displayValidityErrors();
-	        });
-	        
-	        
-	        Map<String, String> configLoadErrors = scriptGeneratorViewModel.getConfigLoadErrors();
-	        
-	        if(!configLoadErrors.isEmpty()) {
-		        setUpConfigLoadErrorTable(parent, configLoadErrors); 			    
-	        }
-	        
-	        // The composite to contain the UI table
-	        Composite tableContainerComposite = new Composite(parent, SWT.NONE);
-	        tableContainerComposite.setLayout(new GridLayout(2, false));
-	        tableContainerComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-			
-	        // The UI table
-			table = new ActionsViewTable(tableContainerComposite, SWT.NONE, SWT.SINGLE | SWT.V_SCROLL | SWT.FULL_SELECTION, scriptGeneratorViewModel);
-			table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-	        
-			// Composite for move action up/down buttons
-			Composite moveComposite = new Composite(tableContainerComposite, SWT.NONE);
-		    moveComposite.setLayout(new GridLayout(1, false));
-		    moveComposite.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false, 1, 1));
-	        
-		    // Make buttons to move an action up and down the list
-	        Button btnMoveActionUp = createMoveRowButton(moveComposite, "move_up.png", "up");
-	        btnMoveActionUp.addListener(SWT.Selection, e -> scriptGeneratorViewModel.moveActionUp(table.getSelectionIndex()));
-	        
-	        Button btnMoveActionDown = createMoveRowButton(moveComposite, "move_down.png", "down");
-	        btnMoveActionDown.addListener(SWT.Selection, e -> scriptGeneratorViewModel.moveActionDown(table.getSelectionIndex()));
-	        
-	        // Composite for laying out new/delete/duplicate action buttons
-	        Composite actionsControlsGrp = new Composite(parent, SWT.NONE);
-	        actionsControlsGrp.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-	        GridLayout ssgLayout = new GridLayout(3, false);
-	        ssgLayout.marginHeight = 10;
-	        ssgLayout.marginWidth = 10;
-	        actionsControlsGrp.setLayout(ssgLayout);
-			        
-	        // Make buttons for insert new/delete/duplicate actions
-	        final Button btnInsertAction = new Button(actionsControlsGrp, SWT.NONE);
-	        btnInsertAction.setText("Add Action");
-	        btnInsertAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-	        btnInsertAction.addListener(SWT.Selection, e -> scriptGeneratorViewModel.addEmptyAction());
-	        
-	        final Button btnDeleteAction = new Button(actionsControlsGrp, SWT.NONE);
-	        btnDeleteAction.setText("Delete Action");
-	        btnDeleteAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-	        btnDeleteAction.addListener(SWT.Selection, e -> scriptGeneratorViewModel.deleteAction(table.getSelectionIndex()));
-	
-	        final Button btnDuplicateAction = new Button(actionsControlsGrp, SWT.NONE);
-	        btnDuplicateAction.setText("Duplicate Action");
-	        btnDuplicateAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-	        btnDuplicateAction.addListener(SWT.Selection, e -> scriptGeneratorViewModel.duplicateAction(table.getSelectionIndex()));
-	        
-	        // Composite for generate buttons
-	        Composite generateButtonsGrp = new Composite(parent, SWT.NONE);
-	        generateButtonsGrp.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-	        GridLayout gbgLayout = new GridLayout(1, false);
-	        gbgLayout.marginHeight = 10;
-	        gbgLayout.marginWidth = 10;
-	        generateButtonsGrp.setLayout(gbgLayout);
-	        
-	        // Button to generate a script
-	        final Button generateScriptButton = new Button(generateButtonsGrp, SWT.NONE);
-	        generateScriptButton.setText("Generate Script");
-	        generateScriptButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-	        generateScriptButton.addListener(SWT.Selection, e -> scriptGeneratorViewModel.generate());
-	        
-	        		
-	        // Bind the context and the validity checking listeners
-	        bind(btnGetValidityErrors, generateScriptButton, helpText);
-			
-	        scriptGeneratorViewModel.addEmptyAction();
-		} else {
-			
-			Label warningMessage = new Label(parent, SWT.NONE);
-			warningMessage.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, true));
-			// Make the warning label bigger from: https://stackoverflow.com/questions/1449968/change-just-the-font-size-in-swt
-			FontData[] fD = warningMessage.getFont().getFontData();
-			fD[0].setHeight(16);
-			warningMessage.setFont(new Font(Display.getDefault(), fD[0]));
-			warningMessage.setText(NO_CONFIGS_MESSAGE);
-			warningMessage.pack();
-			
-			Map<String, String> configLoadErrors = scriptGeneratorViewModel.getConfigLoadErrors();
-	        
-	        if(!configLoadErrors.isEmpty()) {
-		        setUpConfigLoadErrorTable(parent, configLoadErrors); 			    
-	        }
-			
-		}
-	}
-	
-	/**
-	 * Set up a composite and table to display config load errors.
-	 */
-	private void setUpConfigLoadErrorTable(Composite parent, Map<String, String> configLoadErrors) {
-		if(!preferences.hideScriptGenConfigErrorTable()) {
-			// A composite to contain the config load errors
-			Composite configErrorComposite = new Composite(parent, SWT.NONE);
-			configErrorComposite.setLayout(new GridLayout(1, false));
-			configErrorComposite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-			
-			// A table to display the config load errors
-			// From http://www.java2s.com/Code/Java/SWT-JFace-Eclipse/SWTTableSimpleDemo.htm
-			Table table = new Table(configErrorComposite, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
-		    table.setHeaderVisible(true);
-		    String[] titles = { "Config", "Error" };
-		    
-		    for (int i = 0; i < titles.length; i++) {
-		    	TableColumn column = new TableColumn(table, SWT.NULL);
-		    	column.setText(titles[i]);
-		    }
-		    
-		    for(Map.Entry<String, String> loadError : configLoadErrors.entrySet()) {
-		    	TableItem item = new TableItem(table, SWT.NULL);
-		    	item.setText(0, loadError.getKey());
-		    	item.setText(1, loadError.getValue());
-		    }
-		    
-		    for (int i = 0; i < titles.length; i++) {
-		    	table.getColumn(i).pack();
-		    }
-		}
-	}
-	
-	/**
-	 * Creates a new combo box and configures sets its input to the config loader.
-	 * @param globalSettingsComposite
-	 * 			The composite to draw the box in
-	 * @return configSelector
-	 * 			Combo box with available configurations
-	 */
-	private ComboViewer setUpConfigSelector(Composite globalSettingsComposite) {
-		configSelector = new ComboViewer(globalSettingsComposite, SWT.READ_ONLY);
+        scriptGeneratorViewModel = new ScriptGeneratorViewModel();
 
-		configSelector.setContentProvider(ArrayContentProvider.getInstance());
-		configSelector.setLabelProvider(scriptGeneratorViewModel.getConfigSelectorLabelProvider());
-		configSelector.getCombo().setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true, 1, 1));
-		configSelector.setInput(scriptGeneratorViewModel.getAvailableConfigs());
-		configSelector.setSelection(new StructuredSelection(scriptGeneratorViewModel.getConfig().get()));
-		
-		return configSelector;
-	}
-	
-	/**
-	 * Binds the Script Generator Table, config selector and validity check models to their views.
-	 */
-	private void bind(Button btnGetValidityErrors, Button btnGenerateScript, Text helpText) {
-		bindingContext = new DataBindingContext();
-		
-		scriptGeneratorViewModel.bindConfigLoader(bindingContext, configSelector, helpText);
+        GridData gdQueueContainer = new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1);
+        gdQueueContainer.heightHint = 300;
+        parent.setLayoutData(gdQueueContainer);
+        parent.setLayout(new GridLayout(1, false));
 
-		scriptGeneratorViewModel.bindValidityChecks(table, btnGetValidityErrors, btnGenerateScript);
-	}
-	
+        if(scriptGeneratorViewModel.configsLoaded()) {
+
+            // A composite to contain the elements at the top of the script generator
+            Composite topBarComposite = new Composite(parent, SWT.NONE);
+            topBarComposite.setLayout(new GridLayout(6, false));
+            topBarComposite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+
+            // Composite to contain help strings from configs
+            Composite configComposite = new Composite(topBarComposite, SWT.NONE);
+            configComposite.setLayout(new GridLayout(5, false));
+            configComposite.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, true, 1, 1));
+
+            // The label for the config selector drop down
+            Label configSelectorLabel = new Label(configComposite, SWT.NONE);
+            configSelectorLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true, 1, 1));
+            configSelectorLabel.setText("Config:");
+
+            // Drop-down box to select between configs.
+            configSelector = setUpConfigSelector(configComposite);
+
+            // Separate help and selector
+            new Label(configComposite, SWT.SEPARATOR | SWT.VERTICAL);
+
+            // Label for config help
+            Label helpLabel = new Label(configComposite, SWT.NONE);
+            helpLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+            helpLabel.setText("Config Help: ");
+
+            // Display help for the config
+            Text helpText = new Text(configComposite, SWT.BORDER | SWT.READ_ONLY | SWT.WRAP | SWT.MULTI | SWT.V_SCROLL);
+            var helpTextDataLayout = new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false, 1, 1);
+            helpTextDataLayout.widthHint = 400;
+            helpTextDataLayout.heightHint = 100;
+            helpText.setLayoutData(helpTextDataLayout);
+            helpText.setBackground(clearColor);
+            // Display the correct starting text
+            scriptGeneratorViewModel.getConfig().ifPresentOrElse(
+                config -> {
+                    Optional.ofNullable(config.getHelp()).ifPresentOrElse(
+                            helpString -> helpText.setText(helpString),
+                            () -> helpText.setText("")
+                    );
+                },
+                () -> helpText.setText("")
+            );
+
+            // Composite for the Open Manual button
+            Composite manualButtonComposite = new Composite(topBarComposite, SWT.NONE);
+            manualButtonComposite.setLayout(new GridLayout(1, false));
+            manualButtonComposite.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+
+            // Button to open the user manual in a button
+            final Button manualButton = new Button(manualButtonComposite, SWT.NONE);
+            manualButton.setText("Open manual");
+            manualButton.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+            manualButton.addListener(SWT.Selection, e -> {
+                try {
+                    IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser();
+                    browser.openURL(SCRIPT_GENERATOR_DOCS_URL);
+                } catch (PartInitException ex) {
+                    LoggerUtils.logErrorWithStackTrace(LOGGER, "Failed to open user manual in browser", ex);
+                }
+            });
+
+            // The composite to contain the button to check validity
+            Composite validityComposite = new Composite(topBarComposite, SWT.NONE);
+            validityComposite.setLayout(new GridLayout(1, false));
+            validityComposite.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+
+            // Button to check validity errors
+            final Button btnGetValidityErrors = new Button(validityComposite, SWT.NONE);
+            btnGetValidityErrors.setText("Get Validity Errors");
+            btnGetValidityErrors.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+            btnGetValidityErrors.addListener(SWT.Selection, e -> {
+                scriptGeneratorViewModel.displayValidityErrors();
+            });
+
+
+            Map<String, String> configLoadErrors = scriptGeneratorViewModel.getConfigLoadErrors();
+
+            if(!configLoadErrors.isEmpty()) {
+                setUpConfigLoadErrorTable(parent, configLoadErrors); 			    
+            }
+
+            // The composite to contain the UI table
+            Composite tableContainerComposite = new Composite(parent, SWT.NONE);
+            tableContainerComposite.setLayout(new GridLayout(2, false));
+            tableContainerComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+
+            // The UI table
+            table = new ActionsViewTable(tableContainerComposite, SWT.NONE, SWT.SINGLE | SWT.V_SCROLL | SWT.FULL_SELECTION, scriptGeneratorViewModel);
+            table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+
+            // Composite for move action up/down buttons
+            Composite moveComposite = new Composite(tableContainerComposite, SWT.NONE);
+            moveComposite.setLayout(new GridLayout(1, false));
+            moveComposite.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false, 1, 1));
+
+            // Make buttons to move an action up and down the list
+            Button btnMoveActionUp = createMoveRowButton(moveComposite, "move_up.png", "up");
+            btnMoveActionUp.addListener(SWT.Selection, e -> scriptGeneratorViewModel.moveActionUp(table.getSelectionIndex()));
+
+            Button btnMoveActionDown = createMoveRowButton(moveComposite, "move_down.png", "down");
+            btnMoveActionDown.addListener(SWT.Selection, e -> scriptGeneratorViewModel.moveActionDown(table.getSelectionIndex()));
+
+            // Composite for laying out new/delete/duplicate action buttons
+            Composite actionsControlsGrp = new Composite(parent, SWT.NONE);
+            actionsControlsGrp.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+            GridLayout ssgLayout = new GridLayout(3, false);
+            ssgLayout.marginHeight = 10;
+            ssgLayout.marginWidth = 10;
+            actionsControlsGrp.setLayout(ssgLayout);
+
+            // Make buttons for insert new/delete/duplicate actions
+            final Button btnInsertAction = new Button(actionsControlsGrp, SWT.NONE);
+            btnInsertAction.setText("Add Action");
+            btnInsertAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+            btnInsertAction.addListener(SWT.Selection, e -> scriptGeneratorViewModel.addEmptyAction());
+
+            final Button btnDeleteAction = new Button(actionsControlsGrp, SWT.NONE);
+            btnDeleteAction.setText("Delete Action");
+            btnDeleteAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+            btnDeleteAction.addListener(SWT.Selection, e -> scriptGeneratorViewModel.deleteAction(table.getSelectionIndex()));
+
+            final Button btnDuplicateAction = new Button(actionsControlsGrp, SWT.NONE);
+            btnDuplicateAction.setText("Duplicate Action");
+            btnDuplicateAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+            btnDuplicateAction.addListener(SWT.Selection, e -> scriptGeneratorViewModel.duplicateAction(table.getSelectionIndex()));
+
+            // Composite for generate buttons
+            Composite generateButtonsGrp = new Composite(parent, SWT.NONE);
+            generateButtonsGrp.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+            GridLayout gbgLayout = new GridLayout(1, false);
+            gbgLayout.marginHeight = 10;
+            gbgLayout.marginWidth = 10;
+            generateButtonsGrp.setLayout(gbgLayout);
+
+            // Button to generate a script
+            final Button generateScriptButton = new Button(generateButtonsGrp, SWT.NONE);
+            generateScriptButton.setText("Generate Script");
+            generateScriptButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+            generateScriptButton.addListener(SWT.Selection, e -> scriptGeneratorViewModel.generate());
+
+
+            // Bind the context and the validity checking listeners
+            bind(btnGetValidityErrors, generateScriptButton, helpText);
+
+            scriptGeneratorViewModel.addEmptyAction();
+        } else {
+
+            Label warningMessage = new Label(parent, SWT.NONE);
+            warningMessage.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, true));
+            // Make the warning label bigger from: https://stackoverflow.com/questions/1449968/change-just-the-font-size-in-swt
+            FontData[] fD = warningMessage.getFont().getFontData();
+            fD[0].setHeight(16);
+            warningMessage.setFont(new Font(Display.getDefault(), fD[0]));
+            warningMessage.setText(NO_CONFIGS_MESSAGE);
+            warningMessage.pack();
+
+            Map<String, String> configLoadErrors = scriptGeneratorViewModel.getConfigLoadErrors();
+
+            if(!configLoadErrors.isEmpty()) {
+                setUpConfigLoadErrorTable(parent, configLoadErrors); 			    
+            }
+
+        }
+    }
+
+    /**
+     * Set up a composite and table to display config load errors.
+     */
+    private void setUpConfigLoadErrorTable(Composite parent, Map<String, String> configLoadErrors) {
+        if(!preferences.hideScriptGenConfigErrorTable()) {
+            // A composite to contain the config load errors
+            Composite configErrorComposite = new Composite(parent, SWT.NONE);
+            configErrorComposite.setLayout(new GridLayout(1, false));
+            configErrorComposite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+
+            // A table to display the config load errors
+            // From http://www.java2s.com/Code/Java/SWT-JFace-Eclipse/SWTTableSimpleDemo.htm
+            Table table = new Table(configErrorComposite, SWT.BORDER | SWT.V_SCROLL | SWT.H_SCROLL);
+            table.setHeaderVisible(true);
+            String[] titles = { "Config", "Error" };
+
+            for (int i = 0; i < titles.length; i++) {
+                TableColumn column = new TableColumn(table, SWT.NULL);
+                column.setText(titles[i]);
+            }
+
+            for(Map.Entry<String, String> loadError : configLoadErrors.entrySet()) {
+                TableItem item = new TableItem(table, SWT.NULL);
+                item.setText(0, loadError.getKey());
+                item.setText(1, loadError.getValue());
+            }
+
+            for (int i = 0; i < titles.length; i++) {
+                table.getColumn(i).pack();
+            }
+        }
+    }
+
+    /**
+     * Creates a new combo box and configures sets its input to the config loader.
+     * @param globalSettingsComposite
+     * 			The composite to draw the box in
+     * @return configSelector
+     * 			Combo box with available configurations
+     */
+    private ComboViewer setUpConfigSelector(Composite globalSettingsComposite) {
+        configSelector = new ComboViewer(globalSettingsComposite, SWT.READ_ONLY);
+
+        configSelector.setContentProvider(ArrayContentProvider.getInstance());
+        configSelector.setLabelProvider(scriptGeneratorViewModel.getConfigSelectorLabelProvider());
+        configSelector.getCombo().setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true, 1, 1));
+        configSelector.setInput(scriptGeneratorViewModel.getAvailableConfigs());
+        configSelector.setSelection(new StructuredSelection(scriptGeneratorViewModel.getConfig().get()));
+
+        return configSelector;
+    }
+
+    /**
+     * Binds the Script Generator Table, config selector and validity check models to their views.
+     */
+    private void bind(Button btnGetValidityErrors, Button btnGenerateScript, Text helpText) {
+        bindingContext = new DataBindingContext();
+
+        scriptGeneratorViewModel.bindConfigLoader(bindingContext, configSelector, helpText);
+
+        scriptGeneratorViewModel.bindValidityChecks(table, btnGetValidityErrors, btnGenerateScript);
+    }
+
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -1,5 +1,6 @@
 package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -587,4 +588,7 @@ public class ScriptGeneratorViewModel {
 		return scriptGeneratorModel.getConfig();
 	}
 	
+	public Optional<URL> getUserManualUrl() {
+	    return scriptGeneratorModel.getUserManualUrl();
+	}
 }

--- a/base/uk.ac.stfc.isis.scriptgenerator.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.scriptgenerator.client/plugin_customization.ini
@@ -3,3 +3,4 @@
 uk.ac.stfc.isis.ibex.preferences/script_generator_config_folder=C:/ScriptGeneratorConfigs/
 uk.ac.stfc.isis.ibex.preferences/script_generation_folder=C:/Scripts/
 uk.ac.stfc.isis.ibex.preferences/hide_config_error_table=false
+uk.ac.stfc.isis.ibex.preferences/script_generator_manual_url=http://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator,https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Using-the-Script-Generator


### PR DESCRIPTION
### Description of work
The first commit (44df850) adds a button in the Script Generator panel to open the relevant page on the user manual.

The Java file was indented with a mix of tabs and spaces, so the second commit (30a3a6b) converts all tabs to spaces to avoid weird indentation in some editors.

The third commit capitalises the button text to be consistent with the rest of the UI.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/5166

### Acceptance criteria
1. In the Script Generator panel of the IBEX client, a button labelled "Open Manual" is displayed next to the "Get Validity Errors" button
2. When clicked, the button opens the "Using the Script Generator" user manual page in a browser
3. The same button is dispayed and behaves in the same way in the standalone script generator

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

