### PR TITLE
Ticket5136 memory leak

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServerVariables.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServerVariables.java
@@ -143,7 +143,7 @@ public class ConfigServerVariables extends Closer {
         serverStatus = InstrumentUtils.convert(readCompressed(blockServerAddresses.serverStatus()),
                 converters.toServerStatus());
         currentConfig =
-                InstrumentUtils.convert(readCompressed(blockServerAddresses.currentConfig()), converters.toConfig());
+                InstrumentUtils.convert("currentConfig", readCompressed(blockServerAddresses.currentConfig()), converters.toConfig());
         blankConfig =
                 InstrumentUtils.convert(readCompressed(blockServerAddresses.blankConfig()), converters.toConfig());
         componentDetails =

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/Editing.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/Editing.java
@@ -19,8 +19,7 @@
 
 package uk.ac.stfc.isis.ibex.configserver;
 
-import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
-import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
+import uk.ac.stfc.isis.ibex.configserver.editing.ObservableEditableConfiguration;
 
 /**
  * Public interface for editing the config server.
@@ -34,7 +33,7 @@ public interface Editing {
      * @return
      *          The current configuration as an editable configuration.
      */
-    ClosableObservable<EditableConfiguration> currentConfig();
+    ObservableEditableConfiguration currentConfig();
 
     /**
      * Returns a blank configuration as an editable configuration.
@@ -42,7 +41,7 @@ public interface Editing {
      * @return
      *          A blank configuration as an editable configuration.
      */
-    ClosableObservable<EditableConfiguration> blankConfig();
+    ObservableEditableConfiguration blankConfig();
 
     /**
      * Returns a given configuration as an editable configuration.
@@ -53,7 +52,7 @@ public interface Editing {
      * @return
      *                  A given configuration as an editable configuration.
      */
-    ClosableObservable<EditableConfiguration> config(String configName);
+    ObservableEditableConfiguration config(String configName);
 
 
     /**
@@ -65,5 +64,5 @@ public interface Editing {
      * @return
      *                  A given component as an editable configuration.
      */
-    ClosableObservable<EditableConfiguration> component(String componentName);
+    ObservableEditableConfiguration component(String componentName);
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/Editing.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/Editing.java
@@ -20,6 +20,7 @@
 package uk.ac.stfc.isis.ibex.configserver;
 
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
+import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 
 /**
@@ -34,7 +35,7 @@ public interface Editing {
      * @return
      *          The current configuration as an editable configuration.
      */
-	ForwardingObservable<EditableConfiguration> currentConfig();
+	ClosableObservable<EditableConfiguration> currentConfig();
 	
 	/**
      * Returns a blank configuration as an editable configuration.
@@ -42,7 +43,7 @@ public interface Editing {
      * @return
      *          A blank configuration as an editable configuration.
      */
-	ForwardingObservable<EditableConfiguration> blankConfig();
+	ClosableObservable<EditableConfiguration> blankConfig();
 	
 	/**
      * Returns a given configuration as an editable configuration.
@@ -53,7 +54,7 @@ public interface Editing {
      * @return
      *                  A given configuration as an editable configuration.
      */
-	ForwardingObservable<EditableConfiguration> config(String configName);
+	ClosableObservable<EditableConfiguration> config(String configName);
 	
 	
 	/**
@@ -65,5 +66,5 @@ public interface Editing {
     * @return
     *                  A given component as an editable configuration.
     */
-	ForwardingObservable<EditableConfiguration> component(String componentName);
+	ClosableObservable<EditableConfiguration> component(String componentName);
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/Editing.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/Editing.java
@@ -1,27 +1,26 @@
 
 /*
-* This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
-* All rights reserved.
-*
-* This program is distributed in the hope that it will be useful.
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v1.0 which accompanies this distribution.
-* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
-* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
-* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
-*
-* You should have received a copy of the Eclipse Public License v1.0
-* along with this program; if not, you can obtain a copy from
-* https://www.eclipse.org/org/documents/epl-v10.php or 
-* http://opensource.org/licenses/eclipse-1.0.php
-*/
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2015 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
 
 package uk.ac.stfc.isis.ibex.configserver;
 
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
-import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 
 /**
  * Public interface for editing the config server.
@@ -35,17 +34,17 @@ public interface Editing {
      * @return
      *          The current configuration as an editable configuration.
      */
-	ClosableObservable<EditableConfiguration> currentConfig();
-	
-	/**
+    ClosableObservable<EditableConfiguration> currentConfig();
+
+    /**
      * Returns a blank configuration as an editable configuration.
      * 
      * @return
      *          A blank configuration as an editable configuration.
      */
-	ClosableObservable<EditableConfiguration> blankConfig();
-	
-	/**
+    ClosableObservable<EditableConfiguration> blankConfig();
+
+    /**
      * Returns a given configuration as an editable configuration.
      * 
      * @param configName
@@ -54,17 +53,17 @@ public interface Editing {
      * @return
      *                  A given configuration as an editable configuration.
      */
-	ClosableObservable<EditableConfiguration> config(String configName);
-	
-	
-	/**
-    * Returns a given component as an editable component.
-    * 
-    * @param componentName
-    *                  The desired component.
-    * 
-    * @return
-    *                  A given component as an editable configuration.
-    */
-	ClosableObservable<EditableConfiguration> component(String componentName);
+    ClosableObservable<EditableConfiguration> config(String configName);
+
+
+    /**
+     * Returns a given component as an editable component.
+     * 
+     * @param componentName
+     *                  The desired component.
+     * 
+     * @return
+     *                  A given component as an editable configuration.
+     */
+    ClosableObservable<EditableConfiguration> component(String componentName);
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -40,6 +40,7 @@ import uk.ac.stfc.isis.ibex.configserver.configuration.Macro;
 import uk.ac.stfc.isis.ibex.configserver.configuration.PV;
 import uk.ac.stfc.isis.ibex.configserver.internal.ComponentFilteredConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.internal.DisplayUtils;
+import uk.ac.stfc.isis.ibex.epics.pv.Closable;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 import uk.ac.stfc.isis.ibex.validators.GroupNamesProvider;
 import uk.ac.stfc.isis.ibex.managermode.ManagerModeModel;
@@ -55,7 +56,7 @@ import uk.ac.stfc.isis.ibex.managermode.ManagerModeObserver;
  * available blocks (blocks not from the current instrument).
  * 
  */
-public class EditableConfiguration extends ModelObject implements GroupNamesProvider {
+public class EditableConfiguration extends ModelObject implements GroupNamesProvider, Closable {
 
     /** The property change identifier associated with editing groups. */
     public static final String EDITABLE_GROUPS = "editableGroups";
@@ -155,6 +156,8 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
             firePropertyChange("blocks", blocksBeforeRename, transformBlocks());
         }
     };
+
+	private Optional<ManagerModeObserver> manager_mode_observable = Optional.empty();
 
 
     /**
@@ -820,22 +823,23 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * Add observer to the observable.
      */
     private void addObserver() {
-        new ManagerModeObserver(managerModePv.observable) {
-
-            @Override
-            protected void setManagerMode(Boolean value) {
-                inManagerMode = value;
-                EditableConfiguration.this.setEnableOrDisableSaveButton();
-                EditableConfiguration.this.setEnableSaveAsButton();
-
-            }
-
-            @Override
-            protected void setUnknown() {
-                inManagerMode = null;
-            }
-
-        };
+    	
+//        this.manager_mode_observable = Optional.of(new ManagerModeObserver(managerModePv.observable) {
+//
+//            @Override
+//            protected void setManagerMode(Boolean value) {
+//                inManagerMode = value;
+//                // EditableConfiguration.this.setEnableOrDisableSaveButton();
+//                // EditableConfiguration.this.setEnableSaveAsButton();
+//
+//            }
+//
+//            @Override
+//            protected void setUnknown() {
+//                inManagerMode = null;
+//            }
+//
+//        });
     }
     
     /**
@@ -845,4 +849,10 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
     public String getErrorMessage() {
         return currentErrorMessage;
     }
+
+	@Override
+	public void close() {
+		this.manager_mode_observable.ifPresent(ManagerModeObserver::close);
+		this.manager_mode_observable = Optional.empty();
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -102,7 +102,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
 
     /** Available PVs. */
     private final List<PV> pvs;
-    
+
     /** If this is a component. */
     private boolean isComponent;
 
@@ -124,10 +124,10 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
     final private boolean originalProtectedFlag;
     /** Warning to be shown when saving protected config in non manager mode **/
     private final String savingProtectedConfigWarning = "Info : To modify/save a protected "
-            + "configuration you have to be in Manager Mode";
+	    + "configuration you have to be in Manager Mode";
     /** Warning to be shown when saving protected component in non manager mode **/
     private final String savingProtectedCompWarning = "Info : To modify/save a protected "
-            + "component you have to be in Manager Mode";
+	    + "component you have to be in Manager Mode";
     /** To show when no error **/
     private final String noError = " ";
     /** Current error message to be displayed **/
@@ -139,25 +139,25 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * Listener for block renaming events.
      */
     private final PropertyChangeListener blockRenameListener = new PropertyChangeListener() {
-        @Override
-        public void propertyChange(PropertyChangeEvent evt) {
-            String oldName = (String) evt.getOldValue();
-            String newName = (String) evt.getNewValue();
+	@Override
+	public void propertyChange(PropertyChangeEvent evt) {
+	    String oldName = (String) evt.getOldValue();
+	    String newName = (String) evt.getNewValue();
 
-            // Recreate the collection before the rename occurred.
-            Collection<Block> blocksBeforeRename = transformBlocks();
-            Block renamed = getBlockByName(blocksBeforeRename, newName).orElseThrow(NoSuchElementException::new);
-            blocksBeforeRename.remove(renamed);
+	    // Recreate the collection before the rename occurred.
+	    Collection<Block> blocksBeforeRename = transformBlocks();
+	    Block renamed = getBlockByName(blocksBeforeRename, newName).orElseThrow(NoSuchElementException::new);
+	    blocksBeforeRename.remove(renamed);
 
-            Block oldBlock = new Block(renamed);
-            oldBlock.setName(oldName);
-            blocksBeforeRename.add(oldBlock);
+	    Block oldBlock = new Block(renamed);
+	    oldBlock.setName(oldName);
+	    blocksBeforeRename.add(oldBlock);
 
-            firePropertyChange("blocks", blocksBeforeRename, transformBlocks());
-        }
+	    firePropertyChange("blocks", blocksBeforeRename, transformBlocks());
+	}
     };
 
-	private Optional<ManagerModeObserver> manager_mode_observable = Optional.empty();
+    private Optional<ManagerModeObserver> manager_mode_observable = Optional.empty();
 
 
     /**
@@ -172,152 +172,152 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            The PVs available to the configuration
      */
     public EditableConfiguration(
-            Configuration config,
-            Collection<EditableIoc> iocs,
-            Collection<Configuration> components, 
-            Collection<PV> pvs) {
-        this.name = config.name();
-        this.description = config.description();
-        this.synoptic = config.synoptic();
-        this.isProtected = config.isProtected();
-        originalProtectedFlag = this.isProtected;
-        this.allIocs = new ArrayList<>();
-        this.managerMode = ManagerModeModel.getInstance();
-        this.isSaveButtonEnabled = true;
-        this.enableSaveAsButton = true;
-        managerModePv = managerMode.getManagerModeObservable();
+	    Configuration config,
+	    Collection<EditableIoc> iocs,
+	    Collection<Configuration> components, 
+	    Collection<PV> pvs) {
+	this.name = config.name();
+	this.description = config.description();
+	this.synoptic = config.synoptic();
+	this.isProtected = config.isProtected();
+	originalProtectedFlag = this.isProtected;
+	this.allIocs = new ArrayList<>();
+	this.managerMode = ManagerModeModel.getInstance();
+	this.isSaveButtonEnabled = true;
+	this.enableSaveAsButton = true;
+	managerModePv = managerMode.getManagerModeObservable();
 
-        for (EditableIoc ioc : iocs) {
-            EditableIoc newIoc = new EditableIoc(ioc, ioc.getDescription());
-            newIoc.setAvailableMacros(new ArrayList<>(ioc.getAvailableMacros()));
-            this.allIocs.add(newIoc);
-        }
+	for (EditableIoc ioc : iocs) {
+	    EditableIoc newIoc = new EditableIoc(ioc, ioc.getDescription());
+	    newIoc.setAvailableMacros(new ArrayList<>(ioc.getAvailableMacros()));
+	    this.allIocs.add(newIoc);
+	}
 
-        this.history = new ArrayList<>();
+	this.history = new ArrayList<>();
 
-        for (String date : config.getHistory()) {
-            this.history.add(date);
-        }
+	for (String date : config.getHistory()) {
+	    this.history.add(date);
+	}
 
-        this.pvs = new ArrayList<>(pvs);
+	this.pvs = new ArrayList<>(pvs);
 
-        for (Block block : config.getBlocks()) {
-            EditableBlock eb = new EditableBlock(block);
-            allBlocks.add(eb);
-            if (!block.inComponent()) {
-                makeBlockAvailable(eb);
-            }
-            addRenameListener(eb);
-        }
+	for (Block block : config.getBlocks()) {
+	    EditableBlock eb = new EditableBlock(block);
+	    allBlocks.add(eb);
+	    if (!block.inComponent()) {
+		makeBlockAvailable(eb);
+	    }
+	    addRenameListener(eb);
+	}
 
-        for (Group group : config.getGroups()) {
-            editableGroups.add(new EditableGroup(this, group));
-        }
+	for (Group group : config.getGroups()) {
+	    editableGroups.add(new EditableGroup(this, group));
+	}
 
-        editableGroups = new ArrayList<>(DisplayUtils.removeOtherGroup(editableGroups));
+	editableGroups = new ArrayList<>(DisplayUtils.removeOtherGroup(editableGroups));
 
-        for (EditableIoc ioc : allIocs) {
-            iocMap.put(ioc.getName(), ioc);
-        }
-        initMacros(iocMap);
+	for (EditableIoc ioc : allIocs) {
+	    iocMap.put(ioc.getName(), ioc);
+	}
+	initMacros(iocMap);
 
-        for (Ioc ioc : config.getIocs()) {
-            addIoc(convertIoc(ioc));
-        }
+	for (Ioc ioc : config.getIocs()) {
+	    addIoc(convertIoc(ioc));
+	}
 
-        Collection<Configuration> selectedComponents = getComponentDetails(config.getComponents(), components);
-        editableComponents = new EditableComponents(selectedComponents, components);
-        editableComponents.addPropertyChangeListener(evt -> updateComponents());
+	Collection<Configuration> selectedComponents = getComponentDetails(config.getComponents(), components);
+	editableComponents = new EditableComponents(selectedComponents, components);
+	editableComponents.addPropertyChangeListener(evt -> updateComponents());
 
-        updateComponents();
-        setEnableSaveAsButton();
-        addObserver();
+	updateComponents();
+	setEnableSaveAsButton();
+	addObserver();
     }
 
     private EditableIoc convertIoc(Ioc ioc) {
-        final EditableIoc generalIOC = iocMap.get(ioc.getName());
+	final EditableIoc generalIOC = iocMap.get(ioc.getName());
 
-        EditableIoc editableIoc;
+	EditableIoc editableIoc;
 
-        if (generalIOC == null) {
-            editableIoc = new EditableIoc(ioc, UNKNOWN_IOC_TEXT);
-        } else {
-            editableIoc = new EditableIoc(ioc, generalIOC.getDescription());
-            editableIoc.setAvailableMacros(generalIOC.getAvailableMacros());
-        }
+	if (generalIOC == null) {
+	    editableIoc = new EditableIoc(ioc, UNKNOWN_IOC_TEXT);
+	} else {
+	    editableIoc = new EditableIoc(ioc, generalIOC.getDescription());
+	    editableIoc.setAvailableMacros(generalIOC.getAvailableMacros());
+	}
 
-        return editableIoc;
+	return editableIoc;
     }
 
     private void updateComponents() {
-        Collection<EditableIoc> iocsBeforeUpdate = new ArrayList<EditableIoc>();
-        iocsBeforeUpdate.addAll(componentIocs);
-        componentIocs.clear();
-        for (Configuration comp : editableComponents.getSelected()) {
-            for (Ioc ioc : comp.getIocs()) {
-                EditableIoc compIoc = convertIoc(ioc);
-                compIoc.setComponent(comp.getName());
-                componentIocs.add(compIoc);
-            }
-        }
-        firePropertyChange("iocs", componentIocs, iocsBeforeUpdate);
+	Collection<EditableIoc> iocsBeforeUpdate = new ArrayList<EditableIoc>();
+	iocsBeforeUpdate.addAll(componentIocs);
+	componentIocs.clear();
+	for (Configuration comp : editableComponents.getSelected()) {
+	    for (Ioc ioc : comp.getIocs()) {
+		EditableIoc compIoc = convertIoc(ioc);
+		compIoc.setComponent(comp.getName());
+		componentIocs.add(compIoc);
+	    }
+	}
+	firePropertyChange("iocs", componentIocs, iocsBeforeUpdate);
     }
 
     /**
      * @return The configuration name
      */
     public String getName() {
-        return name;
+	return name;
     }
 
     /**
      * @return The configuration description
      */
     public String getDescription() {
-        return description;
+	return description;
     }
 
     /**
      * @return The name of the default synoptic
      */
     public String getSynoptic() {
-        return synoptic;
+	return synoptic;
     }
 
     /**
      * @return The date the configuration was created
      */
     public String getDateCreated() {
-        if (history.size() != 0) {
-            return history.get(0);
-        } else {
-            return "";
-        }
+	if (history.size() != 0) {
+	    return history.get(0);
+	} else {
+	    return "";
+	}
     }
 
     /**
      * @return The date the configuration was last modified
      */
     public String getDateModified() {
-        if (history.size() != 0) {
-            return history.get(history.size() - 1);
-        } else {
-            return "";
-        }
+	if (history.size() != 0) {
+	    return history.get(history.size() - 1);
+	} else {
+	    return "";
+	}
     }
 
     /**
      * @return if the config is protected or not by manager mode
      */
     public boolean getIsProtected() {
-        return isProtected;
+	return isProtected;
     }
     /**
      * @param name
      *            The new configuration name
      */
     public void setName(String name) {
-        firePropertyChange("name", this.name, this.name = name);
+	firePropertyChange("name", this.name, this.name = name);
     }
 
     /**
@@ -325,7 +325,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            The new configuration description
      */
     public void setDescription(String description) {
-        firePropertyChange("description", this.description, this.description = description);
+	firePropertyChange("description", this.description, this.description = description);
     }
 
     /**
@@ -333,18 +333,18 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            The name of the new default synoptic for the configuration
      */
     public void setSynoptic(String synoptic) {
-        firePropertyChange("synoptic", this.synoptic, this.synoptic = synoptic);
+	firePropertyChange("synoptic", this.synoptic, this.synoptic = synoptic);
     }
-    
+
     /**
      * 
      * @param isProtected
      * 				Whether the configuration is protected to only be editable in manager mode or not
      */
     public void setIsProtected(boolean isProtected) {
-    	firePropertyChange("isProtected", this.isProtected, this.isProtected = isProtected);
-        setEnableOrDisableSaveButton();
-        setEnableSaveAsButton();
+	firePropertyChange("isProtected", this.isProtected, this.isProtected = isProtected);
+	setEnableOrDisableSaveButton();
+	setEnableSaveAsButton();
     }
 
     /**
@@ -352,7 +352,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            The date the configuration was created
      */
     public void setDateCreated(String dateCreated) {
-        firePropertyChange("dateCreated", this.dateCreated, this.dateCreated = dateCreated);
+	firePropertyChange("dateCreated", this.dateCreated, this.dateCreated = dateCreated);
     }
 
     /**
@@ -360,7 +360,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            The date the configuration was last modified
      */
     public void setDateModified(String dateModified) {
-        firePropertyChange("dateModified", this.dateModified, this.dateModified = dateModified);
+	firePropertyChange("dateModified", this.dateModified, this.dateModified = dateModified);
     }
 
     /**
@@ -369,51 +369,51 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * @return True if configuration is new.
      */
     public boolean getIsNew() {
-        return (history.size() == 0);
+	return (history.size() == 0);
     }
 
     /**
      * @return The blocks associated with the configuration
      */
     Collection<Block> transformBlocks() {
-        return new ArrayList<Block>(allBlocks);
+	return new ArrayList<Block>(allBlocks);
     }
 
     /**
      * @return The groups associated with the configuration
      */
     private Collection<Group> transformGroups() {
-        return new ArrayList<Group>(getEditableGroups());
+	return new ArrayList<Group>(getEditableGroups());
     }
 
     /**
      * @return The IOCs associated with the configuration
      */
     private Collection<Ioc> transformIocs() {
-        return new ArrayList<Ioc>(configIocs);
+	return new ArrayList<Ioc>(configIocs);
     }
 
     /**
      * @return The components associated with the configuration
      */
-	private Collection<ComponentInfo> transformComponents() {
-        return editableComponents.getSelected().stream()
-        		.map(ComponentInfo::new)
-        		.collect(Collectors.toCollection(ArrayList::new));
-	}
-	
+    private Collection<ComponentInfo> transformComponents() {
+	return editableComponents.getSelected().stream()
+		.map(ComponentInfo::new)
+		.collect(Collectors.toCollection(ArrayList::new));
+    }
+
     /**
      * @return The dates when the configuration has been modified
      */
     private Collection<String> getHistory() {
-        return history;
+	return history;
     }
 
     /**
      * @return The PVs associated with the configuration
      */
     public Collection<PV> pvs() {
-        return new ArrayList<>(pvs);
+	return new ArrayList<>(pvs);
     }
 
     /**
@@ -423,9 +423,9 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            The IOC to be added.
      */
     public void addIoc(EditableIoc ioc) {
-        Collection<Ioc> iocsBeforeAdd = transformIocs();
-        configIocs.add(ioc);
-        firePropertyChange("iocs", iocsBeforeAdd, transformIocs());
+	Collection<Ioc> iocsBeforeAdd = transformIocs();
+	configIocs.add(ioc);
+	firePropertyChange("iocs", iocsBeforeAdd, transformIocs());
     }
 
     /**
@@ -435,79 +435,79 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            the list of IOCs to remove
      */
     public void removeIocs(List<EditableIoc> iocs) {
-        Collection<EditableIoc> iocsBefore = getAddedIocs();
-        for (EditableIoc ioc : iocs) {
-            configIocs.remove(ioc);
-        }
-        firePropertyChange("iocs", iocsBefore, getAddedIocs());
+	Collection<EditableIoc> iocsBefore = getAddedIocs();
+	for (EditableIoc ioc : iocs) {
+	    configIocs.remove(ioc);
+	}
+	firePropertyChange("iocs", iocsBefore, getAddedIocs());
     }
 
     /**
      * @return The available IOCs not associated with the configuration.
      */
     public Collection<EditableIoc> getAvailableIocs() {
-        List<EditableIoc> result = new ArrayList<EditableIoc>();
-    
-        List<String> addedIocNames = new ArrayList<String>();
-        for (EditableIoc ioc : getAddedIocs()) {
-            addedIocNames.add(ioc.getName());
-        }
-    
-        for (EditableIoc ioc : allIocs) {
-            if (!addedIocNames.contains(ioc.getName())) {
-                result.add(ioc);
-            }
-        }
-        Collections.sort(result);
-        return result;
+	List<EditableIoc> result = new ArrayList<EditableIoc>();
+
+	List<String> addedIocNames = new ArrayList<String>();
+	for (EditableIoc ioc : getAddedIocs()) {
+	    addedIocNames.add(ioc.getName());
+	}
+
+	for (EditableIoc ioc : allIocs) {
+	    if (!addedIocNames.contains(ioc.getName())) {
+		result.add(ioc);
+	    }
+	}
+	Collections.sort(result);
+	return result;
     }
 
     /**
      * @return The IOCs added to the configuration
      */
     public Collection<EditableIoc> getAddedIocs() {
-        Collection<EditableIoc> addedIocs = new ArrayList<EditableIoc>();
-        addedIocs.addAll(configIocs);
-        addedIocs.addAll(componentIocs);
-        return addedIocs;
+	Collection<EditableIoc> addedIocs = new ArrayList<EditableIoc>();
+	addedIocs.addAll(configIocs);
+	addedIocs.addAll(componentIocs);
+	return addedIocs;
     }
 
     // Add available macros to IOCs that are part of the configuration.
     private void initMacros(Map<String, EditableIoc> available) {
-        for (EditableIoc selectedIoc : configIocs) {
-            Collection<Macro> availableMacros = available.get(selectedIoc.getName()).getAvailableMacros();
-            selectedIoc.setAvailableMacros(availableMacros);
-        }
-    
-        Collections.sort(configIocs);
+	for (EditableIoc selectedIoc : configIocs) {
+	    Collection<Macro> availableMacros = available.get(selectedIoc.getName()).getAvailableMacros();
+	    selectedIoc.setAvailableMacros(availableMacros);
+	}
+
+	Collections.sort(configIocs);
     }
 
     /**
      * @return All of the blocks associated with the configuration, including those from components.
      */
     public Collection<EditableBlock> getAllBlocks() {
-        return new ArrayList<>(allBlocks);
+	return new ArrayList<>(allBlocks);
     }
 
     /**
      * @return All of the blocks in the configuration that are not in a group
      */
     public Collection<EditableBlock> getOtherBlocks() {
-        return new ArrayList<>(otherBlocks);
+	return new ArrayList<>(otherBlocks);
     }
 
     /**
      * @return The editable groups associated with the configuration
      */
     public Collection<EditableGroup> getEditableGroups() {
-        return new ArrayList<>(editableGroups);
+	return new ArrayList<>(editableGroups);
     }
 
     /**
      * @return The editable components associated with the configuration
      */
     public EditableComponents getEditableComponents() {
-        return editableComponents;
+	return editableComponents;
     }
 
     /**
@@ -521,15 +521,15 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *             already in the configuration
      */
     public void addNewBlock(EditableBlock block) throws DuplicateBlockNameException {
-        if (blockNameIsUnique(block.getName())) {
-            Collection<Block> blocksBeforeAdd = transformBlocks();
-            allBlocks.add(0, block);
-            makeBlockAvailable(block);
-            addRenameListener(block);
-            firePropertyChange("blocks", blocksBeforeAdd, transformBlocks());
-        } else {
-            throw new DuplicateBlockNameException();
-        }
+	if (blockNameIsUnique(block.getName())) {
+	    Collection<Block> blocksBeforeAdd = transformBlocks();
+	    allBlocks.add(0, block);
+	    makeBlockAvailable(block);
+	    addRenameListener(block);
+	    firePropertyChange("blocks", blocksBeforeAdd, transformBlocks());
+	} else {
+	    throw new DuplicateBlockNameException();
+	}
     }
 
     /**
@@ -541,7 +541,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * @return whether the name is unique as boolean
      */
     private boolean blockNameIsUnique(String name) {
-        return !allBlocks.stream().map(Block::getName).anyMatch(name::equals);
+	return !allBlocks.stream().map(Block::getName).anyMatch(name::equals);
     }
 
     /**
@@ -551,7 +551,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            the block to make unavailable
      */
     public void makeBlockUnavailable(EditableBlock block) {
-        otherBlocks.remove(block);
+	otherBlocks.remove(block);
     }
 
     /**
@@ -561,9 +561,9 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            the block to make available
      */
     public void makeBlockAvailable(EditableBlock block) {
-        if (!otherBlocks.contains(block)) {
-            otherBlocks.add(0, block);
-        }
+	if (!otherBlocks.contains(block)) {
+	    otherBlocks.add(0, block);
+	}
     }
 
     /**
@@ -573,12 +573,12 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            the list of blocks to remove
      */
     public void removeBlocks(List<EditableBlock> blocks) {
-        Collection<Block> blocksBefore = transformBlocks();
-        for (EditableBlock block : blocks) {
-            allBlocks.remove(block);
-            makeBlockUnavailable(block);
-        }
-        firePropertyChange("blocks", blocksBefore, transformBlocks());
+	Collection<Block> blocksBefore = transformBlocks();
+	for (EditableBlock block : blocks) {
+	    allBlocks.remove(block);
+	    makeBlockUnavailable(block);
+	}
+	firePropertyChange("blocks", blocksBefore, transformBlocks());
     }
 
     /**
@@ -588,17 +588,17 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * @return The new group
      */
     public EditableGroup addNewGroup() {
-        Collection<EditableGroup> editableGroupsBefore = getEditableGroups();
-        Collection<Group> groupsBefore = transformGroups();
+	Collection<EditableGroup> editableGroupsBefore = getEditableGroups();
+	Collection<Group> groupsBefore = transformGroups();
 
-        String name = groupName.getUnique(getGroupNames());
-        EditableGroup newGroup = new EditableGroup(this, new Group(name));
-        editableGroups.add(newGroup);
+	String name = groupName.getUnique(getGroupNames());
+	EditableGroup newGroup = new EditableGroup(this, new Group(name));
+	editableGroups.add(newGroup);
 
-        firePropertyChange(EDITABLE_GROUPS, editableGroupsBefore, getEditableGroups());
-        firePropertyChange("groups", groupsBefore, transformGroups());
+	firePropertyChange(EDITABLE_GROUPS, editableGroupsBefore, getEditableGroups());
+	firePropertyChange("groups", groupsBefore, transformGroups());
 
-        return newGroup;
+	return newGroup;
     }
 
     /**
@@ -608,16 +608,16 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            The group to remove
      */
     public void removeGroup(EditableGroup group) {
-        Collection<EditableGroup> editableGroupsBefore = getEditableGroups();
-        Collection<Group> groupsBefore = transformGroups();
+	Collection<EditableGroup> editableGroupsBefore = getEditableGroups();
+	Collection<Group> groupsBefore = transformGroups();
 
-        // Remove selected blocks
-        group.toggleSelection(group.getSelectedBlocks());
+	// Remove selected blocks
+	group.toggleSelection(group.getSelectedBlocks());
 
-        editableGroups.remove(group);
+	editableGroups.remove(group);
 
-        firePropertyChange(EDITABLE_GROUPS, editableGroupsBefore, getEditableGroups());
-		firePropertyChange("groups", groupsBefore, transformGroups());
+	firePropertyChange(EDITABLE_GROUPS, editableGroupsBefore, getEditableGroups());
+	firePropertyChange("groups", groupsBefore, transformGroups());
     }
 
     /**
@@ -626,9 +626,9 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * @return the underlying configuration
      */
     public Configuration asConfiguration() {
-        Configuration config = new Configuration(getName(), getDescription(), getSynoptic(), transformIocs(), transformBlocks(),
-                transformGroups(), transformComponents(), getHistory(), getIsProtected());
-        return new ComponentFilteredConfiguration(config);
+	Configuration config = new Configuration(getName(), getDescription(), getSynoptic(), transformIocs(), transformBlocks(),
+		transformGroups(), transformComponents(), getHistory(), getIsProtected());
+	return new ComponentFilteredConfiguration(config);
     }
 
     /**
@@ -638,9 +638,9 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * @return the configuration as a component
      */
     public Configuration asComponent() {
-        Configuration config = asConfiguration();
-        return new Configuration(config.name(), config.description(), config.synoptic(), config.getIocs(),
-                config.getBlocks(), config.getGroups(), Collections.<ComponentInfo>emptyList(), config.getHistory(), config.isProtected());
+	Configuration config = asConfiguration();
+	return new Configuration(config.name(), config.description(), config.synoptic(), config.getIocs(),
+		config.getBlocks(), config.getGroups(), Collections.<ComponentInfo>emptyList(), config.getHistory(), config.isProtected());
     }
 
     /**
@@ -653,18 +653,18 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            The second group
      */
     public void swapGroups(EditableGroup group1, EditableGroup group2) {
-        Collection<EditableGroup> editableGroupsBefore = getEditableGroups();
-        Collection<Group> groupsBefore = transformGroups();
+	Collection<EditableGroup> editableGroupsBefore = getEditableGroups();
+	Collection<Group> groupsBefore = transformGroups();
 
-        // Need to find indexes because the NONE group may throw result in
-        // non-sequential numbers
-        int index1 = editableGroups.indexOf(group1);
-        int index2 = editableGroups.indexOf(group2);
+	// Need to find indexes because the NONE group may throw result in
+	// non-sequential numbers
+	int index1 = editableGroups.indexOf(group1);
+	int index2 = editableGroups.indexOf(group2);
 
-        Collections.swap(editableGroups, index1, index2);
+	Collections.swap(editableGroups, index1, index2);
 
-        firePropertyChange("editableGroups", editableGroupsBefore, getEditableGroups());
-        firePropertyChange("groups", groupsBefore, transformGroups());
+	firePropertyChange("editableGroups", editableGroupsBefore, getEditableGroups());
+	firePropertyChange("groups", groupsBefore, transformGroups());
     }
 
     /**
@@ -677,9 +677,9 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * @return the Block object
      */
     private static Optional<Block> getBlockByName(Collection<Block> blocks, final String name) {
-        return blocks.stream()
-        		.filter(block -> block.getName().equals(name))
-        		.findFirst();
+	return blocks.stream()
+		.filter(block -> block.getName().equals(name))
+		.findFirst();
     }
 
     /**
@@ -690,7 +690,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * @return the Block object
      */
     public Block getBlockByName(final String name) {
-        return getBlockByName(transformBlocks(), name).orElse(null);
+	return getBlockByName(transformBlocks(), name).orElse(null);
     }
 
     /**
@@ -700,7 +700,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            The block to add to the listener
      */
     private void addRenameListener(EditableBlock block) {
-        block.addPropertyChangeListener("name", blockRenameListener);
+	block.addPropertyChangeListener("name", blockRenameListener);
     }
 
     /**
@@ -710,11 +710,11 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      */
     @Override
     public List<String> getGroupNames() {
-        return transformGroups().stream()
-        		.map(Group::getName)
-        		.collect(Collectors.toCollection(ArrayList::new));
+	return transformGroups().stream()
+		.map(Group::getName)
+		.collect(Collectors.toCollection(ArrayList::new));
     }
-    
+
     /**
      * Sets whether this configuration is a component or not.
      * 
@@ -722,57 +722,57 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *            true if this is a component
      */
     public void setIsComponent(boolean isComponent) {
-        firePropertyChange("isComponent", isComponent, this.isComponent = isComponent);
+	firePropertyChange("isComponent", isComponent, this.isComponent = isComponent);
     }
-    
+
     /**
      * Get whether this configuration is a component or not.
      * 
      * @return true if this is a component
      */
     public boolean getIsComponent() {
-        return isComponent;
+	return isComponent;
     }
     private Collection<Configuration> getComponentDetails(Collection<ComponentInfo> selected,
-            Collection<Configuration> available) {
-        Collection<Configuration> result = new ArrayList<Configuration>();
-        for (ComponentInfo compInfo : selected) {
-            for (Configuration details : available) {
-                if (compInfo.getName().equals(details.name())) {
-                    result.add(details);
-                }
-            }
-        }
-        return result;
+	    Collection<Configuration> available) {
+	Collection<Configuration> result = new ArrayList<Configuration>();
+	for (ComponentInfo compInfo : selected) {
+	    for (Configuration details : available) {
+		if (compInfo.getName().equals(details.name())) {
+		    result.add(details);
+		}
+	    }
+	}
+	return result;
     }
 
-        /**
+    /**
      * Logic for whether to enable or disable save button .
      */
     public void setEnableOrDisableSaveButton() {
-        String errorMessage = noError;
-        if (inManagerMode == null) {
-            // Do nothing
-        } else if ((this.originalProtectedFlag == true) && isProtected == false && inManagerMode) {
+	String errorMessage = noError;
+	if (inManagerMode == null) {
+	    // Do nothing
+	} else if ((this.originalProtectedFlag == true) && isProtected == false && inManagerMode) {
 
-            String compOrConfName = isComponent ? "component" : "configuration";
-            errorMessage = "Warning! If saved, the " + compOrConfName + " " + this.name + " "
-                    + "will be downgraded to an unprotected " + compOrConfName;
-            firePropertyChange("enableOrDisableSaveButton", isSaveButtonEnabled, this.isSaveButtonEnabled = true);
-            
-        } else if ((this.originalProtectedFlag == true) && isProtected == false && !inManagerMode) {
-            errorMessage = isComponent ? this.savingProtectedCompWarning : this.savingProtectedConfigWarning;
-            firePropertyChange("enableOrDisableSaveButton", isSaveButtonEnabled, this.isSaveButtonEnabled = false);
-            
-        } else if ((!inManagerMode && !isProtected) || (inManagerMode)) {
-            errorMessage = this.noError;
-            firePropertyChange("enableOrDisableSaveButton", isSaveButtonEnabled, this.isSaveButtonEnabled = true);
-            
-        } else {
-            errorMessage = isComponent ? this.savingProtectedCompWarning : this.savingProtectedConfigWarning;
-            firePropertyChange("enableOrDisableSaveButton", isSaveButtonEnabled, this.isSaveButtonEnabled = false);
-        }
-        setErrorMessage(errorMessage);
+	    String compOrConfName = isComponent ? "component" : "configuration";
+	    errorMessage = "Warning! If saved, the " + compOrConfName + " " + this.name + " "
+		    + "will be downgraded to an unprotected " + compOrConfName;
+	    firePropertyChange("enableOrDisableSaveButton", isSaveButtonEnabled, this.isSaveButtonEnabled = true);
+
+	} else if ((this.originalProtectedFlag == true) && isProtected == false && !inManagerMode) {
+	    errorMessage = isComponent ? this.savingProtectedCompWarning : this.savingProtectedConfigWarning;
+	    firePropertyChange("enableOrDisableSaveButton", isSaveButtonEnabled, this.isSaveButtonEnabled = false);
+
+	} else if ((!inManagerMode && !isProtected) || (inManagerMode)) {
+	    errorMessage = this.noError;
+	    firePropertyChange("enableOrDisableSaveButton", isSaveButtonEnabled, this.isSaveButtonEnabled = true);
+
+	} else {
+	    errorMessage = isComponent ? this.savingProtectedCompWarning : this.savingProtectedConfigWarning;
+	    firePropertyChange("enableOrDisableSaveButton", isSaveButtonEnabled, this.isSaveButtonEnabled = false);
+	}
+	setErrorMessage(errorMessage);
     }
     /**
      * Sets error message.
@@ -780,26 +780,26 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      *          
      */
     private void setErrorMessage(String message) {
-        firePropertyChange("errorMessage", this.currentErrorMessage, this.currentErrorMessage = message);
+	firePropertyChange("errorMessage", this.currentErrorMessage, this.currentErrorMessage = message);
 
     }
-    
+
     /**
      * Decides if save as Button needs to be enabled or disabled.
      */
     public void setEnableSaveAsButton() {
-        if (inManagerMode == null) {
+	if (inManagerMode == null) {
 
-        } else if ((this.originalProtectedFlag == true) && isProtected == false) {
-            firePropertyChange("enableSaveAsButton", enableSaveAsButton, this.enableSaveAsButton = true);
-                
-        } else if (isProtected && (!inManagerMode)) {
-            firePropertyChange("enableSaveAsButton", enableSaveAsButton, this.enableSaveAsButton = false);
-            
-        } else if (inManagerMode || (!isProtected && !inManagerMode)) {
-            firePropertyChange("enableSaveAsButton", enableSaveAsButton, this.enableSaveAsButton = true);
-            
-        }
+	} else if ((this.originalProtectedFlag == true) && isProtected == false) {
+	    firePropertyChange("enableSaveAsButton", enableSaveAsButton, this.enableSaveAsButton = true);
+
+	} else if (isProtected && (!inManagerMode)) {
+	    firePropertyChange("enableSaveAsButton", enableSaveAsButton, this.enableSaveAsButton = false);
+
+	} else if (inManagerMode || (!isProtected && !inManagerMode)) {
+	    firePropertyChange("enableSaveAsButton", enableSaveAsButton, this.enableSaveAsButton = true);
+
+	}
     }
 
     /**
@@ -808,50 +808,50 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      * @return boolean value to disable or enable save button
      */
     public boolean getEnableOrDisableSaveButton() {
-        return isSaveButtonEnabled;
+	return isSaveButtonEnabled;
     }
-    
+
     /**
      * Enabled or Disable Save Button.
      * @return boolean value to enable or disable save as button
      */
     public boolean getEnableSaveAsButton() {
-        return enableSaveAsButton;
+	return enableSaveAsButton;
     }
 
     /**
      * Add observer to the observable.
      */
     private void addObserver() {
-    	
-        this.manager_mode_observable = Optional.of(new ManagerModeObserver(managerModePv.observable) {
 
-            @Override
-            protected void setManagerMode(Boolean value) {
-                inManagerMode = value;
-                EditableConfiguration.this.setEnableOrDisableSaveButton();
-                EditableConfiguration.this.setEnableSaveAsButton();
-            }
+	this.manager_mode_observable = Optional.of(new ManagerModeObserver(managerModePv.observable) {
 
-            @Override
-            protected void setUnknown() {
-                inManagerMode = null;
-            }
+	    @Override
+	    protected void setManagerMode(Boolean value) {
+		inManagerMode = value;
+		EditableConfiguration.this.setEnableOrDisableSaveButton();
+		EditableConfiguration.this.setEnableSaveAsButton();
+	    }
 
-        });
+	    @Override
+	    protected void setUnknown() {
+		inManagerMode = null;
+	    }
+
+	});
     }
-    
+
     /**
      * Gets current error message.
      * @return current error message
      */
     public String getErrorMessage() {
-        return currentErrorMessage;
+	return currentErrorMessage;
     }
 
-	@Override
-	public void close() {
-		this.manager_mode_observable.ifPresent(ManagerModeObserver::close);
-		this.manager_mode_observable = Optional.empty();
-	}
+    @Override
+    public void close() {
+	this.manager_mode_observable.ifPresent(ManagerModeObserver::close);
+	this.manager_mode_observable = Optional.empty();
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -824,22 +824,21 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
      */
     private void addObserver() {
     	
-//        this.manager_mode_observable = Optional.of(new ManagerModeObserver(managerModePv.observable) {
-//
-//            @Override
-//            protected void setManagerMode(Boolean value) {
-//                inManagerMode = value;
-//                // EditableConfiguration.this.setEnableOrDisableSaveButton();
-//                // EditableConfiguration.this.setEnableSaveAsButton();
-//
-//            }
-//
-//            @Override
-//            protected void setUnknown() {
-//                inManagerMode = null;
-//            }
-//
-//        });
+        this.manager_mode_observable = Optional.of(new ManagerModeObserver(managerModePv.observable) {
+
+            @Override
+            protected void setManagerMode(Boolean value) {
+                inManagerMode = value;
+                EditableConfiguration.this.setEnableOrDisableSaveButton();
+                EditableConfiguration.this.setEnableSaveAsButton();
+            }
+
+            @Override
+            protected void setUnknown() {
+                inManagerMode = null;
+            }
+
+        });
     }
     
     /**

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
@@ -1,21 +1,21 @@
 
 /*
-* This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
-* All rights reserved.
-*
-* This program is distributed in the hope that it will be useful.
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v1.0 which accompanies this distribution.
-* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
-* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
-* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
-*
-* You should have received a copy of the Eclipse Public License v1.0
-* along with this program; if not, you can obtain a copy from
-* https://www.eclipse.org/org/documents/epl-v10.php or 
-* http://opensource.org/licenses/eclipse-1.0.php
-*/
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2015 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
 
 package uk.ac.stfc.isis.ibex.configserver.editing;
 
@@ -36,11 +36,11 @@ import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
  * Build a full configuration suitable for editing.
  */
 public class ObservableEditableConfiguration 
-        extends TransformingObservable<Configuration, EditableConfiguration> {
-	
+extends TransformingObservable<Configuration, EditableConfiguration> {
 
-	private static final Logger LOG = IsisLog.getLogger(ObservableEditableConfiguration.class);
-	private final ConfigServer configServer;
+
+    private static final Logger LOG = IsisLog.getLogger(ObservableEditableConfiguration.class);
+    private final ConfigServer configServer;
 
     /**
      * Constructor for the ObservableEditableConfiguration.
@@ -50,53 +50,49 @@ public class ObservableEditableConfiguration
      * @param configServer
      *            The config server
      */
-	public ObservableEditableConfiguration(
-			ClosableObservable<Configuration> config,
-			ConfigServer configServer) {
-		this.configServer = configServer;
-		setSource(config);
-	}
-	
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	protected EditableConfiguration transform(Configuration value) {
-				
-	    try {
-	    	// close the previous editable config
-	    	EditableConfiguration val = this.getValue();
-	    	if (val != null) {
-	    		val.close();
-	    	};
-    		return new EditableConfiguration(
-    				value, 
-                    valueOrEmptyCollection(configServer.iocs()),
-                    valueOrEmptyCollection(configServer.componentDetails()), 
-                    valueOrEmptyCollection(configServer.pvs()));
-	    } catch (RuntimeException e) {
-	        // Log here because the exception will be lost in the observer/observables.
-	    	LoggerUtils.logErrorWithStackTrace(LOG, e.getMessage(), e);
-            throw e;
-        }
-	}
+    public ObservableEditableConfiguration(
+	    ClosableObservable<Configuration> config,
+	    ConfigServer configServer) {
+	this.configServer = configServer;
+	setSource(config);
+    }
 
-    private static <T> Collection<T> valueOrEmptyCollection(Observable<Collection<T>> collection) {
-		return collection.getValue() != null ? collection.getValue() : Collections.<T>emptyList();
-	}
-    
     /**
-     * Close the observable editable configuration.
-     * This is special because we do not want to close the source because the source is config. 
+     * {@inheritDoc}
      */
     @Override
-    public void close() {
-    	//super.close(); This is not done because we don't want to close the source just want to unsubscribe. 
-    	// However we can't do that because this is a closable.
-    	EditableConfiguration val = this.getValue();
-    	if (val != null) {
-    		val.close();
-    	};
-    	cancelSubscription();
+    protected EditableConfiguration transform(Configuration value) {
+
+	try {
+	    // close the previous editable config
+	    EditableConfiguration val = this.getValue();
+	    if (val != null) {
+		val.close();
+	    }
+	    return new EditableConfiguration(
+		    value, 
+		    valueOrEmptyCollection(configServer.iocs()),
+		    valueOrEmptyCollection(configServer.componentDetails()), 
+		    valueOrEmptyCollection(configServer.pvs()));
+	} catch (RuntimeException e) {
+	    // Log here because the exception will be lost in the observer/observables.
+	    LoggerUtils.logErrorWithStackTrace(LOG, e.getMessage(), e);
+	    throw e;
+	}
+    }
+
+    private static <T> Collection<T> valueOrEmptyCollection(Observable<Collection<T>> collection) {
+	return collection.getValue() != null ? collection.getValue() : Collections.<T>emptyList();
+    }
+
+    /**
+     * Unsubscribe from config and close editable config 
+     */
+    public void cancelSubscriptionAndCloseEditableConfig() {
+	EditableConfiguration val = this.getValue();
+	if (val != null) {
+	    val.close();
+	};
+	cancelSubscription();
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
@@ -21,14 +21,16 @@ package uk.ac.stfc.isis.ibex.configserver.editing;
 
 import java.util.Collection;
 import java.util.Collections;
-
 import org.apache.logging.log4j.Logger;
 
 import uk.ac.stfc.isis.ibex.configserver.ConfigServer;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.Observable;
+import uk.ac.stfc.isis.ibex.epics.observing.Observer;
+import uk.ac.stfc.isis.ibex.epics.observing.Subscription;
 import uk.ac.stfc.isis.ibex.epics.observing.TransformingObservable;
+import uk.ac.stfc.isis.ibex.epics.observing.Unsubscriber;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
 
@@ -37,6 +39,8 @@ import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
  */
 public class ObservableEditableConfiguration 
         extends TransformingObservable<Configuration, EditableConfiguration> {
+	
+	//public static ArrayList<ObservableEditableConfiguration> LIST = new ArrayList<>();
 
 	private static final Logger LOG = IsisLog.getLogger(ObservableEditableConfiguration.class);
 	private final ConfigServer configServer;
@@ -61,7 +65,13 @@ public class ObservableEditableConfiguration
 	 */
 	@Override
 	protected EditableConfiguration transform(Configuration value) {
+		//LIST.add(this);
+				
 	    try {
+	    	EditableConfiguration val = this.getValue();
+	    	if (val != null) {
+	    		val.close();
+	    	};
     		return new EditableConfiguration(
     				value, 
                     valueOrEmptyCollection(configServer.iocs()),
@@ -77,4 +87,27 @@ public class ObservableEditableConfiguration
     private static <T> Collection<T> valueOrEmptyCollection(Observable<Collection<T>> collection) {
 		return collection.getValue() != null ? collection.getValue() : Collections.<T>emptyList();
 	}
+    
+    @Override
+    public void close() {
+    	EditableConfiguration val = this.getValue();
+    	if (val != null) {
+    		val.close();
+    	};
+    	//super.close();
+    	cancelSubscription();
+    }
+    
+//    @Override
+//    public void unsubscribe(Observer<EditableConfiguration> observer) {
+//    	source.un
+//    }
+    
+    @Override
+    public Subscription subscribe(Observer<EditableConfiguration> observer) {
+    	// TODO Auto-generated method stub
+    	//if (this.observers.size() > 1)
+    		
+    	return super.subscribe(observer);
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/ObservableEditableConfiguration.java
@@ -21,16 +21,14 @@ package uk.ac.stfc.isis.ibex.configserver.editing;
 
 import java.util.Collection;
 import java.util.Collections;
+
 import org.apache.logging.log4j.Logger;
 
 import uk.ac.stfc.isis.ibex.configserver.ConfigServer;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.Observable;
-import uk.ac.stfc.isis.ibex.epics.observing.Observer;
-import uk.ac.stfc.isis.ibex.epics.observing.Subscription;
 import uk.ac.stfc.isis.ibex.epics.observing.TransformingObservable;
-import uk.ac.stfc.isis.ibex.epics.observing.Unsubscriber;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
 
@@ -40,7 +38,6 @@ import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
 public class ObservableEditableConfiguration 
         extends TransformingObservable<Configuration, EditableConfiguration> {
 	
-	//public static ArrayList<ObservableEditableConfiguration> LIST = new ArrayList<>();
 
 	private static final Logger LOG = IsisLog.getLogger(ObservableEditableConfiguration.class);
 	private final ConfigServer configServer;
@@ -65,9 +62,9 @@ public class ObservableEditableConfiguration
 	 */
 	@Override
 	protected EditableConfiguration transform(Configuration value) {
-		//LIST.add(this);
 				
 	    try {
+	    	// close the previous editable config
 	    	EditableConfiguration val = this.getValue();
 	    	if (val != null) {
 	    		val.close();
@@ -88,26 +85,18 @@ public class ObservableEditableConfiguration
 		return collection.getValue() != null ? collection.getValue() : Collections.<T>emptyList();
 	}
     
+    /**
+     * Close the observable editable configuration.
+     * This is special because we do not want to close the source because the source is config. 
+     */
     @Override
     public void close() {
+    	//super.close(); This is not done because we don't want to close the source just want to unsubscribe. 
+    	// However we can't do that because this is a closable.
     	EditableConfiguration val = this.getValue();
     	if (val != null) {
     		val.close();
     	};
-    	//super.close();
     	cancelSubscription();
-    }
-    
-//    @Override
-//    public void unsubscribe(Observer<EditableConfiguration> observer) {
-//    	source.un
-//    }
-    
-    @Override
-    public Subscription subscribe(Observer<EditableConfiguration> observer) {
-    	// TODO Auto-generated method stub
-    	//if (this.observers.size() > 1)
-    		
-    	return super.subscribe(observer);
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ConfigEditing.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ConfigEditing.java
@@ -22,7 +22,6 @@ package uk.ac.stfc.isis.ibex.configserver.internal;
 import uk.ac.stfc.isis.ibex.configserver.ConfigServer;
 import uk.ac.stfc.isis.ibex.configserver.Editing;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
-import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.editing.ObservableEditableConfiguration;
 import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.epics.pv.Closer;
@@ -57,7 +56,7 @@ public class ConfigEditing extends Closer implements Editing {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ClosableObservable<EditableConfiguration> currentConfig() {
+	public ObservableEditableConfiguration currentConfig() {
 		return edit(configServer.currentConfig());
 	}
 
@@ -65,7 +64,7 @@ public class ConfigEditing extends Closer implements Editing {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ClosableObservable<EditableConfiguration> blankConfig() {
+	public ObservableEditableConfiguration blankConfig() {
 		return edit(configServer.blankConfig());
 	}
 
@@ -73,7 +72,7 @@ public class ConfigEditing extends Closer implements Editing {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ClosableObservable<EditableConfiguration> config(String configName) {
+	public ObservableEditableConfiguration config(String configName) {
 		return edit(configServer.config(configName));
 	}
 
@@ -81,15 +80,11 @@ public class ConfigEditing extends Closer implements Editing {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ClosableObservable<EditableConfiguration> component(String componentName) {
+	public ObservableEditableConfiguration component(String componentName) {
 		return edit(configServer.component(componentName));
 	}
 
-	private ClosableObservable<EditableConfiguration> edit(ClosableObservable<Configuration> config) {
-		ObservableEditableConfiguration editableConfig = new ObservableEditableConfiguration(
-				config, 
-				configServer);
-		
-		return editableConfig;
+	private ObservableEditableConfiguration edit(ClosableObservable<Configuration> config) { 		
+		return registerForClose(new ObservableEditableConfiguration(config,configServer));
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ConfigEditing.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ConfigEditing.java
@@ -25,7 +25,6 @@ import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.editing.ObservableEditableConfiguration;
 import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
-import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.epics.pv.Closer;
 
 /**
@@ -91,6 +90,6 @@ public class ConfigEditing extends Closer implements Editing {
 				config, 
 				configServer);
 		
-		return editableConfig; //new ForwardingObservable<>("config editor", editableConfig);
+		return editableConfig;
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ConfigEditing.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/ConfigEditing.java
@@ -58,7 +58,7 @@ public class ConfigEditing extends Closer implements Editing {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ForwardingObservable<EditableConfiguration> currentConfig() {
+	public ClosableObservable<EditableConfiguration> currentConfig() {
 		return edit(configServer.currentConfig());
 	}
 
@@ -66,7 +66,7 @@ public class ConfigEditing extends Closer implements Editing {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ForwardingObservable<EditableConfiguration> blankConfig() {
+	public ClosableObservable<EditableConfiguration> blankConfig() {
 		return edit(configServer.blankConfig());
 	}
 
@@ -74,7 +74,7 @@ public class ConfigEditing extends Closer implements Editing {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ForwardingObservable<EditableConfiguration> config(String configName) {
+	public ClosableObservable<EditableConfiguration> config(String configName) {
 		return edit(configServer.config(configName));
 	}
 
@@ -82,11 +82,15 @@ public class ConfigEditing extends Closer implements Editing {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public ForwardingObservable<EditableConfiguration> component(String componentName) {
+	public ClosableObservable<EditableConfiguration> component(String componentName) {
 		return edit(configServer.component(componentName));
 	}
 
-	private ForwardingObservable<EditableConfiguration> edit(ClosableObservable<Configuration> config) {
-		return registerForClose(new ForwardingObservable<>(new ObservableEditableConfiguration(config, configServer)));
+	private ClosableObservable<EditableConfiguration> edit(ClosableObservable<Configuration> config) {
+		ObservableEditableConfiguration editableConfig = new ObservableEditableConfiguration(
+				config, 
+				configServer);
+		
+		return editableConfig; //new ForwardingObservable<>("config editor", editableConfig);
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/adapters/UpdatedObservableAdapter.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/adapters/UpdatedObservableAdapter.java
@@ -20,6 +20,7 @@
 package uk.ac.stfc.isis.ibex.epics.adapters;
 
 import uk.ac.stfc.isis.ibex.epics.observing.BaseObserver;
+import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.Observable;
 import uk.ac.stfc.isis.ibex.epics.observing.Observer;
@@ -57,7 +58,7 @@ public class UpdatedObservableAdapter<T> extends SettableUpdatedValue<T> impleme
      * @param observable
      *            the observable
      */
-	public UpdatedObservableAdapter(ForwardingObservable<T> observable) {
+	public UpdatedObservableAdapter(ClosableObservable<T> observable) {
 		subscribeTo(observable);
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ClosableObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ClosableObservable.java
@@ -128,7 +128,7 @@ public abstract class ClosableObservable<T> implements Observable<T>, Closable {
     		logErrorsAndContinue(() -> this.value.ifPresent(observer::onValue));
     	}
     }
-
+    
     /**
      * Sets the current error experienced by this observable. Error is blanked
      * if a new value is set

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
@@ -60,6 +60,10 @@ public class ForwardingObservable<T> extends TransformingObservable<T, T> {
     
     @Override
     public String toString() {
-        return this.name + " " + super.toString();
+	String asString = super.toString();	
+	if (this.name != "") {
+	    asString = this.name + " which is " + asString;
+	}
+        return asString;
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
@@ -27,8 +27,8 @@ package uk.ac.stfc.isis.ibex.epics.observing;
  *            The type of the value that you are observing.
  */
 public class ForwardingObservable<T> extends TransformingObservable<T, T> {
-	
-	public final String name;
+
+    public final String name;
 
     /**
      * Sets up an unnamed forwarding observable with a closable source.
@@ -36,12 +36,12 @@ public class ForwardingObservable<T> extends TransformingObservable<T, T> {
      * @param source
      *            the source observable
      */
-	public ForwardingObservable(ClosableObservable<T> source) {
-		this("", source);
-	}
-		
+    public ForwardingObservable(ClosableObservable<T> source) {
+	this("", source);
+    }
+
     /**
-     * Sets up a forwarding observable with a closable source.
+     * Sets up a named forwarding observable with a closable source.
      * 
      * @param source
      *            the source observable
@@ -49,12 +49,12 @@ public class ForwardingObservable<T> extends TransformingObservable<T, T> {
      * 				an optional name for this forwarding observable to help with identification
      */
     public ForwardingObservable(String name, ClosableObservable<T> source) {
-    	setSource(source);
-    	this.name = name;
+	setSource(source);
+	this.name = name;
     }
 
-	@Override
-	protected T transform(T value) {
-		return value;
-	}
+    @Override
+    protected T transform(T value) {
+	return value;
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
@@ -27,6 +27,12 @@ package uk.ac.stfc.isis.ibex.epics.observing;
  *            The type of the value that you are observing.
  */
 public class ForwardingObservable<T> extends TransformingObservable<T, T> {
+	
+	public final String name;
+	
+	public ForwardingObservable(ClosableObservable<T> source) {
+		this("not the one we care about", source);
+	}
 		
     /**
      * Sets up a forwarding observable with a closable source.
@@ -34,8 +40,9 @@ public class ForwardingObservable<T> extends TransformingObservable<T, T> {
      * @param source
      *            the source observable
      */
-    public ForwardingObservable(ClosableObservable<T> source) {
+    public ForwardingObservable(String name, ClosableObservable<T> source) {
     	setSource(source);
+    	this.name = name;
     }
 
 	@Override

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
@@ -57,4 +57,9 @@ public class ForwardingObservable<T> extends TransformingObservable<T, T> {
     protected T transform(T value) {
 	return value;
     }
+    
+    @Override
+    public String toString() {
+        return this.name + " " + super.toString();
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/ForwardingObservable.java
@@ -29,9 +29,15 @@ package uk.ac.stfc.isis.ibex.epics.observing;
 public class ForwardingObservable<T> extends TransformingObservable<T, T> {
 	
 	public final String name;
-	
+
+    /**
+     * Sets up an unnamed forwarding observable with a closable source.
+     * 
+     * @param source
+     *            the source observable
+     */
 	public ForwardingObservable(ClosableObservable<T> source) {
-		this("not the one we care about", source);
+		this("", source);
 	}
 		
     /**
@@ -39,6 +45,8 @@ public class ForwardingObservable<T> extends TransformingObservable<T, T> {
      * 
      * @param source
      *            the source observable
+     * @param name
+     * 				an optional name for this forwarding observable to help with identification
      */
     public ForwardingObservable(String name, ClosableObservable<T> source) {
     	setSource(source);

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/TransformingObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/TransformingObservable.java
@@ -30,64 +30,64 @@ package uk.ac.stfc.isis.ibex.epics.observing;
  */
 public abstract class TransformingObservable<T1, T2> extends ClosableObservable<T2> {
 
-	/**
-	 * The observable that provides the raw value to be converted.
-	 */
+    /**
+     * The observable that provides the raw value to be converted.
+     */
     protected ClosableObservable<T1> source;
 
     /**
      * Keeps track of the connection between the source observer and the source so it
      * can be cancelled later on if desired.
      */
-	private Subscription sourceSubscription;
+    private Subscription sourceSubscription;
 
-	/**
-	 * Observes the source and triggers the properties of this object to be updated when
-	 * they change.
-	 */
-	private final BaseObserver<T1> sourceObserver = new BaseObserver<T1>() {
-		@Override
-		public void onValue(T1 value) {
-			setValue(transform(value));
-		}
+    /**
+     * Observes the source and triggers the properties of this object to be updated when
+     * they change.
+     */
+    private final BaseObserver<T1> sourceObserver = new BaseObserver<T1>() {
+	@Override
+	public void onValue(T1 value) {
+	    setValue(transform(value));
+	}
 
-		@Override
-		public void onError(Exception e) {
-			setError(e);
-		}
+	@Override
+	public void onError(Exception e) {
+	    setError(e);
+	}
 
-		@Override
-		public void onConnectionStatus(boolean isConnected) {
-			setConnectionStatus(isConnected);
-		}
+	@Override
+	public void onConnectionStatus(boolean isConnected) {
+	    setConnectionStatus(isConnected);
+	}
 
-	};
+    };
 
-	/**
-	 * Set the data source for this observable to get its data from.
-	 *
-	 * @param source The source that supplies the raw data that this object transforms
-	 */
+    /**
+     * Set the data source for this observable to get its data from.
+     *
+     * @param source The source that supplies the raw data that this object transforms
+     */
     protected synchronized void setSource(ClosableObservable<T1> source) {
-		cancelSubscription();
+	cancelSubscription();
 
-		closeSource();
-		this.source = source;
+	closeSource();
+	this.source = source;
 
-        sourceObserver.onConnectionStatus(false);
-        sourceObserver.onConnectionStatus(source.isConnected());
+	sourceObserver.onConnectionStatus(false);
+	sourceObserver.onConnectionStatus(source.isConnected());
 
-        T1 value = source.getValue();
-        if (value != null) {
-        	sourceObserver.onValue(value);
-        }
+	T1 value = source.getValue();
+	if (value != null) {
+	    sourceObserver.onValue(value);
+	}
 
-        Exception error = source.currentError();
-        if (error != null) {
-        	sourceObserver.onError(error);
-        }
+	Exception error = source.currentError();
+	if (error != null) {
+	    sourceObserver.onError(error);
+	}
 
-		sourceSubscription = source.subscribe(sourceObserver);
+	sourceSubscription = source.subscribe(sourceObserver);
     }
 
     /**
@@ -97,44 +97,44 @@ public abstract class TransformingObservable<T1, T2> extends ClosableObservable<
      * @param value The new value of the source
      * @return The transformed value supplied by this object
      */
-	protected abstract T2 transform(T1 value);
+    protected abstract T2 transform(T1 value);
 
-	@Override
-	public void close() {
-		cancelSubscription();
-		closeSource();
-        super.close();
-	}
+    @Override
+    public void close() {
+	cancelSubscription();
+	closeSource();
+	super.close();
+    }
 
-	/**
-	 * Break the connection between this objects source observer and the source
-	 * it is currently pointing at.
-	 */
-	protected void cancelSubscription() {
-		if (sourceSubscription != null) {
-			sourceSubscription.cancelSubscription();
-		}
+    /**
+     * Break the connection between this objects source observer and the source
+     * it is currently pointing at.
+     */
+    protected void cancelSubscription() {
+	if (sourceSubscription != null) {
+	    sourceSubscription.cancelSubscription();
 	}
+    }
 
-	/**
-	 * Close the attached data source. Useful for triggering a whole stack of observables to close
-	 * from the top down.
-	 */
-	private void closeSource() {
-		if (source != null) {
-	        sourceObserver.onConnectionStatus(false);
-			source.close();
-			source=null;
-		}
+    /**
+     * Close the attached data source. Useful for triggering a whole stack of observables to close
+     * from the top down.
+     */
+    private void closeSource() {
+	if (source != null) {
+	    sourceObserver.onConnectionStatus(false);
+	    source.close();
+	    source = null;
 	}
+    }
 
-	/**
-	 * Return a human readable value to assist with identifying issues in the observable stack.
-	 *
-	 * @return The string representation of the object.
-	 */
-	@Override
-	public String toString() {
-		return this.getClass().getName() + " observing source: " + source;
-	}
+    /**
+     * Return a human readable value to assist with identifying issues in the observable stack.
+     *
+     * @return The string representation of the object.
+     */
+    @Override
+    public String toString() {
+	return this.getClass().getName() + " observing source: " + source;
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/TransformingObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/observing/TransformingObservable.java
@@ -110,7 +110,7 @@ public abstract class TransformingObservable<T1, T2> extends ClosableObservable<
 	 * Break the connection between this objects source observer and the source
 	 * it is currently pointing at.
 	 */
-	private void cancelSubscription() {
+	protected void cancelSubscription() {
 		if (sourceSubscription != null) {
 			sourceSubscription.cancelSubscription();
 		}
@@ -124,6 +124,7 @@ public abstract class TransformingObservable<T1, T2> extends ClosableObservable<
 		if (source != null) {
 	        sourceObserver.onConnectionStatus(false);
 			source.close();
+			source=null;
 		}
 	}
 
@@ -134,6 +135,6 @@ public abstract class TransformingObservable<T1, T2> extends ClosableObservable<
 	 */
 	@Override
 	public String toString() {
-		return this.getClass().getName() + " observing source: " + source.toString();
+		return this.getClass().getName() + " observing source: " + source;
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pv/Closer.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pv/Closer.java
@@ -20,8 +20,11 @@
 package uk.ac.stfc.isis.ibex.epics.pv;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.WeakHashMap;
 
 import org.apache.logging.log4j.Logger;
 
@@ -33,7 +36,7 @@ import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
  */
 public class Closer implements Closable {
 
-	private final List<Closable> resources = new ArrayList<>();
+	private final Set<Closable> resources = Collections.newSetFromMap(new WeakHashMap<Closable, Boolean>());
 	private static final Logger LOG = IsisLog.getLogger(Closer.class);
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pv/Closer.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pv/Closer.java
@@ -19,9 +19,7 @@
 
 package uk.ac.stfc.isis.ibex.epics.pv;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -36,6 +34,7 @@ import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
  */
 public class Closer implements Closable {
 
+	// resources to close, these are weak references so that the garbage collector can collect them even if they are in a closer
 	private final Set<Closable> resources = Collections.newSetFromMap(new WeakHashMap<Closable, Boolean>());
 	private static final Logger LOG = IsisLog.getLogger(Closer.class);
 

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentUtils.java
@@ -48,9 +48,14 @@ public final class InstrumentUtils {
      *            the converter
      * @return the new observable
      */
+    public static <S, T> ForwardingObservable<T> convert(String name, ClosableObservable<S> observable,
+            Converter<S, T> converter) {
+        return new ForwardingObservable<>(name, new ConvertingObservable<>(observable, converter));
+	}
+
     public static <S, T> ForwardingObservable<T> convert(ClosableObservable<S> observable,
             Converter<S, T> converter) {
-        return new ForwardingObservable<>(new ConvertingObservable<>(observable, converter));
+        return new ForwardingObservable<>("InstUtils", new ConvertingObservable<>(observable, converter));
 	}
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/InstrumentUtils.java
@@ -55,12 +55,12 @@ public final class InstrumentUtils {
 
     public static <S, T> ForwardingObservable<T> convert(ClosableObservable<S> observable,
             Converter<S, T> converter) {
-        return new ForwardingObservable<>("InstUtils", new ConvertingObservable<>(observable, converter));
+        return new ForwardingObservable<>(new ConvertingObservable<>(observable, converter));
 	}
 
     /**
      * Provides a writable that converts data and sends to another writable.
-     * 
+     * 	
      * @param <S>
      *            The type of data to convert to
      * @param <T>

--- a/base/uk.ac.stfc.isis.ibex.ui.banner/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.banner/META-INF/MANIFEST.MF
@@ -13,8 +13,7 @@ Require-Bundle: org.eclipse.ui,
  uk.ac.stfc.isis.ibex.instrument;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.managermode;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.dae,
- uk.ac.stfc.isis.ibex.configserver,
- javax.annotation;bundle-version="1.2.0"
+ uk.ac.stfc.isis.ibex.configserver
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.ui.banner.views;uses:="org.eclipse.ui,org.eclipse.ui.part,org.eclipse.swt.widgets"

--- a/base/uk.ac.stfc.isis.ibex.ui.banner/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.banner/META-INF/MANIFEST.MF
@@ -13,7 +13,8 @@ Require-Bundle: org.eclipse.ui,
  uk.ac.stfc.isis.ibex.instrument;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.managermode;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.dae,
- uk.ac.stfc.isis.ibex.configserver
+ uk.ac.stfc.isis.ibex.configserver,
+ javax.annotation.source;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.ui.banner.views;uses:="org.eclipse.ui,org.eclipse.ui.part,org.eclipse.swt.widgets"

--- a/base/uk.ac.stfc.isis.ibex.ui.banner/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.banner/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Require-Bundle: org.eclipse.ui,
  uk.ac.stfc.isis.ibex.managermode;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.dae,
  uk.ac.stfc.isis.ibex.configserver,
- javax.annotation.source;bundle-version="1.2.0"
+ javax.annotation;bundle-version="1.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.ui.banner.views;uses:="org.eclipse.ui,org.eclipse.ui.part,org.eclipse.swt.widgets"

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/ConfigurationViewModels.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/ConfigurationViewModels.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import uk.ac.stfc.isis.ibex.configserver.Editing;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
+import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.model.Awaited;
@@ -41,132 +42,153 @@ import uk.ac.stfc.isis.ibex.ui.configserver.editing.groups.GroupEditorViewModel;
  */
 public class ConfigurationViewModels {
 
-    private static final int MAX_SECONDS_TO_WAIT_FOR_VALUE = 10;
+	private static final int MAX_SECONDS_TO_WAIT_FOR_VALUE = 10;
 
-    /** model that is being edited. */
-    private Editing editingModel;
+	/** model that is being edited. */
+	private Editing editingModel;
 
-    /** common observables from the model for configuration. */
-    private UpdatedObservableAdapter<EditableConfiguration> observableConfigModel;
+	/** common observables from the model for configuration. */
+	private UpdatedObservableAdapter<EditableConfiguration> observableConfigModel;
 
-    /** view model for the group. */
-    private GroupEditorViewModel groupEditorViewModel;
+	/** view model for the group. */
+	private GroupEditorViewModel groupEditorViewModel;
 
-    private static final Logger LOG = IsisLog.getLogger(ConfigurationViewModels.class);
+	private Optional<ClosableObservable<EditableConfiguration>> configModel = Optional.empty();
 
-    /**
-     * Constructor.
-     */
-    public ConfigurationViewModels() {
-        groupEditorViewModel = new GroupEditorViewModel();
-        LOG.info("Created configurationviewmodels");
-    }
+	private static final Logger LOG = IsisLog.getLogger(ConfigurationViewModels.class);
 
-    /**
-     * Bind the editing model to this model.
-     * Note: this must be done before changing the item being edited.
-     *
-     * @param editingModel the editing model
-     */
-    public void bind(Editing editingModel) {
-        this.editingModel = editingModel;
-        observableConfigModel = new UpdatedObservableAdapter<EditableConfiguration>(editingModel.currentConfig());
-    }
+	/**
+	 * Constructor.
+	 */
+	public ConfigurationViewModels() {
+		groupEditorViewModel = new GroupEditorViewModel();
+		LOG.info("Created configurationviewmodels");
+	}
 
-    /**
-     * Get the model for group being edited.
-     *
-     * @return the group editor view model
-     */
-    public GroupEditorViewModel groupEditorViewModel() {
-        return groupEditorViewModel;
-    }
+	/**
+	 * Bind the editing model to this model. Note: this must be done before changing
+	 * the item being edited.
+	 *
+	 * @param editingModel the editing model
+	 */
+	public void bind(Editing editingModel) {
+		this.editingModel = editingModel;
+		LOG.info("Calling bind in ConfigurationViewModels");
+		// observableConfigModel = new
+		// UpdatedObservableAdapter<EditableConfiguration>(editingModel.currentConfig());
+		setAsObservableConfigModel(editingModel.currentConfig());
+	}
 
-    /**
-     * Get the configuration model.
-     *
-     * @return configuration model
-     */
-    public UpdatedObservableAdapter<EditableConfiguration> getConfigModel() {
-        return observableConfigModel;
-    }
+	/**
+	 * Get the model for group being edited.
+	 *
+	 * @return the group editor view model
+	 */
+	public GroupEditorViewModel groupEditorViewModel() {
+		return groupEditorViewModel;
+	}
 
-    /**
-     * Set the model to point at the current configuration.
-     *
-     * @return configuration model
-     * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed before the current config was accessible.
-     */
-    public EditableConfiguration getCurrentConfig() throws TimeoutException {
-    	return currentValueFromObservable(editingModel.currentConfig());
-    }
+	/**
+	 * Get the configuration model.
+	 *
+	 * @return configuration model
+	 */
+	public UpdatedObservableAdapter<EditableConfiguration> getConfigModel() {
+		return observableConfigModel;
+	}
 
-    /**
-     * Set the model to point at the named configuration.
-     *
-     * @param configName name of the configuration
-     * @return configuration model
-     * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed before the config was accessible.
-     */
-    public EditableConfiguration getConfig(String configName) throws TimeoutException {
-        return currentValueFromObservable(editingModel.config(configName));
-    }
+	/**
+	 * Set the model to point at the current configuration.
+	 *
+	 * @return configuration model
+	 * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed
+	 *                          before the current config was accessible.
+	 */
+	public EditableConfiguration getCurrentConfig() throws TimeoutException {
+		return currentValueFromObservable(editingModel.currentConfig());
+	}
 
-    /**
-     * Set the model to point at the named component.
-     *
-     * @param componentName name of the component
-     * @return configuration model
-     * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed before the component was accessible.
-     */
-    public EditableConfiguration getComponent(String componentName) throws TimeoutException {
-        return currentValueFromObservable(editingModel.component(componentName));
-    }
+	/**
+	 * Set the model to point at the named configuration.
+	 *
+	 * @param configName name of the configuration
+	 * @return configuration model
+	 * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed
+	 *                          before the config was accessible.
+	 */
+	public EditableConfiguration getConfig(String configName) throws TimeoutException {
+		return currentValueFromObservable(editingModel.config(configName));
+	}
 
-    /**
-     * Set the model to point at a blank configuration.
-     * @return configuration model
-     * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed before the blank config was accessible.
-     */
-    public EditableConfiguration getBlankConfig() throws TimeoutException {
-    	return currentValueFromObservable(editingModel.blankConfig());
-    }
+	/**
+	 * Set the model to point at the named component.
+	 *
+	 * @param componentName name of the component
+	 * @return configuration model
+	 * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed
+	 *                          before the component was accessible.
+	 */
+	public EditableConfiguration getComponent(String componentName) throws TimeoutException {
+		return currentValueFromObservable(editingModel.component(componentName));
+	}
 
-    /**
-     * This method takes an observable, waits for it to have a correct value, and then returns that value
-     * @param <T> - the type of value
-     * @param observable - the observable to monitor
-     * @return - the current value
-     * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed before the value was accessible.
-     */
-    private EditableConfiguration currentValueFromObservable(ForwardingObservable<EditableConfiguration> observable) throws TimeoutException {
-    	// Required because the groups model uses the "global" state of this class - so need to ensure we keep updating the state even
-    	// if things don't directly need it to be updated.
-    	setAsObservableConfigModel(observable);
+	/**
+	 * Set the model to point at a blank configuration.
+	 * 
+	 * @return configuration model
+	 * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed
+	 *                          before the blank config was accessible.
+	 */
+	public EditableConfiguration getBlankConfig() throws TimeoutException {
+		return currentValueFromObservable(editingModel.blankConfig());
+	}
 
-    	UpdatedObservableAdapter<EditableConfiguration> updateAdapter = new UpdatedObservableAdapter<>(observable);
+	/**
+	 * This method takes an observable, waits for it to have a correct value, and
+	 * then returns that value
+	 * 
+	 * @param <T>        - the type of value
+	 * @param observable - the observable to monitor
+	 * @return - the current value
+	 * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed
+	 *                          before the value was accessible.
+	 */
+	private EditableConfiguration currentValueFromObservable(ClosableObservable<EditableConfiguration> observable)
+			throws TimeoutException {
+		// Required because the groups model uses the "global" state of this class - so
+		// need to ensure we keep updating the state even
+		// if things don't directly need it to be updated.
+		setAsObservableConfigModel(observable);
 
-        if (Awaited.returnedValue(updateAdapter, MAX_SECONDS_TO_WAIT_FOR_VALUE)) {
-        	EditableConfiguration value = updateAdapter.getValue();
-            updateAdapter.close();
-            return value;
-        } else {
-        	updateAdapter.close();
-        	throw new TimeoutException("Could not get value from " + observable + " after waiting " + MAX_SECONDS_TO_WAIT_FOR_VALUE + " seconds.");
-        }
-    }
+		UpdatedObservableAdapter<EditableConfiguration> updateAdapter = new UpdatedObservableAdapter<>(observable);
 
-    /**
-     * Changes this class to point at a different type of configuration object to edit.
-     * @param model - the new model to use.
-     * @return an updated observable observing the new model
-     */
-    private void setAsObservableConfigModel(ForwardingObservable<EditableConfiguration> model) {
-    	// Close old observable adapter if it was set.
-    	Optional.ofNullable(observableConfigModel).ifPresent(UpdatedObservableAdapter::close);
+		if (Awaited.returnedValue(updateAdapter, MAX_SECONDS_TO_WAIT_FOR_VALUE)) {
+			EditableConfiguration value = updateAdapter.getValue();
+			updateAdapter.close();
+			return value;
+		} else {
+			updateAdapter.close();
+			throw new TimeoutException("Could not get value from " + observable + " after waiting "
+					+ MAX_SECONDS_TO_WAIT_FOR_VALUE + " seconds.");
+		}
+	}
 
-    	observableConfigModel = new UpdatedObservableAdapter<>(model);
-    	groupEditorViewModel.updateModel(observableConfigModel);
-    }
+	/**
+	 * Changes this class to point at a different type of configuration object to
+	 * edit.
+	 * 
+	 * @param model - the new model to use.
+	 * @return an updated observable observing the new model
+	 */
+	private void setAsObservableConfigModel(ClosableObservable<EditableConfiguration> model) {
+		// Close old observable adapter if it was set.
+
+		configModel.ifPresent(ClosableObservable<EditableConfiguration>::close);
+		Optional.ofNullable(observableConfigModel).ifPresent(UpdatedObservableAdapter::close);
+
+		configModel = Optional.of(model);
+		observableConfigModel = new UpdatedObservableAdapter<>(model);
+		groupEditorViewModel.updateModel(observableConfigModel);
+	}
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/ConfigurationViewModels.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/ConfigurationViewModels.java
@@ -65,8 +65,8 @@ public class ConfigurationViewModels {
     }
 
     /**
-     * Bind the editing model to this model. Note: this must be done before changing
-     * the item being edited.
+     * Bind the editing model to this model. 
+     * Note: this must be done before changing the item being edited.
      *
      * @param editingModel the editing model
      */

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/ConfigurationViewModels.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/ConfigurationViewModels.java
@@ -29,8 +29,8 @@ import org.apache.logging.log4j.Logger;
 
 import uk.ac.stfc.isis.ibex.configserver.Editing;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
+import uk.ac.stfc.isis.ibex.configserver.editing.ObservableEditableConfiguration;
 import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
-import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.model.Awaited;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.groups.GroupEditorViewModel;
@@ -52,7 +52,7 @@ public class ConfigurationViewModels {
     /** view model for the group. */
     private GroupEditorViewModel groupEditorViewModel;
 
-    private Optional<ClosableObservable<EditableConfiguration>> configModel = Optional.empty();
+    private Optional<ObservableEditableConfiguration> configModel = Optional.empty();
 
     private static final Logger LOG = IsisLog.getLogger(ConfigurationViewModels.class);
 
@@ -72,7 +72,6 @@ public class ConfigurationViewModels {
      */
     public void bind(Editing editingModel) {
 	this.editingModel = editingModel;
-	LOG.info("Calling bind in ConfigurationViewModels");
 	setAsObservableConfigModel(editingModel.currentConfig());
     }
 
@@ -150,7 +149,7 @@ public class ConfigurationViewModels {
      * @throws TimeoutException - if more than MAX_SECONDS_TO_WAIT_FOR_VALUE elapsed
      *                          before the value was accessible.
      */
-    private EditableConfiguration currentValueFromObservable(ClosableObservable<EditableConfiguration> observable)
+    private EditableConfiguration currentValueFromObservable(ObservableEditableConfiguration observable)
 	    throws TimeoutException {
 	// Required because the groups model uses the "global" state of this class - so
 	// need to ensure we keep updating the state even
@@ -177,12 +176,12 @@ public class ConfigurationViewModels {
      * @param model - the new model to use.
      * @return an updated observable observing the new model
      */
-    private void setAsObservableConfigModel(ClosableObservable<EditableConfiguration> model) {
-	// Close old observable adapter and modelif it was set.
-	configModel.ifPresent(ClosableObservable<EditableConfiguration>::close);
+    private void setAsObservableConfigModel(ObservableEditableConfiguration model) {
+	// Close old observable adapter and model if they were set.
+	configModel.ifPresent(ObservableEditableConfiguration::cancelSubscriptionAndCloseEditableConfig);
 	Optional.ofNullable(observableConfigModel).ifPresent(UpdatedObservableAdapter::close);
 
-	configModel = Optional.of(model);
+	configModel = Optional.ofNullable(model);
 	observableConfigModel = new UpdatedObservableAdapter<>(model);
 	groupEditorViewModel.updateModel(observableConfigModel);
     }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/ConfigHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/ConfigHandler.java
@@ -37,6 +37,7 @@ import uk.ac.stfc.isis.ibex.configserver.editing.DuplicateChecker;
 import uk.ac.stfc.isis.ibex.epics.writing.SameTypeWriter;
 import uk.ac.stfc.isis.ibex.epics.writing.Writable;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
+import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
 
 /**
  * This class forms the basis of any "commands" used in relation to the ConfigServer.
@@ -141,7 +142,7 @@ public abstract class ConfigHandler<T> {
      *            the exception that was thrown from the handler
      */
     public void onError(Exception ex) {
-        IsisLog.getLogger(getClass()).error("Exception while executing configserver command", ex);
+        LoggerUtils.logErrorWithStackTrace(IsisLog.getLogger(getClass()), "Exception while executing configserver command", ex);
 
         MessageDialog.openError(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
                 "Error",

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewComponentHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewComponentHandler.java
@@ -1,21 +1,21 @@
 
 /*
-* This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
-* All rights reserved.
-*
-* This program is distributed in the hope that it will be useful.
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v1.0 which accompanies this distribution.
-* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM
-* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
-* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
-*
-* You should have received a copy of the Eclipse Public License v1.0
-* along with this program; if not, you can obtain a copy from
-* https://www.eclipse.org/org/documents/epl-v10.php or
-* http://opensource.org/licenses/eclipse-1.0.php
-*/
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2015 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
 
 package uk.ac.stfc.isis.ibex.ui.configserver.commands;
 
@@ -36,37 +36,36 @@ import uk.ac.stfc.isis.ibex.ui.configserver.dialogs.EditConfigDialog;
 public class NewComponentHandler extends DisablingConfigHandler<Configuration> {
 
     private static final String TITLE = "New Component";
-	private static final String SUB_TITLE = "Editing a new component";
+    private static final String SUB_TITLE = "Editing a new component";
 
     /**
      * The constructor.
      */
-	public NewComponentHandler() {
-		super(SERVER.saveAs());
-	}
+    public NewComponentHandler() {
+	super(SERVER.saveAs());
+    }
 
-	/**
-	 * Open a new component dialogue.
-	 *
-	 * @param shell shell to use
-	 */
-	@Override
-	public void safeExecute(Shell shell) throws TimeoutException {
-        ConfigurationViewModels configurationViewModels = ConfigurationServerUI.getDefault().configurationViewModels();
-        openDialog(shell, configurationViewModels.getBlankConfig(), configurationViewModels);
-	}
+    /**
+     * Open a new component dialogue.
+     *
+     * @param shell shell to use
+     */
+    @Override
+    public void safeExecute(Shell shell) throws TimeoutException {
+	ConfigurationViewModels configurationViewModels = ConfigurationServerUI.getDefault().configurationViewModels();
+	openDialog(shell, configurationViewModels.getBlankConfig(), configurationViewModels);
+    }
 
     private void openDialog(Shell shell, EditableConfiguration config, ConfigurationViewModels configurationViewModels) {
-        config.setIsComponent(true);
-        EditConfigDialog editDialog =
-                new EditConfigDialog(shell, TITLE, SUB_TITLE, config, true, configurationViewModels, false);
-        if (editDialog.open() == Window.OK) {
-            if (editDialog.doAsComponent()) {
-                SERVER.saveAsComponent().uncheckedWrite(editDialog.getComponent());
-            } else {
-                SERVER.saveAs().uncheckedWrite(editDialog.getConfig());
-            }
-        }
-        editDialog.close();
+	config.setIsComponent(true);
+	EditConfigDialog editDialog =
+		new EditConfigDialog(shell, TITLE, SUB_TITLE, config, true, configurationViewModels, false);
+	if (editDialog.open() == Window.OK) {
+	    if (editDialog.doAsComponent()) {
+		SERVER.saveAsComponent().uncheckedWrite(editDialog.getComponent());
+	    } else {
+		SERVER.saveAs().uncheckedWrite(editDialog.getConfig());
+	    }
 	}
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewComponentHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewComponentHandler.java
@@ -67,5 +67,6 @@ public class NewComponentHandler extends DisablingConfigHandler<Configuration> {
                 SERVER.saveAs().uncheckedWrite(editDialog.getConfig());
             }
         }
+        editDialog.close();
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewConfigHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewConfigHandler.java
@@ -73,5 +73,6 @@ public class NewConfigHandler extends DisablingConfigHandler<Configuration> {
                 }
             }
         }
+        editDialog.close();
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewConfigHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewConfigHandler.java
@@ -1,21 +1,21 @@
 
 /*
-* This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
-* All rights reserved.
-*
-* This program is distributed in the hope that it will be useful.
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v1.0 which accompanies this distribution.
-* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM
-* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
-* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
-*
-* You should have received a copy of the Eclipse Public License v1.0
-* along with this program; if not, you can obtain a copy from
-* https://www.eclipse.org/org/documents/epl-v10.php or
-* http://opensource.org/licenses/eclipse-1.0.php
-*/
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2015 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
 
 package uk.ac.stfc.isis.ibex.ui.configserver.commands;
 
@@ -37,42 +37,41 @@ import uk.ac.stfc.isis.ibex.ui.configserver.dialogs.EditConfigDialog;
 public class NewConfigHandler extends DisablingConfigHandler<Configuration> {
 
     private static final String TITLE = "New Configuration";
-	private static final String SUB_TITLE = "Editing a new configuration";
+    private static final String SUB_TITLE = "Editing a new configuration";
 
     /**
      * The constructor.
      */
-	public NewConfigHandler() {
-		super(SERVER.saveAs());
-	}
+    public NewConfigHandler() {
+	super(SERVER.saveAs());
+    }
 
 
-	/**
-	 * Open the new config dialogue.
-	 *
-	 * @param shell the shell
-	 */
-	@Override
+    /**
+     * Open the new config dialogue.
+     *
+     * @param shell the shell
+     */
+    @Override
     public void safeExecute(Shell shell) throws TimeoutException {
-        ConfigurationViewModels configurationViewModels = ConfigurationServerUI.getDefault().configurationViewModels();
-        openDialog(shell, configurationViewModels.getBlankConfig(), configurationViewModels);
-	}
+	ConfigurationViewModels configurationViewModels = ConfigurationServerUI.getDefault().configurationViewModels();
+	openDialog(shell, configurationViewModels.getBlankConfig(), configurationViewModels);
+    }
 
     private void openDialog(Shell shell, EditableConfiguration config, ConfigurationViewModels configurationViewModels) {
-        config.setIsComponent(false);
-        EditConfigDialog editDialog =
-                new EditConfigDialog(shell, TITLE, SUB_TITLE, config, true, configurationViewModels, false);
-        if (editDialog.open() == Window.OK) {
-            if (editDialog.doAsComponent()) {
-                SERVER.saveAsComponent().uncheckedWrite(editDialog.getComponent());
-            } else {
-                SERVER.saveAs().uncheckedWrite(editDialog.getConfig());
-                if (editDialog.switchConfigOnSaveAs()) {
-                    SERVER.load().uncheckedWrite(editDialog.getConfig().name());
-                    Configurations.getInstance().addNameToRecentlyLoadedConfigList(editDialog.getConfig().getName());
-                }
-            }
-        }
-        editDialog.close();
+	config.setIsComponent(false);
+	EditConfigDialog editDialog =
+		new EditConfigDialog(shell, TITLE, SUB_TITLE, config, true, configurationViewModels, false);
+	if (editDialog.open() == Window.OK) {
+	    if (editDialog.doAsComponent()) {
+		SERVER.saveAsComponent().uncheckedWrite(editDialog.getComponent());
+	    } else {
+		SERVER.saveAs().uncheckedWrite(editDialog.getConfig());
+		if (editDialog.switchConfigOnSaveAs()) {
+		    SERVER.load().uncheckedWrite(editDialog.getConfig().name());
+		    Configurations.getInstance().addNameToRecentlyLoadedConfigList(editDialog.getConfig().getName());
+		}
+	    }
 	}
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/ConfigHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/ConfigHelper.java
@@ -48,9 +48,9 @@ public abstract class ConfigHelper {
      *             Thrown if the config cannot be obtained in a reasonable time.
      */
     public void createDialog(String configName, boolean editBlockFirst) throws TimeoutException {
-        EditableConfiguration config = configurationViewModels.getConfig(configName);
-		openDialog(config, false, editBlockFirst);
-		config.close();
+	EditableConfiguration config = configurationViewModels.getConfig(configName);
+	openDialog(config, false, editBlockFirst);
+	config.close();
     }
 
     /**
@@ -60,20 +60,20 @@ public abstract class ConfigHelper {
      *            Whether the first operation we want to do is edit a block
      */
     public void createDialogCurrent(boolean editBlockFirst) {
-        try {
-            EditableConfiguration currentConfig = configurationViewModels.getCurrentConfig();
-			openDialog(currentConfig, true, editBlockFirst);
-			currentConfig.close();
-        } catch (TimeoutException err) {
-            MessageDialog.openError(shell, "Error", "There is no current configuration, so it can not be edited.");
-        }
+	try {
+	    EditableConfiguration currentConfig = configurationViewModels.getCurrentConfig();
+	    openDialog(currentConfig, true, editBlockFirst);
+	    currentConfig.close();
+	} catch (TimeoutException err) {
+	    MessageDialog.openError(shell, "Error", "There is no current configuration, so it can not be edited.");
+	}
     }
 
     /**
      * Create a dialog box for editing the current config.
      */
     public void createDialogCurrent() {
-        createDialogCurrent(false);
+	createDialogCurrent(false);
     }
 
     /**
@@ -87,7 +87,7 @@ public abstract class ConfigHelper {
      *            Should the dialog open the blocks tab first
      */
     protected abstract void openDialog(EditableConfiguration config, boolean isCurrent,
-            boolean editBlockFirst);
+	    boolean editBlockFirst);
 
     /**
      * Get the display name for this configuration
@@ -100,6 +100,6 @@ public abstract class ConfigHelper {
      * @return the display name for this configuration
      */
     public String getConfigDisplayName(EditableConfiguration config, boolean isCurrent) {
-    	return (isCurrent) ? "current" : config.getName();
+	return (isCurrent) ? "current" : config.getName();
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/ConfigHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/ConfigHelper.java
@@ -48,7 +48,9 @@ public abstract class ConfigHelper {
      *             Thrown if the config cannot be obtained in a reasonable time.
      */
     public void createDialog(String configName, boolean editBlockFirst) throws TimeoutException {
-        openDialog(configurationViewModels.getConfig(configName), false, editBlockFirst);
+        EditableConfiguration config = configurationViewModels.getConfig(configName);
+		openDialog(config, false, editBlockFirst);
+		config.close();
     }
 
     /**
@@ -59,7 +61,9 @@ public abstract class ConfigHelper {
      */
     public void createDialogCurrent(boolean editBlockFirst) {
         try {
-            openDialog(configurationViewModels.getCurrentConfig(), true, editBlockFirst);
+            EditableConfiguration currentConfig = configurationViewModels.getCurrentConfig();
+			openDialog(currentConfig, true, editBlockFirst);
+			currentConfig.close();
         } catch (TimeoutException err) {
             MessageDialog.openError(shell, "Error", "There is no current configuration, so it can not be edited.");
         }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
@@ -64,6 +64,7 @@ public class EditConfigHelper extends ConfigHelper {
         if (dialog.open() == Window.OK) {
             server.ifDoAsComponentChooseSave(config, isCurrent, dialog.doAsComponent(), dialog.switchConfigOnSaveAs(), dialog.calledSwitchConfigOnSaveAs());
         }
+        dialog.close();
     }
     
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/EditConfigHelper.java
@@ -64,7 +64,6 @@ public class EditConfigHelper extends ConfigHelper {
         if (dialog.open() == Window.OK) {
             server.ifDoAsComponentChooseSave(config, isCurrent, dialog.doAsComponent(), dialog.switchConfigOnSaveAs(), dialog.calledSwitchConfigOnSaveAs());
         }
-        dialog.close();
     }
     
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/ConfigDetailsDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/ConfigDetailsDialog.java
@@ -87,6 +87,12 @@ public class ConfigDetailsDialog extends TitleAreaDialog implements
 		setTitle(subTitle);
 		return editor;
 	}
+	
+	@Override
+	public boolean close() {
+		editor.close();
+		return super.close();
+	}
 
 	@Override
 	protected void configureShell(Shell shell) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/ConfigDetailsDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/ConfigDetailsDialog.java
@@ -89,12 +89,6 @@ public class ConfigDetailsDialog extends TitleAreaDialog implements
 	}
 	
 	@Override
-	public boolean close() {
-		editor.close();
-		return super.close();
-	}
-
-	@Override
 	protected void configureShell(Shell shell) {
 		super.configureShell(shell);
 		shell.setText(title);

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
@@ -38,7 +38,7 @@ import uk.ac.stfc.isis.ibex.configserver.ConfigServer;
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.ui.configserver.ConfigurationViewModels;
-
+import uk.ac.stfc.isis.ibex.epics.pv.Closable;
 /**
  * Dialog for editing a configuration (top dialogue that contains save and save
  * as buttons).
@@ -85,7 +85,7 @@ public class EditConfigDialog extends ConfigDetailsDialog {
         }
         return control;
     }
-
+    
     @Override
     protected void createButtonsForButtonBar(Composite parent) {
         if (!isBlank && !this.config.getName().isEmpty()) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/EditConfigDialog.java
@@ -23,8 +23,8 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.eclipse.core.databinding.DataBindingContext;
-import org.eclipse.core.databinding.beans.BeanProperties;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.events.SelectionAdapter;
@@ -38,7 +38,6 @@ import uk.ac.stfc.isis.ibex.configserver.ConfigServer;
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.ui.configserver.ConfigurationViewModels;
-import uk.ac.stfc.isis.ibex.epics.pv.Closable;
 /**
  * Dialog for editing a configuration (top dialogue that contains save and save
  * as buttons).

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
@@ -39,11 +39,12 @@ import uk.ac.stfc.isis.ibex.ui.configserver.editing.groups.GroupsEditorPanel;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs.IocOverviewPanel;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.summary.SummaryPanel;
 import uk.ac.stfc.isis.ibex.validators.MessageDisplayer;
+import uk.ac.stfc.isis.ibex.epics.pv.Closable;
 
 /**
  * The panel that contains all the information for editing a configuration.
  */
-public class ConfigEditorPanel extends Composite {
+public class ConfigEditorPanel extends Composite implements Closable {
 	private final IocOverviewPanel iocs;
 	private final BlocksEditorPanel blocks;
 	private final GroupsEditorPanel groups;
@@ -158,4 +159,10 @@ public class ConfigEditorPanel extends Composite {
     public void selectBlocksTab() {
         editorTabs.setSelection(blocksTab);
     }
+
+	@Override
+	public void close() {
+		summary.close();
+		
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/ConfigEditorPanel.java
@@ -39,12 +39,11 @@ import uk.ac.stfc.isis.ibex.ui.configserver.editing.groups.GroupsEditorPanel;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs.IocOverviewPanel;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.summary.SummaryPanel;
 import uk.ac.stfc.isis.ibex.validators.MessageDisplayer;
-import uk.ac.stfc.isis.ibex.epics.pv.Closable;
 
 /**
  * The panel that contains all the information for editing a configuration.
  */
-public class ConfigEditorPanel extends Composite implements Closable {
+public class ConfigEditorPanel extends Composite {
 	private final IocOverviewPanel iocs;
 	private final BlocksEditorPanel blocks;
 	private final GroupsEditorPanel groups;
@@ -160,9 +159,4 @@ public class ConfigEditorPanel extends Composite implements Closable {
         editorTabs.setSelection(blocksTab);
     }
 
-	@Override
-	public void close() {
-		summary.close();
-		
-	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
@@ -1,21 +1,21 @@
 
 /*
-* This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
-* All rights reserved.
-*
-* This program is distributed in the hope that it will be useful.
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v1.0 which accompanies this distribution.
-* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
-* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
-* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
-*
-* You should have received a copy of the Eclipse Public License v1.0
-* along with this program; if not, you can obtain a copy from
-* https://www.eclipse.org/org/documents/epl-v10.php or 
-* http://opensource.org/licenses/eclipse-1.0.php
-*/
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2015 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
 
 package uk.ac.stfc.isis.ibex.ui.configserver.editing.summary;
 
@@ -24,8 +24,8 @@ import java.util.Collection;
 
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.UpdateValueStrategy;
-import org.eclipse.core.databinding.beans.BeanProperties;
-import org.eclipse.jface.databinding.swt.WidgetProperties;
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.swt.SWT;
@@ -68,8 +68,8 @@ public class SummaryPanel extends Composite implements Closable {
     private Button protectedCheckBox;
     private Label protectLabel;
     private Label warning;
-	private Observer<Collection<SynopticInfo>> synopticInfoObserver;
-	private Subscription synoptic_subscription;
+    private Observer<Collection<SynopticInfo>> synopticInfoObserver;
+    private Subscription synoptic_subscription;
 
     /**
      * Constructor for the general information about the configuration.
@@ -82,69 +82,69 @@ public class SummaryPanel extends Composite implements Closable {
      *            The message displayer used to show error messages to the user.
      */
     public SummaryPanel(Composite parent, int style, MessageDisplayer dialog) {
-        super(parent, style);
+	super(parent, style);
 
-        messageDisplayer = dialog;
-        setLayout(new FillLayout(SWT.HORIZONTAL));
+	messageDisplayer = dialog;
+	setLayout(new FillLayout(SWT.HORIZONTAL));
 
-        Composite cmpSummary = new Composite(this, SWT.NONE);
-        cmpSummary.setLayout(new GridLayout(2, false));
+	Composite cmpSummary = new Composite(this, SWT.NONE);
+	cmpSummary.setLayout(new GridLayout(2, false));
 
-        Label lblName = new Label(cmpSummary, SWT.NONE);
-        lblName.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-        lblName.setText("Name:");
+	Label lblName = new Label(cmpSummary, SWT.NONE);
+	lblName.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+	lblName.setText("Name:");
 
-        txtName = new Text(cmpSummary, SWT.BORDER);
-        txtName.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+	txtName = new Text(cmpSummary, SWT.BORDER);
+	txtName.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 
-        Label lblDescription = new Label(cmpSummary, SWT.NONE);
-        lblDescription.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-        lblDescription.setText("Description:");
+	Label lblDescription = new Label(cmpSummary, SWT.NONE);
+	lblDescription.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+	lblDescription.setText("Description:");
 
-        txtDescription = new Text(cmpSummary, SWT.BORDER);
-        txtDescription.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-        txtDescription.setTextLimit(39);
+	txtDescription = new Text(cmpSummary, SWT.BORDER);
+	txtDescription.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+	txtDescription.setTextLimit(39);
 
-        lblSynoptic = new Label(cmpSummary, SWT.NONE);
-        lblSynoptic.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-        lblSynoptic.setText("Synoptic:");
+	lblSynoptic = new Label(cmpSummary, SWT.NONE);
+	lblSynoptic.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+	lblSynoptic.setText("Synoptic:");
 
-        cmboSynoptic = new ComboViewer(cmpSummary, SWT.READ_ONLY);
-        cmboSynoptic.getCombo().setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
-        cmboSynoptic.setContentProvider(new ArrayContentProvider());
-        
-        
-        protectLabel = new Label(cmpSummary,  SWT.NONE);
-        protectLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.NONE, false, false, 1, 1));
-        protectLabel.setText("Protected:");
-        
-        protectedCheckBox = new Button(cmpSummary, SWT.CHECK);
-        protectedCheckBox.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1));     
+	cmboSynoptic = new ComboViewer(cmpSummary, SWT.READ_ONLY);
+	cmboSynoptic.getCombo().setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false, 1, 1));
+	cmboSynoptic.setContentProvider(new ArrayContentProvider());
 
-        lblDateCreated = new Label(cmpSummary, SWT.NONE);
-        lblDateCreated.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-        lblDateCreated.setText("Date Created:");
 
-        lblDateCreatedField = new Label(cmpSummary, SWT.NONE);
-        
-        lblDateModified = new Label(cmpSummary, SWT.NONE);
-        lblDateModified.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
-        lblDateModified.setText("Date Modified:");
+	protectLabel = new Label(cmpSummary,  SWT.NONE);
+	protectLabel.setLayoutData(new GridData(SWT.RIGHT, SWT.NONE, false, false, 1, 1));
+	protectLabel.setText("Protected:");
 
-        lblDateModifiedField = new Label(cmpSummary, SWT.NONE);
-        
-        warning = new Label(cmpSummary, SWT.WRAP | SWT.NONE);
-        GridData gd = new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1);
-        gd.widthHint = 800;
-        warning.setLayoutData(gd);
-        warning.setText("");
-        warning.setForeground(parent.getDisplay().getSystemColor(SWT.COLOR_RED));
+	protectedCheckBox = new Button(cmpSummary, SWT.CHECK);
+	protectedCheckBox.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1));     
+
+	lblDateCreated = new Label(cmpSummary, SWT.NONE);
+	lblDateCreated.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+	lblDateCreated.setText("Date Created:");
+
+	lblDateCreatedField = new Label(cmpSummary, SWT.NONE);
+
+	lblDateModified = new Label(cmpSummary, SWT.NONE);
+	lblDateModified.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+	lblDateModified.setText("Date Modified:");
+
+	lblDateModifiedField = new Label(cmpSummary, SWT.NONE);
+
+	warning = new Label(cmpSummary, SWT.WRAP | SWT.NONE);
+	GridData gd = new GridData(SWT.LEFT, SWT.CENTER, false, false, 2, 1);
+	gd.widthHint = 800;
+	warning.setLayoutData(gd);
+	warning.setText("");
+	warning.setForeground(parent.getDisplay().getSystemColor(SWT.COLOR_RED));
 
     }
-    
+
     @Override
     public void close() {
-    	synoptic_subscription.cancelSubscription();
+	synoptic_subscription.cancelSubscription();
     }
 
     /**
@@ -154,49 +154,48 @@ public class SummaryPanel extends Composite implements Closable {
      *            The configuration that the panel relates to.
      */
     public void setConfig(EditableConfiguration config) {
-        this.config = config;
-        setBindings();
+	this.config = config;
+	setBindings();
     }
 
     private void setBindings() {
-        DataBindingContext bindingContext = new DataBindingContext();
+	DataBindingContext bindingContext = new DataBindingContext();
 
-        UpdateValueStrategy descValidator = new UpdateValueStrategy();
-        // Set validator if not saving a new config
-        if (!config.getIsNew()) {
-        	 BlockServerNameValidator configDescriptionRules = Configurations.getInstance()
-                     .variables().configDescriptionRules.getValue();
-            descValidator
-                    .setBeforeSetValidator(new SummaryDescriptionValidator(messageDisplayer, configDescriptionRules));
-        }
-        
-        bindSynopticList();
+	UpdateValueStrategy<String, String> descValidator = new UpdateValueStrategy<>();
+	// Set validator if not saving a new config
+	if (!config.getIsNew()) {
+	    BlockServerNameValidator configDescriptionRules = Configurations.getInstance()
+		    .variables().configDescriptionRules.getValue();
+	    descValidator.setBeforeSetValidator(new SummaryDescriptionValidator(messageDisplayer, configDescriptionRules));
+	}
 
-        bindingContext.bindValue(WidgetProperties.enabled().observe(txtName),
-                BeanProperties.value("isNew").observe(config));
-        bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtName),
-                BeanProperties.value("name").observe(config));
-        bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtDescription),
-                BeanProperties.value("description").observe(config), descValidator, null);
-        bindingContext.bindValue(WidgetProperties.selection().observe(cmboSynoptic.getCombo()),
-                BeanProperties.value("synoptic").observe(config));
-        bindingContext.bindValue(WidgetProperties.visible().observe(lblDateCreated),
-                BeanProperties.value("isNew").observe(config), null, UIUtils.NOT_CONVERTER);
-        bindingContext.bindValue(WidgetProperties.visible().observe(lblDateModified),
-                BeanProperties.value("isNew").observe(config), null, UIUtils.NOT_CONVERTER);
-        bindingContext.bindValue(WidgetProperties.text().observe(lblDateCreatedField),
-                BeanProperties.value("dateCreated").observe(config));
-        bindingContext.bindValue(WidgetProperties.text().observe(lblDateModifiedField),
-                BeanProperties.value("dateModified").observe(config));
-        bindingContext.bindValue(WidgetProperties.selection().observe(protectedCheckBox),
-                BeanProperties.value("isProtected").observe(config));
+	bindSynopticList();
 
-        bindingContext.bindValue(WidgetProperties.visible().observe(lblSynoptic),
-                BeanProperties.value("isComponent").observe(config), null, UIUtils.NOT_CONVERTER);
-        bindingContext.bindValue(WidgetProperties.visible().observe(cmboSynoptic.getCombo()),
-                BeanProperties.value("isComponent").observe(config), null, UIUtils.NOT_CONVERTER);
-        bindingContext.bindValue(WidgetProperties.text().observe(warning),
-                BeanProperties.value("errorMessage").observe(config));
+	bindingContext.bindValue(WidgetProperties.enabled().observe(txtName),
+		BeanProperties.value("isNew").observe(config));
+	bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtName),
+		BeanProperties.value("name").observe(config));
+	bindingContext.bindValue(WidgetProperties.text(SWT.Modify).observe(txtDescription),
+		BeanProperties.value("description").observe(config), descValidator, null);
+	bindingContext.bindValue(WidgetProperties.comboSelection().observe(cmboSynoptic.getCombo()),
+		BeanProperties.value("synoptic").observe(config));
+	bindingContext.bindValue(WidgetProperties.visible().observe(lblDateCreated),
+		BeanProperties.value("isNew", Boolean.class).observe(config), null, UIUtils.TYPED_NOT_CONVERTER);
+	bindingContext.bindValue(WidgetProperties.visible().observe(lblDateModified),
+		BeanProperties.value("isNew", Boolean.class).observe(config), null, UIUtils.TYPED_NOT_CONVERTER);
+	bindingContext.bindValue(WidgetProperties.text().observe(lblDateCreatedField),
+		BeanProperties.value("dateCreated").observe(config));
+	bindingContext.bindValue(WidgetProperties.text().observe(lblDateModifiedField),
+		BeanProperties.value("dateModified").observe(config));
+	bindingContext.bindValue(WidgetProperties.buttonSelection().observe(protectedCheckBox),
+		BeanProperties.value("isProtected").observe(config));
+
+	bindingContext.bindValue(WidgetProperties.visible().observe(lblSynoptic),
+		BeanProperties.value("isComponent", Boolean.class).observe(config), null, UIUtils.TYPED_NOT_CONVERTER);
+	bindingContext.bindValue(WidgetProperties.visible().observe(cmboSynoptic.getCombo()),
+		BeanProperties.value("isComponent", Boolean.class).observe(config), null, UIUtils.TYPED_NOT_CONVERTER);
+	bindingContext.bindValue(WidgetProperties.text().observe(warning),
+		BeanProperties.value("errorMessage").observe(config));
 
 
     }
@@ -210,70 +209,70 @@ public class SummaryPanel extends Composite implements Closable {
      * #2527.
      */
     private void bindSynopticList() {
-        synopticInfoObserver = new Observer<Collection<SynopticInfo>>() {
+	synopticInfoObserver = new Observer<Collection<SynopticInfo>>() {
 
-            @Override
-            public void update(final Collection<SynopticInfo> value, Exception error, boolean isConnected) {
-            	Display.getDefault().asyncExec(() -> updateSynopticNamesInComboBox(value));
-            }
+	    @Override
+	    public void update(final Collection<SynopticInfo> value, Exception error, boolean isConnected) {
+		Display.getDefault().asyncExec(() -> updateSynopticNamesInComboBox(value));
+	    }
 
-            @Override
-            public void onValue(Collection<SynopticInfo> value) {
-            	// The event comes from PV manager's threadpool but the method
-            	// needs to manipulate UI elements so need to explicitly run on UI thread.
-                Display.getDefault().asyncExec(() -> updateSynopticNamesInComboBox(value));
-            }
+	    @Override
+	    public void onValue(Collection<SynopticInfo> value) {
+		// The event comes from PV manager's threadpool but the method
+		// needs to manipulate UI elements so need to explicitly run on UI thread.
+		Display.getDefault().asyncExec(() -> updateSynopticNamesInComboBox(value));
+	    }
 
-            /**
-             * Get the new list of synoptics and the current default and update
-             * the combo box.
-             * 
-             * @param value
-             *            the new value of the synoptics list
-             */
-            private void updateSynopticNamesInComboBox(Collection<SynopticInfo> value) {
-                final String[] names = SynopticInfo.names(value).toArray(new String[0]);
-                Arrays.sort(names);
+	    /**
+	     * Get the new list of synoptics and the current default and update
+	     * the combo box.
+	     * 
+	     * @param value
+	     *            the new value of the synoptics list
+	     */
+	    private void updateSynopticNamesInComboBox(Collection<SynopticInfo> value) {
+		final String[] names = SynopticInfo.names(value).toArray(new String[0]);
+		Arrays.sort(names);
 
-                final String selected = getDefaultSelection(value);
-                if (!cmboSynoptic.getControl().isDisposed()) {
-                    cmboSynoptic.setInput(names);
-                    if (selected != null) {
-                        config.setSynoptic(selected);
-                    }
-                }
-            }
+		final String selected = getDefaultSelection(value);
+		if (!cmboSynoptic.getControl().isDisposed()) {
+		    cmboSynoptic.setInput(names);
+		    if (selected != null) {
+			config.setSynoptic(selected);
+		    }
+		}
+	    }
 
-            /**
-             * Based on the synoptics list get the current default.
-             * 
-             * @param value
-             *            the synoptics list
-             * @return the label; empty if there is no default
-             */
-            private String getDefaultSelection(Collection<SynopticInfo> value) {
-                if (value == null) {
-                    return null;
-                }
-                for (SynopticInfo info : value) {
-                    if (info.isDefault()) {
-                        return info.name();
-                    }
-                }
-                return null;
-            }
+	    /**
+	     * Based on the synoptics list get the current default.
+	     * 
+	     * @param value
+	     *            the synoptics list
+	     * @return the label; empty if there is no default
+	     */
+	    private String getDefaultSelection(Collection<SynopticInfo> value) {
+		if (value == null) {
+		    return null;
+		}
+		for (SynopticInfo info : value) {
+		    if (info.isDefault()) {
+			return info.name();
+		    }
+		}
+		return null;
+	    }
 
-            @Override
-            public void onError(Exception e) {
-                // keep list as is
+	    @Override
+	    public void onError(Exception e) {
+		// keep list as is
 
-            }
+	    }
 
-            @Override
-            public void onConnectionStatus(boolean isConnected) {
-                // keep list as is
-            }
-        };
-		synoptic_subscription = Synoptic.getInstance().availableSynopticsInfo().subscribe(synopticInfoObserver);
+	    @Override
+	    public void onConnectionStatus(boolean isConnected) {
+		// keep list as is
+	    }
+	};
+	synoptic_subscription = Synoptic.getInstance().availableSynopticsInfo().subscribe(synopticInfoObserver);
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
@@ -29,6 +29,8 @@ import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -48,13 +50,12 @@ import uk.ac.stfc.isis.ibex.ui.UIUtils;
 import uk.ac.stfc.isis.ibex.validators.BlockServerNameValidator;
 import uk.ac.stfc.isis.ibex.validators.MessageDisplayer;
 import uk.ac.stfc.isis.ibex.validators.SummaryDescriptionValidator;
-import uk.ac.stfc.isis.ibex.epics.pv.Closable;
 
 /**
  * The panel that holds general misc information about the configuration.
  */
 @SuppressWarnings("checkstyle:magicnumber")
-public class SummaryPanel extends Composite implements Closable {
+public class SummaryPanel extends Composite {
     private Text txtName;
     private Text txtDescription;
     private Label lblDateCreated;
@@ -69,7 +70,7 @@ public class SummaryPanel extends Composite implements Closable {
     private Label protectLabel;
     private Label warning;
     private Observer<Collection<SynopticInfo>> synopticInfoObserver;
-    private Subscription synoptic_subscription;
+    private Subscription synopticSubscription;
 
     /**
      * Constructor for the general information about the configuration.
@@ -140,11 +141,6 @@ public class SummaryPanel extends Composite implements Closable {
 	warning.setText("");
 	warning.setForeground(parent.getDisplay().getSystemColor(SWT.COLOR_RED));
 
-    }
-
-    @Override
-    public void close() {
-	synoptic_subscription.cancelSubscription();
     }
 
     /**
@@ -273,6 +269,15 @@ public class SummaryPanel extends Composite implements Closable {
 		// keep list as is
 	    }
 	};
-	synoptic_subscription = Synoptic.getInstance().availableSynopticsInfo().subscribe(synopticInfoObserver);
+	synopticSubscription = Synoptic.getInstance().availableSynopticsInfo().subscribe(synopticInfoObserver);
+	
+	this.addDisposeListener(new DisposeListener() {
+	    
+	    @Override
+	    public void widgetDisposed(DisposeEvent e) {
+		
+		synopticSubscription.cancelSubscription();
+	    }
+	});
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/UIUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/UIUtils.java
@@ -46,6 +46,16 @@ public final class UIUtils {
             return !(Boolean) value;
         }
     };
+    
+    /**
+     * A typed update strategy for inverting an observed boolean value.
+     */
+    public static final UpdateValueStrategy<Boolean, Boolean> TYPED_NOT_CONVERTER = new UpdateValueStrategy<Boolean, Boolean>() {
+        @Override
+        public Boolean convert(Boolean value) {
+            return !(Boolean) value;
+        }
+    };
 
     private UIUtils() {
 


### PR DESCRIPTION
### Description of work

Fix various memory leaks on editable configuration

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5136

### Acceptance criteria

- Opening multiple configuration no longer fills up the mmemory
- (You can check) The number of Editable configuration is < 5 at al ltimes

### Unit tests

-

### System tests

Relying on memory test in squish

### Documentation

Will update debugging memory error sin the wiki

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

