### PR TITLE
rsakey changed to map because of migrating NICOS to python 3

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/ReceiveBannerMessage.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/ReceiveBannerMessage.java
@@ -18,6 +18,8 @@
 
 package uk.ac.stfc.isis.ibex.nicos.messages;
 
+import java.util.Map;
+
 /**
  * A Banner Message that has been received from NICOS. This message should be
  * the first sent and details various things about the instance of NICOS that we
@@ -30,7 +32,7 @@ package uk.ac.stfc.isis.ibex.nicos.messages;
 public class ReceiveBannerMessage {
     private String custom_path;
     private String nicos_root;
-    private String rsakey;
+    private Map<String, String> rsakey;
     private String daemon_version;
     private String pw_hashing;
     private String serializer;


### PR DESCRIPTION
### Description of work

Changed `rsakey` from string to map because JsonDeserialisation converts `rsakey` to a dictionary in after migrating Nicos to python 3

### Ticket

[#4887](https://github.com/ISISComputingGroup/IBEX/issues/4887)

### Acceptance criteria

Nicos script server can run python 3 user scripts and is displayed correctly

### Unit tests

Should pass previous unit test

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

