### PR TITLE
Populate dropdown with default synoptic

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
@@ -28,6 +28,7 @@ import org.eclipse.core.databinding.beans.BeanProperties;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.jface.viewers.ArrayContentProvider;
 import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
@@ -230,6 +231,7 @@ public class SummaryPanel extends Composite {
                 if (!cmboSynoptic.getControl().isDisposed()) {
                     cmboSynoptic.setInput(names);
                     if (selected != null) {
+                        cmboSynoptic.setSelection(new StructuredSelection(selected));
                         config.setSynoptic(selected);
                     }
                 }


### PR DESCRIPTION
### Description of work
Auto-selects the default synoptic from the synoptic dropdown menu in the configuration edit dialog.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/5155

### Acceptance criteria
- Create or load a config with a default synoptic
- Edit the config
- In the "Synoptic" dropdown menu, the default synoptic should be automatically selected

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

