### PR TITLE
Ensure python 3 is set to a default

### DIFF
--- a/build/build.bat
+++ b/build/build.bat
@@ -9,6 +9,10 @@ if %errcode% GEQ 4 (
 )
 
 SET "JAVA_HOME=%~dp0\jdk"
+
+if "%PYTHON3%" == "" (
+	set "PYTHON3=C:\Instrument\Apps\Python3\python.exe"
+)
  
 %PYTHON3% .\check_build.py ..\base\
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/build/build_script_generator.bat
+++ b/build/build_script_generator.bat
@@ -9,6 +9,10 @@ if %errcode% GEQ 4 (
 )
 
 SET "JAVA_HOME=%~dp0\jdk"
+
+if "%PYTHON3%" == "" (
+	set "PYTHON3=C:\Instrument\Apps\Python3\python.exe"
+)
  
 %PYTHON3% .\check_build.py ..\base\
 if %errorlevel% neq 0 exit /b %errorlevel%


### PR DESCRIPTION
### Description of work

When running build.bat without the env variable python 3 set the python script is not run correctly. Set a default for build.bat of C:\Instrument\Apps\Python3\python.exe

### Ticket

*Link to Ticket*

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

