### PR TITLE
Fix ls372 opi

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/lakeshore372.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/lakeshore372.opi
@@ -1442,46 +1442,6 @@ $(pv_value)</tooltip>
       <x>102</x>
       <y>54</y>
     </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-      <actions hook="false" hook_all="false"/>
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0"/>
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
-      </font>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
-      </foreground_color>
-      <height>1</height>
-      <image/>
-      <name>Dummy</name>
-      <push_action_index>0</push_action_index>
-      <pv_name/>
-      <pv_value/>
-      <rules/>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts/>
-      <style>1</style>
-      <text/>
-      <toggle_button>false</toggle_button>
-      <tooltip/>
-      <visible>true</visible>
-      <widget_type>Action Button</widget_type>
-      <width>1</width>
-      <wuid>-648922a4:1624e4fa0bd:-7f69</wuid>
-      <x>12</x>
-      <y>210</y>
-    </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <actions hook="false" hook_all="false"/>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/lakeshore372.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/lakeshore372.opi
@@ -1483,4 +1483,44 @@ $(pv_value)</tooltip>
     <x>288</x>
     <y>186</y>
   </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+      <actions hook="false" hook_all="false"/>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      </foreground_color>
+      <height>1</height>
+      <image/>
+      <name>Dummy</name>
+      <push_action_index>0</push_action_index>
+      <pv_name/>
+      <pv_value/>
+      <rules/>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts/>
+      <style>1</style>
+      <text/>
+      <toggle_button>false</toggle_button>
+      <tooltip/>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>1</width>
+      <wuid>-648922a4:1624e4fa0bd:-7f69</wuid>
+      <x>12</x>
+      <y>210</y>
+    </widget>
 </display>


### PR DESCRIPTION
A dummy widget was accidentally added in an invalid place on the lakeshore 372 opi, this caused scrollbars to appear in a container when they shouldn't have.

This manually removes the badly-positioned dummy widget and adds it back in at the end of the file, where it should be.