### PR TITLE
Removed some guessing of types from the DataboundTable hierarchy

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/CheckboxLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/CheckboxLabelProvider.java
@@ -39,7 +39,7 @@ public abstract class CheckboxLabelProvider<T> extends ButtonCellLabelProvider<T
 	 * The default constructor for the CheckboxLabelProvider.
 	 * @param stateProperties The properties that this label provider should be observing
 	 */
-	public CheckboxLabelProvider(IObservableMap stateProperties) {
+	public CheckboxLabelProvider(IObservableMap<T, ?> stateProperties) {
 		super(stateProperties);
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.ioccontrol/src/uk/ac/stfc/isis/ibex/ui/ioccontrol/StateLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.ioccontrol/src/uk/ac/stfc/isis/ibex/ui/ioccontrol/StateLabelProvider.java
@@ -50,7 +50,7 @@ public class StateLabelProvider extends SortableObservableMapCellLabelProvider<I
 	 * 
 	 * @param attributeMaps A map of the attributes that this cell will observe.
 	 */
-	public StateLabelProvider(IObservableMap attributeMaps) {
+	public StateLabelProvider(IObservableMap<IocState, ?> attributeMaps) {
 		super(attributeMaps);
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/ControlCellLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/ControlCellLabelProvider.java
@@ -48,7 +48,7 @@ public abstract class ControlCellLabelProvider<T extends Control, TRow> extends 
 	 * 
 	 * @param attributeMaps A map of the attributes that this cell will observe.
 	 */
-	protected ControlCellLabelProvider(IObservableMap attributeMaps) {
+	protected ControlCellLabelProvider(IObservableMap<TRow, ?> attributeMaps) {
 		super(attributeMaps);
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundCellLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundCellLabelProvider.java
@@ -42,7 +42,7 @@ public abstract class DataboundCellLabelProvider<TRow> extends SortableObservabl
      *
      * @param attributeMap the attribute map
      */
-	public DataboundCellLabelProvider(IObservableMap attributeMap) {
+	public DataboundCellLabelProvider(IObservableMap<TRow, ?> attributeMap) {
 		super(attributeMap);
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.eclipse.core.databinding.beans.BeanProperties;
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.observable.list.WritableList;
 import org.eclipse.core.databinding.observable.map.IObservableMap;
 import org.eclipse.jface.databinding.viewers.ObservableListContentProvider;
@@ -70,7 +70,7 @@ public abstract class DataboundTable<TRow> extends Composite {
 	private TableViewer viewer;
 	private TableColumnLayout tableColumnLayout = new TableColumnLayout();
 	private Composite tableComposite;
-	private ObservableListContentProvider contentProvider = new ObservableListContentProvider();
+	private ObservableListContentProvider<TRow> contentProvider = new ObservableListContentProvider<TRow>();
 	
     /**
      * Instantiates a new databound table.
@@ -434,7 +434,7 @@ public abstract class DataboundTable<TRow> extends Composite {
      * @param propertyName the property name
      * @return the observable map
      */
-	public IObservableMap observeProperty(String propertyName) {
+	public IObservableMap<TRow, ?> observeProperty(String propertyName) {
 		return BeanProperties.value(propertyName).observeDetail(contentProvider.getKnownElements());
 	}	
 

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/SortableObservableMapCellLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/SortableObservableMapCellLabelProvider.java
@@ -12,7 +12,7 @@ public abstract class SortableObservableMapCellLabelProvider<TRow> extends Obser
 	 * Constructor for the observable label provider.
 	 * @param attributeMap A map of the attributes that this cell will observe.
 	 */
-	protected SortableObservableMapCellLabelProvider(IObservableMap attributeMap) {
+	protected SortableObservableMapCellLabelProvider(IObservableMap<TRow, ?> attributeMap) {
 		super(attributeMap);
 	}
 	


### PR DESCRIPTION
To test:

* Confirm code builds
* Confirm tables still work in the GUI
* Confirm less warnings of type inference

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

