### PR TITLE
Stopping eclipse displaying memory monitor by default

### DIFF
--- a/base/uk.ac.stfc.isis.scriptgenerator.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.scriptgenerator.client/plugin_customization.ini
@@ -4,3 +4,6 @@ uk.ac.stfc.isis.ibex.preferences/script_definitions_folder=C:/ScriptDefinitions/
 uk.ac.stfc.isis.ibex.preferences/script_generation_folder=C:/Scripts/
 uk.ac.stfc.isis.ibex.preferences/hide_script_definition_error_table=false
 uk.ac.stfc.isis.ibex.preferences/script_generator_manual_url=http://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator,https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Using-the-Script-Generator
+
+# Eclipse
+org.eclipse.ui/SHOW_MEMORY_MONITOR=false


### PR DESCRIPTION
Eclipse now shows memory monitor by default. Prevent this in config ini file.