### PR TITLE
Remove log4j from feature requirements

### DIFF
--- a/base/uk.ac.stfc.isis.scriptgenerator.feature.base/feature.xml
+++ b/base/uk.ac.stfc.isis.scriptgenerator.feature.base/feature.xml
@@ -375,13 +375,6 @@
          unpack="false"/>
 
    <plugin
-         id="org.apache.log4j"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
          id="org.eclipse.ui"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
The script generator was attempting to pull in log4j (whose API has changed and is managed by the ibex logger). As the IBEX logger exports it, we don't need to have it in our script generator features.

To test (requires dependencies to be updated):

Build the script generator using build_script_generator.bat and run it. Confirm it works. 