### PR TITLE
Fix switching listener property

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -127,7 +127,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	/**
 	 * A property that is changed when script definitions are switched.
 	 */
-	private static final String SCRIPT_DEFINITION_SWITCH_PROPERTY = "script definition";
+	private static final String SCRIPT_DEFINITION_SWITCH_PROPERTY = "scriptDefinition";
 	
 	/**
 	 * A property to notify listeners when python becomes ready or not ready.


### PR DESCRIPTION
When you switch script definition the help text should be updated. This somehow regressed after the last time I tested it, because the property names were changed. Change the property string to match and now it switches definitions.

To test:

- Switch between script definitions and check the help text updates