### PR TITLE
Rename SUSPEND_ON_INVALID to SOI

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.runcontrol/src/uk/ac/stfc/isis/ibex/runcontrol/internal/RunControlAddresses.java
+++ b/base/uk.ac.stfc.isis.ibex.runcontrol/src/uk/ac/stfc/isis/ibex/runcontrol/internal/RunControlAddresses.java
@@ -27,7 +27,7 @@ import uk.ac.stfc.isis.ibex.epics.pv.PVAddress;
 public class RunControlAddresses {
 	private static final String LOW_LIMIT = "RC:LOW";
 	private static final String HIGH_LIMIT = "RC:HIGH";
-	private static final String SUSPEND_ON_INVALID = "RC:SUSPEND_ON_INVALID";
+	private static final String SUSPEND_ON_INVALID = "RC:SOI";
 	private static final String ENABLE = "RC:ENABLE";
 	private static final String INRANGE = "RC:INRANGE";
 


### PR DESCRIPTION
### Description of work
Renames the constant to mirror the change in PV name.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/5207

### Acceptance criteria
- The PV is correctly set when running with the modified name

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

