### PR TITLE
Copy jre into the build as part of build.bat

### DIFF
--- a/build/build.bat
+++ b/build/build.bat
@@ -1,6 +1,6 @@
 REM We bundle our own JRE with the client, this is where it is
 set "JRELOCATION=\\isis\inst$\Kits$\CompGroup\ICP\ibex_client_jre"
-set "LOCAL_JRE_LOCATION=%~dp0\jdk"
+set "LOCAL_JRE_LOCATION=%~dp0jdk"
 robocopy "%JRELOCATION%" "%LOCAL_JRE_LOCATION%" /E /PURGE /R:2 /MT /XF "install.log" /NFL /NDL /NC /NS /NP /LOG:NUL
 set errcode=%ERRORLEVEL%
 if %errcode% GEQ 4 (
@@ -14,7 +14,7 @@ call copy_in_maven.bat
 if %errorlevel% neq 0 exit /b %errorlevel%
 set "PATH=%PATH%;%~dp0maven\bin"
 
-SET "JAVA_HOME=%~dp0\jdk"
+SET "JAVA_HOME=%~dp0jdk"
 
 if "%PYTHON3%" == "" (
 	set "PYTHON3=C:\Instrument\Apps\Python3\python.exe"

--- a/build/build.bat
+++ b/build/build.bat
@@ -1,6 +1,6 @@
 REM We bundle our own JRE with the client, this is where it is
-set JRELOCATION=\\isis\inst$\Kits$\CompGroup\ICP\ibex_client_jre
-set LOCAL_JRE_LOCATION=%~dp0\jdk
+set "JRELOCATION=\\isis\inst$\Kits$\CompGroup\ICP\ibex_client_jre"
+set "LOCAL_JRE_LOCATION=%~dp0\jdk"
 robocopy "%JRELOCATION%" "%LOCAL_JRE_LOCATION%" /E /PURGE /R:2 /MT /XF "install.log" /NFL /NDL /NC /NS /NP /LOG:NUL
 set errcode=%ERRORLEVEL%
 if %errcode% GEQ 4 (
@@ -40,7 +40,7 @@ RMDIR /S /Q %sensible_build_dir%
 robocopy "%built_client%" "%sensible_build_dir%" /MT /E /PURGE /R:2 /XF "install.log" /NFL /NDL /NP /NS /NC /LOG:NUL
 
 REM Copy the JRE across 
-robocopy %LOCAL_JRE_LOCATION% %sensible_build_dir%\jre /MT /MIR /R:1 /XF "install.log" /NFL /NDL /NP /NS /NC /LOG:NUL
+robocopy "%LOCAL_JRE_LOCATION%" "%sensible_build_dir%\jre" /MT /MIR /R:1 /XF "install.log" /NFL /NDL /NP /NS /NC /LOG:NUL
 if %errorlevel% geq 4 (
     @echo Failed to copy JRE across
     exit /b 1

--- a/build/build.bat
+++ b/build/build.bat
@@ -1,4 +1,7 @@
-robocopy "\\isis\inst$\Kits$\CompGroup\ICP\ibex_client_jre" "%~dp0\jdk" /E /PURGE /R:2 /MT /XF "install.log" /NFL /NDL /NC /NS /NP /LOG:NUL
+REM We bundle our own JRE with the client, this is where it is
+set JRELOCATION=\\isis\inst$\Kits$\CompGroup\ICP\ibex_client_jre
+set LOCAL_JRE_LOCATION=%~dp0\jdk
+robocopy "%JRELOCATION%" "%LOCAL_JRE_LOCATION%" /E /PURGE /R:2 /MT /XF "install.log" /NFL /NDL /NC /NS /NP /LOG:NUL
 set errcode=%ERRORLEVEL%
 if %errcode% GEQ 4 (
     @echo *** Exit Code %errcode% ERROR see %INSTALLDIR%install.log ***
@@ -35,6 +38,13 @@ if "%~2" == "" (
 set sensible_build_dir="%~dp0..\built_client"
 RMDIR /S /Q %sensible_build_dir%
 robocopy "%built_client%" "%sensible_build_dir%" /MT /E /PURGE /R:2 /XF "install.log" /NFL /NDL /NP /NS /NC /LOG:NUL
+
+REM Copy the JRE across 
+robocopy %LOCAL_JRE_LOCATION% %sensible_build_dir%\jre /MT /MIR /R:1 /XF "install.log" /NFL /NDL /NP /NS /NC /LOG:NUL
+if %errorlevel% geq 4 (
+    @echo Failed to copy JRE across
+    exit /b 1
+)
 
 REM Copy python into the client
 %PYTHON3% get_python_write_dir.py %sensible_build_dir% > Output

--- a/build/jenkins_build.bat
+++ b/build/jenkins_build.bat
@@ -7,9 +7,6 @@ set M2=%MAVEN%bin
 set PYTHON3=C:\Instrument\Apps\Python3\python.exe
 set PYTHON_HOME=C:\Instrument\Apps\Python3
 
-REM We bundle our own JRE with the client, this is where it is
-set JRELOCATION=p:\Kits$\CompGroup\ICP\ibex_client_jre
-
 set PATH=%M2%;%JAVA_HOME%;%PATH%
 
 if "%IS_E4%" == "YES" (
@@ -87,13 +84,6 @@ if %errorlevel% geq 4 (
         rd /q /s %INSTALLDIR%\Client
     )
     @echo Client copy failed
-    exit /b 1
-)
-
-REM Copy the JRE across 
-robocopy %JRELOCATION% %INSTALLDIR%\Client\jre /MT /MIR /R:1 /NFL /NDL /NP /NS /NC /LOG:NUL
-if %errorlevel% geq 4 (
-    @echo Failed to copy JRE across
     exit /b 1
 )
 


### PR DESCRIPTION
### Description of work

JRE is now copied every time `build.bat` is run, rather than just `jenkins_build.bat`.

### Acceptance criteria

When running `build.bat` the jre is copied into `built_client`.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

