### PR TITLE
Rename STABLE PV to AT_SETPOINT

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/zero_field_controller/zero_field_controller_basic_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/zero_field_controller/zero_field_controller_basic_panel.opi
@@ -1066,13 +1066,13 @@ $(pv_value)</tooltip>
       </scale_options>
       <scripts />
       <show_scrollbar>false</show_scrollbar>
-      <text>Stability:</text>
+      <text>At setpoint:</text>
       <tooltip></tooltip>
       <transparent>false</transparent>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>49</width>
+      <width>67</width>
       <wrap_words>true</wrap_words>
       <wuid>68613d89:16eeb454cf7:-7c72</wuid>
       <x>0</x>
@@ -1106,7 +1106,7 @@ $(pv_value)</tooltip>
       <name>Text Update</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT)STABLE</pv_name>
+      <pv_name>$(PV_ROOT)AT_SETPOINT</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules />
@@ -1124,10 +1124,10 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Text Update</widget_type>
-      <width>217</width>
+      <width>199</width>
       <wrap_words>false</wrap_words>
       <wuid>68613d89:16eeb454cf7:-7c68</wuid>
-      <x>54</x>
+      <x>72</x>
       <y>6</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -1168,7 +1168,7 @@ $(pv_value)</tooltip>
       <width>49</width>
       <wrap_words>true</wrap_words>
       <wuid>68613d89:16eeb454cf7:-7c5b</wuid>
-      <x>0</x>
+      <x>18</x>
       <y>36</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -1217,10 +1217,10 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Text Update</widget_type>
-      <width>217</width>
+      <width>199</width>
       <wrap_words>false</wrap_words>
       <wuid>68613d89:16eeb454cf7:-7c5a</wuid>
-      <x>54</x>
+      <x>72</x>
       <y>36</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -1261,7 +1261,7 @@ $(pv_value)</tooltip>
       <width>49</width>
       <wrap_words>true</wrap_words>
       <wuid>68613d89:16eeb454cf7:-7c46</wuid>
-      <x>0</x>
+      <x>18</x>
       <y>66</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -1310,10 +1310,10 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Text Update</widget_type>
-      <width>103</width>
+      <width>85</width>
       <wrap_words>false</wrap_words>
       <wuid>68613d89:16eeb454cf7:-7c45</wuid>
-      <x>54</x>
+      <x>72</x>
       <y>66</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.combo" version="1.0.0">


### PR DESCRIPTION
### Description of work
Changes the reference to the `STABLE` PV to `AT_SETPOINT` in the zero field controller OPI (see [linked PR](https://github.com/ISISComputingGroup/EPICS-ZFCNTRL/pull/8)). The field label has also been changed to "At setpoint" and made a bit larger to fit the extra text.

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/5190

### Acceptance criteria
- When running the updated IOC, the "At setpoint" field correctly displays the value of the `AT_SETPOINT` PV

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

