### PR TITLE
Ticket5121 script gen tabbing across table

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-#uk.ac.stfc.isis.ibex.preferences/perspectives_not_shown=uk.ac.stfc.isis.ibex.client.e4.product.perspective.scriptGenerator,uk.ac.stfc.isis.ibex.client.e4.product.perspective.reflectometry
+uk.ac.stfc.isis.ibex.preferences/perspectives_not_shown=uk.ac.stfc.isis.ibex.client.e4.product.perspective.scriptGenerator,uk.ac.stfc.isis.ibex.client.e4.product.perspective.reflectometry
 uk.ac.stfc.isis.ibex.preferences/show_values_of_invalid_blocks=false
 
 # Script generator preferences

--- a/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-uk.ac.stfc.isis.ibex.preferences/perspectives_not_shown=uk.ac.stfc.isis.ibex.client.e4.product.perspective.scriptGenerator,uk.ac.stfc.isis.ibex.client.e4.product.perspective.reflectometry
+#uk.ac.stfc.isis.ibex.preferences/perspectives_not_shown=uk.ac.stfc.isis.ibex.client.e4.product.perspective.scriptGenerator,uk.ac.stfc.isis.ibex.client.e4.product.perspective.reflectometry
 uk.ac.stfc.isis.ibex.preferences/show_values_of_invalid_blocks=false
 
 # Script generator preferences

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
@@ -113,9 +113,7 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
 					        ||  event.eventType == ColumnViewerEditorActivationEvent.PROGRAMMATIC;
 				}
 			}
-
 		};
-		
 	}
 	
     /**
@@ -183,11 +181,11 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
 	/**
 	 * Sets focus of cell
 	 * @param row row number of table
-	 * @param col column number of table
+	 * @param column column number of table
 	 */
-	private void setCellFocus(int row, int col) {
+	private void setCellFocus(int row, int column) {
 		if (row >= 0) {
-			viewer.editElement(viewer.getElementAt(row), col);
+			viewer.editElement(viewer.getElementAt(row), column);
 		}
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
@@ -38,7 +38,6 @@ import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 
-
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
 import uk.ac.stfc.isis.ibex.ui.tables.ColumnComparator;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundTable;
@@ -49,8 +48,10 @@ import uk.ac.stfc.isis.ibex.ui.tables.SortableObservableMapCellLabelProvider;
  * A table that holds the properties for a target.
  */
 public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
+    
 	private final ScriptGeneratorViewModel scriptGeneratorViewModel;
 	private boolean shiftCellFocusToNewlyAddedRow = false;
+	
 	/**
      * Default constructor for the table. Creates all the correct columns.
      * 
@@ -67,9 +68,12 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
         super(parent, style, tableStyle | SWT.BORDER);
         this.scriptGeneratorViewModel = scriptGeneratorViewModel;
         initialise();
+        
         scriptGeneratorViewModel.addActionParamPropertyListener(this);
-		TableViewerFocusCellManager focusCellManager = new TableViewerFocusCellManager(viewer, new FocusCellOwnerDrawHighlighter(viewer), new CellNavigationStrategy());
+		TableViewerFocusCellManager focusCellManager = new TableViewerFocusCellManager(viewer,
+		        new FocusCellOwnerDrawHighlighter(viewer), new CellNavigationStrategy());
 		ColumnViewerEditorActivationStrategy activationStrategy = createEditorActivationStrategy(viewer);
+		
 		TableViewerEditor.create(viewer, focusCellManager, activationStrategy, 
 				ColumnViewerEditor.TABBING_HORIZONTAL 
 				| ColumnViewerEditor.TABBING_MOVE_TO_ROW_NEIGHBOR
@@ -84,25 +88,29 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
      */
 	private ColumnViewerEditorActivationStrategy createEditorActivationStrategy(TableViewer tableViewer) {
 		return new ColumnViewerEditorActivationStrategy(tableViewer) {
-			protected boolean isEditorActivationEvent(ColumnViewerEditorActivationEvent event) {
-				boolean retVal = true;
+			@Override
+            protected boolean isEditorActivationEvent(ColumnViewerEditorActivationEvent event) {
+				boolean isEditorActivationEvent = true;
+				
 				if (event.eventType == ColumnViewerEditorActivationEvent.TRAVERSAL) { 
  					ColumnViewerEditor editor = this.getViewer().getColumnViewerEditor();
  					ViewerCell nextCell = editor.getFocusCell().getNeighbor(ViewerCell.RIGHT, false);
 					int currentlyFocusedColumn = editor.getFocusCell().getColumnIndex() + 1;
+					
 					// Add new action if tab is pressed by user in the last cell of the table
-					if (nextCell.getNeighbor(ViewerCell.BELOW, false) == null &&
-                    		(viewer.getTable().getColumnCount() - 1 == 
-							currentlyFocusedColumn)) {
+					if (nextCell.getNeighbor(ViewerCell.BELOW, false) == null 
+					        && (viewer.getTable().getColumnCount() - 1 == currentlyFocusedColumn)) {
+					    
                     	scriptGeneratorViewModel.addEmptyAction();
                     	shiftCellFocusToNewlyAddedRow = true;
                     	// return false as we will handle this specific case of traversal
-                    	retVal = false;
-                    } 
-					return retVal;
+                    	isEditorActivationEvent = false;
+                    }
+					
+					return isEditorActivationEvent;
 				} else {
-					return event.eventType == ColumnViewerEditorActivationEvent.MOUSE_CLICK_SELECTION
-					||  event.eventType == ColumnViewerEditorActivationEvent.PROGRAMMATIC;
+					return event.eventType == ColumnViewerEditorActivationEvent.MOUSE_CLICK_SELECTION 
+					        ||  event.eventType == ColumnViewerEditorActivationEvent.PROGRAMMATIC;
 				}
 			}
 
@@ -156,20 +164,19 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
 	@Override
 	public void setRows(Collection<ScriptGeneratorAction> rows) {
 		if ((!viewer.getTable().isDisposed())) {
-			int row = viewer.getTable().getSelectionIndex();
-			int col = 0;
+			int focusRow = viewer.getTable().getSelectionIndex();
+			int focusColumn = 0;
 
 			if (shiftCellFocusToNewlyAddedRow) {
-				row = viewer.getTable().getSelectionIndex() + 1;
+				focusRow = viewer.getTable().getSelectionIndex() + 1;
 				shiftCellFocusToNewlyAddedRow = false;
-				
 			// if row is not empty
-			} else if (row != -1) {
-				col = viewer.getColumnViewerEditor().getFocusCell().getColumnIndex();
+			} else if (focusRow != -1) {
+				focusColumn = viewer.getColumnViewerEditor().getFocusCell().getColumnIndex();
 			}
 			
 			viewer.setInput(new WritableList<ScriptGeneratorAction>(rows, null));
-			setCellFocus(row, col);
+			setCellFocus(focusRow, focusColumn);
 		}
 	} 
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
@@ -95,9 +95,14 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
 				if (event.eventType == ColumnViewerEditorActivationEvent.TRAVERSAL) { 
  					ColumnViewerEditor editor = this.getViewer().getColumnViewerEditor();
  					ViewerCell nextCell = editor.getFocusCell().getNeighbor(ViewerCell.RIGHT, false);
+ 					
+ 					/* The reason this variable is a 1 based index and not a 0 base index 
+ 					 * is because we want to go to a new row when we are on the penultimate
+ 					 * column rather than when we are on the last column. This is because the 
+ 					 * last column is a non editable validity column.*/
 					int currentlyFocusedColumn = editor.getFocusCell().getColumnIndex() + 1;
 					
-					// Add new action if tab is pressed by user in the last cell of the table
+					// Add new action if tab is pressed by user in the last cell of the table.
 					if (nextCell.getNeighbor(ViewerCell.BELOW, false) == null 
 					        && (viewer.getTable().getColumnCount() - 1 == currentlyFocusedColumn)) {
 					    

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
@@ -68,7 +68,7 @@ public abstract class DataboundTable<TRow> extends Composite {
 
     private int tableStyle;
 	private Table table;
-	private TableViewer viewer;
+	protected TableViewer viewer;
 	private TableColumnLayout tableColumnLayout = new TableColumnLayout();
 	private Composite tableComposite;
 	private ObservableListContentProvider<TRow> contentProvider = new ObservableListContentProvider<TRow>();


### PR DESCRIPTION
### Description of work

Allow user to tab across the script gen table.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5121

### Acceptance criteria

- [ ] When I am editing an action in the table and press tab I switch to editing the next in the row
- [ ] When I am editing the last column of the table and press tab a new action is created as a row just below this action and I am editing the first column of this row

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

