### PR TITLE
Allow ctrl-C in reflectometry perspective

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/META-INF/MANIFEST.MF
@@ -16,5 +16,6 @@ Require-Bundle: uk.ac.stfc.isis.ibex.ui;bundle-version="1.0.0",
  org.eclipse.e4.ui.workbench;bundle-version="1.10.0",
  org.eclipse.e4.ui.model.workbench;bundle-version="2.1.400",
  uk.ac.stfc.isis.ibex.epics;bundle-version="1.0.0",
- uk.ac.stfc.isis.ibex.ui.graphing;bundle-version="1.0.0"
+ uk.ac.stfc.isis.ibex.ui.graphing;bundle-version="1.0.0",
+ uk.ac.stfc.isis.ibex.ui.scripting;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/plugin.xml
@@ -18,5 +18,12 @@
             restorable="true">
       </view>
    </extension>
+   <extension
+         point="org.eclipse.ui.handlers">
+      <handler
+            class="uk.ac.stfc.isis.ibex.ui.scripting.InterruptScript"
+            commandId="uk.ac.stfc.isis.ibex.ui.scripting.KillScript">
+      </handler>
+   </extension>
 
 </plugin>


### PR DESCRIPTION
### Description of work

Fixes bug where ctrl-c would not work in reflectometry perspective

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5387

### Acceptance criteria

CTRL-C should interrupt a script in both the scripting and reflectometry perspectives (note: it is the same script running in both)

### Unit tests

n/a

### System tests

n/a

### Documentation

n/a

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

