### PR TITLE
Updated layout

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/crisp/hgaps_CRISP.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/crisp/hgaps_CRISP.opi
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
-  <actions hook="false" hook_all="false"/>
+  <actions hook="false" hook_all="false" />
   <auto_scale_widgets>
     <auto_scale_widgets>false</auto_scale_widgets>
     <min_width>-1</min_width>
@@ -8,39 +8,39 @@
   </auto_scale_widgets>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
-    <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
+    <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
   <boy_version>5.1.0.201707071649</boy_version>
   <foreground_color>
-    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
+    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
-  <height>181</height>
+  <height>185</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
-    <PV_ROOT>$(P)REF:</PV_ROOT>
+    <PV_ROOT>$(P)REFL:</PV_ROOT>
     <PREFIXED_PV>PARAM:$(PARAM_PV)</PREFIXED_PV>
   </macros>
   <name>$(NAME)</name>
-  <rules/>
-  <scripts/>
+  <rules />
+  <scripts />
   <show_close_button>true</show_close_button>
   <show_edit_range>true</show_edit_range>
   <show_grid>true</show_grid>
   <show_ruler>true</show_ruler>
   <snap_to_geometry>true</snap_to_geometry>
   <widget_type>Display</widget_type>
-  <width>295</width>
+  <width>474</width>
   <wuid>450885f3:157944e4d4b:-797d</wuid>
   <x>-1</x>
   <y>-1</y>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </background_color>
     <border_color>
-      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255"/>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
     </border_color>
     <border_style>13</border_style>
     <border_width>1</border_width>
@@ -50,37 +50,37 @@
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
     </font>
     <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>181</height>
+    <height>185</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <name>Horizontal Slit Gaps (mm)</name>
-    <rules/>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <show_scrollbar>true</show_scrollbar>
-    <tooltip/>
+    <tooltip></tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>295</width>
+    <width>474</width>
     <wuid>28840e26:169d9726b77:-799b</wuid>
     <x>0</x>
     <y>0</y>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
+      <actions hook="false" hook_all="false" />
       <background_color>
-        <color red="240" green="240" blue="240"/>
+        <color red="240" green="240" blue="240" />
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255"/>
+        <color red="0" green="128" blue="255" />
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -89,205 +89,205 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192"/>
+        <color red="192" green="192" blue="192" />
       </foreground_color>
-      <group_name/>
-      <height>31</height>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S1HG</PARAM_PV>
-        <PARAM_NAME>S1HG</PARAM_NAME>
-      </macros>
-      <name>vgap_1</name>
-      <opi_file>../param.opi</opi_file>
-      <resize_behaviour>1</resize_behaviour>
-      <rules/>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts/>
-      <tooltip/>
-      <visible>true</visible>
-      <widget_type>Linking Container</widget_type>
-      <width>261</width>
-      <wuid>28840e26:169d9726b77:-799a</wuid>
-      <x>0</x>
-      <y>24</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
-      <background_color>
-        <color red="240" green="240" blue="240"/>
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255"/>
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-      </font>
-      <foreground_color>
-        <color red="192" green="192" blue="192"/>
-      </foreground_color>
-      <group_name/>
-      <height>31</height>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S2HG</PARAM_PV>
-        <PARAM_NAME>S2HG</PARAM_NAME>
-      </macros>
-      <name>vgap_2</name>
-      <opi_file>../param.opi</opi_file>
-      <resize_behaviour>1</resize_behaviour>
-      <rules/>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts/>
-      <tooltip/>
-      <visible>true</visible>
-      <widget_type>Linking Container</widget_type>
-      <width>261</width>
-      <wuid>28840e26:169d9726b77:-7999</wuid>
-      <x>0</x>
-      <y>54</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
-      <background_color>
-        <color red="240" green="240" blue="240"/>
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255"/>
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-      </font>
-      <foreground_color>
-        <color red="192" green="192" blue="192"/>
-      </foreground_color>
-      <group_name/>
-      <height>31</height>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S3HG</PARAM_PV>
-        <PARAM_NAME>S3HG</PARAM_NAME>
-      </macros>
-      <name>vgap_3</name>
-      <opi_file>../param.opi</opi_file>
-      <resize_behaviour>1</resize_behaviour>
-      <rules/>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts/>
-      <tooltip/>
-      <visible>true</visible>
-      <widget_type>Linking Container</widget_type>
-      <width>261</width>
-      <wuid>28840e26:169d9726b77:-7998</wuid>
-      <x>0</x>
-      <y>84</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
-      <background_color>
-        <color red="240" green="240" blue="240"/>
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255"/>
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-      </font>
-      <foreground_color>
-        <color red="192" green="192" blue="192"/>
-      </foreground_color>
-      <group_name/>
-      <height>31</height>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S4HG</PARAM_PV>
-        <PARAM_NAME>S4HG</PARAM_NAME>
-      </macros>
-      <name>vgap_4</name>
-      <opi_file>../param.opi</opi_file>
-      <resize_behaviour>1</resize_behaviour>
-      <rules/>
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts/>
-      <tooltip/>
-      <visible>true</visible>
-      <widget_type>Linking Container</widget_type>
-      <width>261</width>
-      <wuid>28840e26:169d9726b77:-7997</wuid>
-      <x>0</x>
-      <y>114</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
-      <background_color>
-        <color red="240" green="240" blue="240"/>
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255"/>
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-      </font>
-      <foreground_color>
-        <color red="192" green="192" blue="192"/>
-      </foreground_color>
-      <group_name/>
-      <height>20</height>
+      <group_name></group_name>
+      <height>17</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Linking Container</name>
       <opi_file>../set_point_column_labels.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
-      <rules/>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts/>
-      <tooltip/>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
-      <width>182</width>
+      <width>201</width>
       <wuid>-166f7f1c:16bdb17a9a5:-7483</wuid>
-      <x>70</x>
-      <y>5</y>
+      <x>180</x>
+      <y>-1</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>25</height>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+        <PARAM_PV>S1HG</PARAM_PV>
+        <PARAM_NAME>S1HG</PARAM_NAME>
+      </macros>
+      <name>vgap_1</name>
+      <opi_file>../param_move.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>441</width>
+      <wuid>28840e26:169d9726b77:-799a</wuid>
+      <x>0</x>
+      <y>20</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>25</height>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+        <PARAM_PV>S2HG</PARAM_PV>
+        <PARAM_NAME>S2HG</PARAM_NAME>
+      </macros>
+      <name>vgap_2</name>
+      <opi_file>../param_move.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>441</width>
+      <wuid>28840e26:169d9726b77:-7999</wuid>
+      <x>0</x>
+      <y>50</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>25</height>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+        <PARAM_PV>S3HG</PARAM_PV>
+        <PARAM_NAME>S3HG</PARAM_NAME>
+      </macros>
+      <name>vgap_3</name>
+      <opi_file>../param_move.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>441</width>
+      <wuid>28840e26:169d9726b77:-7998</wuid>
+      <x>0</x>
+      <y>80</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>25</height>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+        <PARAM_PV>S4HG</PARAM_PV>
+        <PARAM_NAME>S4HG</PARAM_NAME>
+      </macros>
+      <name>vgap_4</name>
+      <opi_file>../param_move.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>441</width>
+      <wuid>28840e26:169d9726b77:-7997</wuid>
+      <x>0</x>
+      <y>110</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -297,25 +297,25 @@
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>1</height>
-    <image/>
+    <image></image>
     <name>Dummy</name>
     <push_action_index>0</push_action_index>
-    <pv_name/>
-    <pv_value/>
-    <rules/>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <style>1</style>
-    <text/>
+    <text></text>
     <toggle_button>false</toggle_button>
-    <tooltip/>
+    <tooltip></tooltip>
     <visible>true</visible>
     <widget_type>Action Button</widget_type>
     <width>1</width>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/crisp/important_params_CRISP.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/crisp/important_params_CRISP.opi
@@ -8,20 +8,18 @@
   </auto_scale_widgets>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
-    <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    <color red="240" green="240" blue="240" />
   </background_color>
   <boy_version>5.1.0.201707071649</boy_version>
   <foreground_color>
-    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    <color red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
-  <height>185</height>
+  <height>600</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
-    <PV_ROOT>$(P)REFL:</PV_ROOT>
-    <PREFIXED_PV>PARAM:$(PARAM_PV)</PREFIXED_PV>
   </macros>
-  <name>$(NAME)</name>
+  <name></name>
   <rules />
   <scripts />
   <show_close_button>true</show_close_button>
@@ -30,8 +28,8 @@
   <show_ruler>true</show_ruler>
   <snap_to_geometry>true</snap_to_geometry>
   <widget_type>Display</widget_type>
-  <width>474</width>
-  <wuid>450885f3:157944e4d4b:-797d</wuid>
+  <width>800</width>
+  <wuid>-76f649f7:171a7364276:-7b71</wuid>
   <x>-1</x>
   <y>-1</y>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
@@ -47,7 +45,8 @@
     <enabled>true</enabled>
     <fc>false</fc>
     <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW
+                      </opifont.name>
     </font>
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
@@ -57,7 +56,7 @@
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
-    <name>Vertical Slit Gaps (mm)</name>
+    <name>Important Beamline Parameters</name>
     <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -70,8 +69,8 @@
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>474</width>
-    <wuid>28840e26:169d9726b77:-7b95</wuid>
+    <width>475</width>
+    <wuid>-76f649f7:171a7364276:-7b5a</wuid>
     <x>0</x>
     <y>0</y>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
@@ -95,10 +94,10 @@
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S1VG</PARAM_PV>
-        <PARAM_NAME>S1VG</PARAM_NAME>
+        <PARAM_PV>PARAM:THETA</PARAM_PV>
+        <PARAM_NAME>Theta</PARAM_NAME>
       </macros>
-      <name>vgap_1</name>
+      <name></name>
       <opi_file>../param_move.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
       <rules />
@@ -112,7 +111,7 @@
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>441</width>
-      <wuid>28840e26:169d9726b77:-7b93</wuid>
+      <wuid>-76f649f7:171a7364276:-7b58</wuid>
       <x>0</x>
       <y>20</y>
     </widget>
@@ -137,10 +136,10 @@
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S2VG</PARAM_PV>
-        <PARAM_NAME>S2VG</PARAM_NAME>
+        <PARAM_NAME>SM Angle</PARAM_NAME>
+        <PARAM_PV>PARAM:SMANGLE</PARAM_PV>
       </macros>
-      <name>vgap_1</name>
+      <name></name>
       <opi_file>../param_move.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
       <rules />
@@ -154,7 +153,7 @@
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>441</width>
-      <wuid>28840e26:169d9726b77:-7b92</wuid>
+      <wuid>-76f649f7:171a7364276:-7b59</wuid>
       <x>0</x>
       <y>50</y>
     </widget>
@@ -179,11 +178,11 @@
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S3VG</PARAM_PV>
-        <PARAM_NAME>S3VG</PARAM_NAME>
+        <PARAM_NAME>SM In Beam</PARAM_NAME>
+        <PARAM_PV>PARAM:SMINBEAM</PARAM_PV>
       </macros>
-      <name>vgap_1</name>
-      <opi_file>../param_move.opi</opi_file>
+      <name></name>
+      <opi_file>../param_inout.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
       <rules />
       <scale_options>
@@ -196,7 +195,7 @@
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>441</width>
-      <wuid>28840e26:169d9726b77:-7b91</wuid>
+      <wuid>-76f649f7:171a7364276:-7b57</wuid>
       <x>0</x>
       <y>80</y>
     </widget>
@@ -221,11 +220,11 @@
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S4VG</PARAM_PV>
-        <PARAM_NAME>S4VG</PARAM_NAME>
+        <PARAM_NAME>Sample In Beam</PARAM_NAME>
+        <PARAM_PV>PARAM:SAMPINBEAM</PARAM_PV>
       </macros>
-      <name>vgap_1</name>
-      <opi_file>../param_move.opi</opi_file>
+      <name>_3</name>
+      <opi_file>../param_inout.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
       <rules />
       <scale_options>
@@ -238,7 +237,7 @@
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>441</width>
-      <wuid>28840e26:169d9726b77:-7b90</wuid>
+      <wuid>-76f649f7:171a7364276:-7b56</wuid>
       <x>0</x>
       <y>110</y>
     </widget>
@@ -278,49 +277,9 @@
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>201</width>
-      <wuid>-166f7f1c:16bdb17a9a5:-73c6</wuid>
-      <x>180</x>
-      <y>-1</y>
+      <wuid>-76f649f7:171a7364276:-7b55</wuid>
+      <x>170</x>
+      <y>0</y>
     </widget>
-  </widget>
-  <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-    <actions hook="false" hook_all="false" />
-    <border_alarm_sensitive>false</border_alarm_sensitive>
-    <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
-    </border_color>
-    <border_style>0</border_style>
-    <border_width>1</border_width>
-    <enabled>true</enabled>
-    <font>
-      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
-    </font>
-    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-    <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-    </foreground_color>
-    <height>1</height>
-    <image></image>
-    <name>Dummy</name>
-    <push_action_index>0</push_action_index>
-    <pv_name></pv_name>
-    <pv_value />
-    <rules />
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
-    <style>1</style>
-    <text></text>
-    <toggle_button>false</toggle_button>
-    <tooltip></tooltip>
-    <visible>true</visible>
-    <widget_type>Action Button</widget_type>
-    <width>1</width>
-    <wuid>-648922a4:1624e4fa0bd:-7f69</wuid>
-    <x>0</x>
-    <y>0</y>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/crisp/sample_stack_CRISP.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/crisp/sample_stack_CRISP.opi
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
-  <actions hook="false" hook_all="false"/>
+  <actions hook="false" hook_all="false" />
   <auto_scale_widgets>
     <auto_scale_widgets>false</auto_scale_widgets>
     <min_width>-1</min_width>
@@ -8,39 +8,39 @@
   </auto_scale_widgets>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
-    <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
+    <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
   <boy_version>5.1.0.201707071649</boy_version>
   <foreground_color>
-    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
+    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
-  <height>320</height>
+  <height>185</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
     <PV_ROOT>$(P)REF:</PV_ROOT>
     <PREFIXED_PV>PARAM:$(PARAM_PV)</PREFIXED_PV>
   </macros>
   <name>$(NAME)</name>
-  <rules/>
-  <scripts/>
+  <rules />
+  <scripts />
   <show_close_button>true</show_close_button>
   <show_edit_range>true</show_edit_range>
   <show_grid>true</show_grid>
   <show_ruler>true</show_ruler>
   <snap_to_geometry>true</snap_to_geometry>
   <widget_type>Display</widget_type>
-  <width>280</width>
+  <width>474</width>
   <wuid>450885f3:157944e4d4b:-797d</wuid>
   <x>-1</x>
   <y>-1</y>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </background_color>
     <border_color>
-      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255"/>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
     </border_color>
     <border_style>13</border_style>
     <border_width>1</border_width>
@@ -50,37 +50,37 @@
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
     </font>
     <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>320</height>
+    <height>185</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <name>Sample Stack</name>
-    <rules/>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <show_scrollbar>true</show_scrollbar>
-    <tooltip/>
+    <tooltip></tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>295</width>
+    <width>474</width>
     <wuid>2150758c:16990a9ebac:-79ce</wuid>
     <x>0</x>
     <y>0</y>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
+      <actions hook="false" hook_all="false" />
       <background_color>
-        <color red="240" green="240" blue="240"/>
+        <color red="240" green="240" blue="240" />
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255"/>
+        <color red="0" green="128" blue="255" />
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -89,40 +89,80 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192"/>
+        <color red="192" green="192" blue="192" />
       </foreground_color>
-      <group_name/>
-      <height>31</height>
+      <group_name></group_name>
+      <height>17</height>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+      </macros>
+      <name>Linking Container</name>
+      <opi_file>../set_point_column_labels.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>201</width>
+      <wuid>-610e831b:171971644fa:-62fd</wuid>
+      <x>180</x>
+      <y>0</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PARAM_NAME>Phi</PARAM_NAME>
-        <M>MOT:STACK:PHI</M>
+        <PARAM_PV>SAMPPHI</PARAM_PV>
       </macros>
       <name>Linking Container</name>
-      <opi_file>../param_placeholder.opi</opi_file>
+      <opi_file>../param_move.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
-      <rules/>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts/>
-      <tooltip/>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
-      <width>260</width>
+      <width>441</width>
       <wuid>2150758c:16990a9ebac:-7450</wuid>
-      <x>2</x>
-      <y>7</y>
+      <x>0</x>
+      <y>20</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
+      <actions hook="false" hook_all="false" />
       <background_color>
-        <color red="240" green="240" blue="240"/>
+        <color red="240" green="240" blue="240" />
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255"/>
+        <color red="0" green="128" blue="255" />
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -131,40 +171,40 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192"/>
+        <color red="192" green="192" blue="192" />
       </foreground_color>
-      <group_name/>
-      <height>31</height>
+      <group_name></group_name>
+      <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PARAM_NAME>Psi</PARAM_NAME>
-        <M>MOT:STACK:PSI</M>
+        <PARAM_PV>SAMPPSI</PARAM_PV>
       </macros>
       <name>Linking Container</name>
-      <opi_file>../param_placeholder.opi</opi_file>
+      <opi_file>../param_move.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
-      <rules/>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts/>
-      <tooltip/>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
-      <width>260</width>
+      <width>441</width>
       <wuid>2150758c:16990a9ebac:-7441</wuid>
-      <x>2</x>
-      <y>47</y>
+      <x>0</x>
+      <y>50</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
+      <actions hook="false" hook_all="false" />
       <background_color>
-        <color red="240" green="240" blue="240"/>
+        <color red="240" green="240" blue="240" />
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255"/>
+        <color red="0" green="128" blue="255" />
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -173,40 +213,40 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192"/>
+        <color red="192" green="192" blue="192" />
       </foreground_color>
-      <group_name/>
-      <height>31</height>
+      <group_name></group_name>
+      <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PARAM_NAME>Height</PARAM_NAME>
-        <M>MOT:STACK:HEIGHT</M>
+        <PARAM_PV>SAMPOFFSET</PARAM_PV>
       </macros>
       <name>Linking Container</name>
-      <opi_file>../param_placeholder.opi</opi_file>
+      <opi_file>../param_move.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
-      <rules/>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts/>
-      <tooltip/>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
-      <width>260</width>
+      <width>441</width>
       <wuid>2150758c:16990a9ebac:-742b</wuid>
-      <x>2</x>
-      <y>87</y>
+      <x>0</x>
+      <y>80</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
+      <actions hook="false" hook_all="false" />
       <background_color>
-        <color red="240" green="240" blue="240"/>
+        <color red="240" green="240" blue="240" />
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255"/>
+        <color red="0" green="128" blue="255" />
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -215,39 +255,39 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192"/>
+        <color red="192" green="192" blue="192" />
       </foreground_color>
-      <group_name/>
-      <height>31</height>
+      <group_name></group_name>
+      <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PARAM_NAME>Trans</PARAM_NAME>
-        <M>MOT:STACK:TRANS</M>
+        <PARAM_PV>SAMPTRANS</PARAM_PV>
       </macros>
       <name>Linking Container</name>
-      <opi_file>../param_placeholder.opi</opi_file>
+      <opi_file>../param_move.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
-      <rules/>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts/>
-      <tooltip/>
+      <scripts />
+      <tooltip></tooltip>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
-      <width>260</width>
+      <width>441</width>
       <wuid>2150758c:16990a9ebac:-73e7</wuid>
-      <x>2</x>
-      <y>127</y>
+      <x>0</x>
+      <y>110</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -257,25 +297,25 @@
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>1</height>
-    <image/>
+    <image></image>
     <name>Dummy</name>
     <push_action_index>0</push_action_index>
-    <pv_name/>
-    <pv_value/>
-    <rules/>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <style>1</style>
-    <text/>
+    <text></text>
     <toggle_button>false</toggle_button>
-    <tooltip/>
+    <tooltip></tooltip>
     <visible>true</visible>
     <widget_type>Action Button</widget_type>
     <width>1</width>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -147,14 +147,14 @@
         <color red="150" green="150" blue="150" />
       </bulb_border_color>
       <data_type>0</data_type>
-      <effect_3d>true</effect_3d>
+      <effect_3d>false</effect_3d>
       <enabled>true</enabled>
       <font>
         <opifont.name fontName="Arial" height="9" style="0" pixels="false">ISIS_Label_Small</opifont.name>
       </font>
       <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
       <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+        <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
       </foreground_color>
       <height>31</height>
       <name>Autotune_LED</name>
@@ -168,7 +168,16 @@
       <on_label>In Motion</on_label>
       <pv_name>$(P)CS:MOT:MOVING</pv_name>
       <pv_value />
-      <rules />
+      <rules>
+        <rule name="TextColour" prop_id="foreground_color" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>
+              <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+            </value>
+          </exp>
+          <pv trig="true">$(P)CS:MOT:MOVING</pv>
+        </rule>
+      </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -6,7 +6,7 @@
     <min_width>-1</min_width>
     <min_height>-1</min_height>
   </auto_scale_widgets>
-  <auto_zoom_to_fit_all>true</auto_zoom_to_fit_all>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
     <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
@@ -128,47 +128,6 @@
       <x>732</x>
       <y>12</y>
     </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false" />
-      <auto_size>false</auto_size>
-      <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-      </background_color>
-      <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
-      </font>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <height>20</height>
-      <horizontal_alignment>2</horizontal_alignment>
-      <name>Autotune_label</name>
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts />
-      <show_scrollbar>false</show_scrollbar>
-      <text>In Motion:</text>
-      <tooltip></tooltip>
-      <transparent>false</transparent>
-      <vertical_alignment>1</vertical_alignment>
-      <visible>true</visible>
-      <widget_type>Label</widget_type>
-      <width>60</width>
-      <wrap_words>true</wrap_words>
-      <wuid>-7578f52:165a3e390a9:-7314</wuid>
-      <x>624</x>
-      <y>20</y>
-    </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
       <actions hook="false" hook_all="false" />
       <alarm_pulsing>false</alarm_pulsing>
@@ -195,18 +154,18 @@
       </font>
       <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
       <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
-      <height>25</height>
+      <height>31</height>
       <name>Autotune_LED</name>
       <off_color>
         <color name="ISIS_Green_LED_Off" red="0" green="102" blue="0" />
       </off_color>
-      <off_label>OFF</off_label>
+      <off_label>Not In Motion</off_label>
       <on_color>
         <color name="ISIS_Green_LED_On" red="0" green="255" blue="0" />
       </on_color>
-      <on_label>ON</on_label>
+      <on_label>In Motion</on_label>
       <pv_name>$(P)CS:MOT:MOVING</pv_name>
       <pv_value />
       <rules />
@@ -216,17 +175,17 @@
         <keep_wh_ratio>true</keep_wh_ratio>
       </scale_options>
       <scripts />
-      <show_boolean_label>false</show_boolean_label>
-      <square_led>false</square_led>
+      <show_boolean_label>true</show_boolean_label>
+      <square_led>true</square_led>
       <tooltip>$(pv_name)
               $(pv_value)
           </tooltip>
       <visible>true</visible>
       <widget_type>LED</widget_type>
-      <width>25</width>
+      <width>115</width>
       <wuid>-7578f52:165a3e390a9:-7315</wuid>
-      <x>690</x>
-      <y>17</y>
+      <x>606</x>
+      <y>14</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.tab" version="1.0.0">
       <actions hook="false" hook_all="false" />

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/front_panel.opi
@@ -6,7 +6,7 @@
     <min_width>-1</min_width>
     <min_height>-1</min_height>
   </auto_scale_widgets>
-  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <auto_zoom_to_fit_all>true</auto_zoom_to_fit_all>
   <background_color>
     <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
@@ -15,7 +15,7 @@
     <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
-  <height>660</height>
+  <height>650</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
     <PV_ROOT>$(P)REFL:</PV_ROOT>
@@ -51,7 +51,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>660</height>
+    <height>646</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -69,7 +69,7 @@
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>1051</width>
+    <width>967</width>
     <wuid>-16c8e940:165f1448c04:-7afd</wuid>
     <x>0</x>
     <y>0</y>
@@ -125,7 +125,7 @@
       <widget_type>Action Button</widget_type>
       <width>235</width>
       <wuid>-7f97b5e4:165e6b6475b:-4c96</wuid>
-      <x>804</x>
+      <x>732</x>
       <y>12</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -166,7 +166,7 @@
       <width>60</width>
       <wrap_words>true</wrap_words>
       <wuid>-7578f52:165a3e390a9:-7314</wuid>
-      <x>696</x>
+      <x>624</x>
       <y>20</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
@@ -225,7 +225,7 @@
       <widget_type>LED</widget_type>
       <width>25</width>
       <wuid>-7578f52:165a3e390a9:-7315</wuid>
-      <x>762</x>
+      <x>690</x>
       <y>17</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.tab" version="1.0.0">
@@ -243,7 +243,7 @@
       <foreground_color>
         <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
       </foreground_color>
-      <height>577</height>
+      <height>580</height>
       <horizontal_tabs>true</horizontal_tabs>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -333,7 +333,7 @@
       <tooltip></tooltip>
       <visible>true</visible>
       <widget_type>Tabbed Container</widget_type>
-      <width>1045</width>
+      <width>967</width>
       <wuid>450885f3:157944e4d4b:-7436</wuid>
       <x>0</x>
       <y>36</y>
@@ -355,7 +355,7 @@
         <foreground_color>
           <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
         </foreground_color>
-        <height>548</height>
+        <height>551</height>
         <lock_children>false</lock_children>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -373,7 +373,7 @@
         <transparent>true</transparent>
         <visible>true</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>1043</width>
+        <width>965</width>
         <wuid>4fbad31a:1436c3e166f:-6faf</wuid>
         <x>1</x>
         <y>1</y>
@@ -396,7 +396,7 @@
           <foreground_color>
             <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
           </foreground_color>
-          <height>212</height>
+          <height>172</height>
           <lock_children>false</lock_children>
           <macros>
             <include_parent_macros>true</include_parent_macros>
@@ -414,10 +414,10 @@
           <transparent>false</transparent>
           <visible>true</visible>
           <widget_type>Grouping Container</widget_type>
-          <width>296</width>
+          <width>181</width>
           <wuid>-744b7940:165a9b5d31a:-7882</wuid>
           <x>306</x>
-          <y>331</y>
+          <y>378</y>
           <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
             <actions hook="false" hook_all="false" />
             <alarm_pulsing>false</alarm_pulsing>
@@ -439,7 +439,7 @@
             <foreground_color>
               <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
             </foreground_color>
-            <height>163</height>
+            <height>127</height>
             <horizontal>false</horizontal>
             <items_from_pv>true</items_from_pv>
             <name>Choice Button</name>
@@ -460,9 +460,9 @@
                       </tooltip>
             <visible>true</visible>
             <widget_type>Choice Button</widget_type>
-            <width>241</width>
+            <width>139</width>
             <wuid>-744b7940:165a9b5d31a:-770a</wuid>
-            <x>12</x>
+            <x>6</x>
             <y>12</y>
           </widget>
         </widget>
@@ -506,7 +506,7 @@
           <width>295</width>
           <wuid>-66312240:1683d19d453:-70c9</wuid>
           <x>12</x>
-          <y>372</y>
+          <y>378</y>
           <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
             <actions hook="false" hook_all="false" />
             <auto_size>false</auto_size>
@@ -937,256 +937,6 @@
             </widget>
           </widget>
         </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>13</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <fc>false</fc>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW
-                      </opifont.name>
-          </font>
-          <foreground_color>
-            <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
-          </foreground_color>
-          <height>361</height>
-          <lock_children>false</lock_children>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>Important Beamline Parameters</name>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <show_scrollbar>true</show_scrollbar>
-          <tooltip></tooltip>
-          <transparent>false</transparent>
-          <visible>true</visible>
-          <widget_type>Grouping Container</widget_type>
-          <width>432</width>
-          <wuid>3a15ff6c:167a2ac2773:-7e19</wuid>
-          <x>601</x>
-          <y>12</y>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>33</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-              <PARAM_NAME>SM Angle</PARAM_NAME>
-              <PARAM_PV>PARAM:SMANGLE</PARAM_PV>
-            </macros>
-            <name></name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>1</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>true</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>398</width>
-            <wuid>660a6691:1677ec40d1b:-7ebd</wuid>
-            <x>0</x>
-            <y>65</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>33</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-              <PARAM_PV>PARAM:THETA</PARAM_PV>
-              <PARAM_NAME>Theta</PARAM_NAME>
-            </macros>
-            <name></name>
-            <opi_file>param_move.opi</opi_file>
-            <resize_behaviour>1</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>true</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>398</width>
-            <wuid>-19dc714f:1677a2ed8a5:-7ece</wuid>
-            <x>0</x>
-            <y>26</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>33</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-              <PARAM_NAME>SM In Beam</PARAM_NAME>
-              <PARAM_PV>PARAM:SMINBEAM</PARAM_PV>
-            </macros>
-            <name></name>
-            <opi_file>param_inout.opi</opi_file>
-            <resize_behaviour>1</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>true</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>398</width>
-            <wuid>2150758c:16990a9ebac:-6ddf</wuid>
-            <x>0</x>
-            <y>104</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>33</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-              <PARAM_NAME>Sample In Beam</PARAM_NAME>
-              <PARAM_PV>PARAM:SAMPINBEAM</PARAM_PV>
-            </macros>
-            <name>_3</name>
-            <opi_file>param_inout.opi</opi_file>
-            <resize_behaviour>1</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>true</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>398</width>
-            <wuid>-74439178:16b93487e3a:-7ced</wuid>
-            <x>0</x>
-            <y>143</y>
-          </widget>
-          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-            <actions hook="false" hook_all="false" />
-            <background_color>
-              <color red="240" green="240" blue="240" />
-            </background_color>
-            <border_color>
-              <color red="0" green="128" blue="255" />
-            </border_color>
-            <border_style>0</border_style>
-            <border_width>1</border_width>
-            <enabled>true</enabled>
-            <font>
-              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-            </font>
-            <foreground_color>
-              <color red="192" green="192" blue="192" />
-            </foreground_color>
-            <group_name></group_name>
-            <height>20</height>
-            <macros>
-              <include_parent_macros>true</include_parent_macros>
-            </macros>
-            <name>Linking Container</name>
-            <opi_file>set_point_column_labels.opi</opi_file>
-            <resize_behaviour>1</resize_behaviour>
-            <rules />
-            <scale_options>
-              <width_scalable>true</width_scalable>
-              <height_scalable>true</height_scalable>
-              <keep_wh_ratio>false</keep_wh_ratio>
-            </scale_options>
-            <scripts />
-            <tooltip></tooltip>
-            <visible>true</visible>
-            <widget_type>Linking Container</widget_type>
-            <width>182</width>
-            <wuid>5ab6761d:16c1e2986e0:-7c70</wuid>
-            <x>146</x>
-            <y>6</y>
-          </widget>
-        </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
           <background_color>
@@ -1205,53 +955,13 @@
             <color red="192" green="192" blue="192" />
           </foreground_color>
           <group_name></group_name>
-          <height>320</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>Sample Stack</name>
-          <opi_file>crisp/sample_stack_CRISP.opi</opi_file>
-          <resize_behaviour>0</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>true</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>296</width>
-          <wuid>28840e26:169d9726b77:-7d57</wuid>
-          <x>306</x>
-          <y>12</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>181</height>
+          <height>185</height>
           <macros>
             <include_parent_macros>true</include_parent_macros>
           </macros>
           <name>Linking Container</name>
           <opi_file>crisp/vgaps_CRISP.opi</opi_file>
-          <resize_behaviour>0</resize_behaviour>
+          <resize_behaviour>3</resize_behaviour>
           <rules />
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -1262,10 +972,10 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>295</width>
+          <width>475</width>
           <wuid>28840e26:169d9726b77:-7a98</wuid>
           <x>12</x>
-          <y>12</y>
+          <y>10</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -1285,7 +995,7 @@
             <color red="192" green="192" blue="192" />
           </foreground_color>
           <group_name></group_name>
-          <height>181</height>
+          <height>185</height>
           <macros>
             <include_parent_macros>true</include_parent_macros>
           </macros>
@@ -1302,10 +1012,10 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>295</width>
+          <width>475</width>
           <wuid>28840e26:169d9726b77:-790b</wuid>
           <x>12</x>
-          <y>192</y>
+          <y>194</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -1344,10 +1054,10 @@
           <transparent>false</transparent>
           <visible>true</visible>
           <widget_type>Grouping Container</widget_type>
-          <width>432</width>
+          <width>475</width>
           <wuid>28840e26:169d9726b77:-7720</wuid>
-          <x>601</x>
-          <y>372</y>
+          <x>486</x>
+          <y>378</y>
           <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
             <actions hook="false" hook_all="false" />
             <auto_size>false</auto_size>
@@ -1428,7 +1138,7 @@
             <width>164</width>
             <wrap_words>true</wrap_words>
             <wuid>-7f369489:170ab284932:-7b7f</wuid>
-            <x>228</x>
+            <x>263</x>
             <y>6</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -1509,7 +1219,7 @@
               <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
             </foreground_color>
             <format_type>4</format_type>
-            <height>97</height>
+            <height>100</height>
             <horizontal_alignment>0</horizontal_alignment>
             <name>Text Update_1</name>
             <precision>0</precision>
@@ -1533,12 +1243,92 @@
             <vertical_alignment>0</vertical_alignment>
             <visible>true</visible>
             <widget_type>Text Update</widget_type>
-            <width>380</width>
+            <width>427</width>
             <wrap_words>true</wrap_words>
             <wuid>28840e26:169d9726b77:-76c2</wuid>
             <x>12</x>
             <y>36</y>
           </widget>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>185</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>Sample Stack</name>
+          <opi_file>crisp/sample_stack_CRISP.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>true</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>475</width>
+          <wuid>28840e26:169d9726b77:-7d57</wuid>
+          <x>486</x>
+          <y>10</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <foreground_color>
+            <color red="192" green="192" blue="192" />
+          </foreground_color>
+          <group_name></group_name>
+          <height>185</height>
+          <macros>
+            <include_parent_macros>true</include_parent_macros>
+          </macros>
+          <name>Sample Stack</name>
+          <opi_file>crisp/important_params_CRISP.opi</opi_file>
+          <resize_behaviour>3</resize_behaviour>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <tooltip></tooltip>
+          <visible>true</visible>
+          <widget_type>Linking Container</widget_type>
+          <width>475</width>
+          <wuid>-76f649f7:171a7364276:-7aac</wuid>
+          <x>486</x>
+          <y>194</y>
         </widget>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
@@ -1559,7 +1349,7 @@
         <foreground_color>
           <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
         </foreground_color>
-        <height>548</height>
+        <height>551</height>
         <lock_children>false</lock_children>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -1577,7 +1367,7 @@
         <transparent>true</transparent>
         <visible>false</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>1043</width>
+        <width>965</width>
         <wuid>4fbad31a:1436c3e166f:-6fae</wuid>
         <x>1</x>
         <y>1</y>
@@ -1599,7 +1389,7 @@
           <foreground_color>
             <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
           </foreground_color>
-          <height>535</height>
+          <height>545</height>
           <lock_children>false</lock_children>
           <macros>
             <include_parent_macros>true</include_parent_macros>
@@ -1624,9 +1414,9 @@
           <transparent>false</transparent>
           <visible>true</visible>
           <widget_type>Grouping Container</widget_type>
-          <width>931</width>
+          <width>950</width>
           <wuid>7b2b8c8d:165c7bfd038:-7a1c</wuid>
-          <x>60</x>
+          <x>6</x>
           <y>6</y>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1646,7 +1436,87 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>17</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>Linking Container</name>
+            <opi_file>set_point_column_labels.opi</opi_file>
+            <resize_behaviour>1</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>true</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>201</width>
+            <wuid>-610e831b:171971644fa:-5e70</wuid>
+            <x>180</x>
+            <y>1</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>17</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>Linking Container</name>
+            <opi_file>set_point_column_labels.opi</opi_file>
+            <resize_behaviour>1</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>true</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>201</width>
+            <wuid>-610e831b:171971644fa:-5d40</wuid>
+            <x>656</x>
+            <y>1</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -1663,10 +1533,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>-744b7940:165a9b5d31a:-6596</wuid>
-            <x>0</x>
-            <y>1</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5e63</wuid>
+            <x>12</x>
+            <y>20</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1686,7 +1556,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -1703,10 +1573,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>-744b7940:165a9b5d31a:-61cf</wuid>
-            <x>0</x>
-            <y>51</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5e51</wuid>
+            <x>12</x>
+            <y>55</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1726,7 +1596,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -1743,10 +1613,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>-744b7940:165a9b5d31a:-61bd</wuid>
-            <x>0</x>
-            <y>101</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5e3f</wuid>
+            <x>12</x>
+            <y>90</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1766,7 +1636,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -1783,10 +1653,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>-744b7940:165a9b5d31a:-61ae</wuid>
-            <x>0</x>
-            <y>151</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5e2d</wuid>
+            <x>12</x>
+            <y>125</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1806,7 +1676,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -1823,10 +1693,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>-744b7940:165a9b5d31a:-619f</wuid>
-            <x>0</x>
-            <y>201</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5e1b</wuid>
+            <x>12</x>
+            <y>160</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1846,7 +1716,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -1863,10 +1733,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>-744b7940:165a9b5d31a:-6190</wuid>
-            <x>0</x>
-            <y>251</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5e09</wuid>
+            <x>12</x>
+            <y>195</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1886,7 +1756,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -1903,10 +1773,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>-744b7940:165a9b5d31a:-6181</wuid>
-            <x>0</x>
-            <y>301</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5df7</wuid>
+            <x>12</x>
+            <y>230</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1926,7 +1796,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -1943,10 +1813,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>-744b7940:165a9b5d31a:-6172</wuid>
-            <x>0</x>
-            <y>351</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5de5</wuid>
+            <x>12</x>
+            <y>265</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -1966,7 +1836,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -1983,10 +1853,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-7249</wuid>
-            <x>0</x>
-            <y>397</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5dd3</wuid>
+            <x>12</x>
+            <y>300</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2006,7 +1876,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2023,10 +1893,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-723e</wuid>
-            <x>0</x>
-            <y>445</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5dc1</wuid>
+            <x>12</x>
+            <y>335</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2046,7 +1916,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2063,10 +1933,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-7233</wuid>
-            <x>0</x>
-            <y>492</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5daf</wuid>
+            <x>12</x>
+            <y>370</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2086,7 +1956,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2103,10 +1973,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-7228</wuid>
-            <x>486</x>
-            <y>1</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5d9d</wuid>
+            <x>12</x>
+            <y>405</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2126,7 +1996,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2143,10 +2013,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
-            <wuid>7b2b8c8d:165c7bfd038:-721d</wuid>
-            <x>486</x>
-            <y>51</y>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5d8b</wuid>
+            <x>12</x>
+            <y>440</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2166,7 +2036,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2183,10 +2053,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
+            <width>451</width>
             <wuid>7b2b8c8d:165c7bfd038:-7212</wuid>
-            <x>486</x>
-            <y>101</y>
+            <x>12</x>
+            <y>475</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2206,7 +2076,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2223,10 +2093,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
+            <width>451</width>
             <wuid>7b2b8c8d:165c7bfd038:-7207</wuid>
-            <x>486</x>
-            <y>151</y>
+            <x>12</x>
+            <y>510</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2246,7 +2116,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2263,10 +2133,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
+            <width>451</width>
             <wuid>7b2b8c8d:165c7bfd038:-71fc</wuid>
             <x>486</x>
-            <y>201</y>
+            <y>20</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2286,7 +2156,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2303,10 +2173,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
+            <width>451</width>
             <wuid>-74439178:16b93487e3a:-7cb6</wuid>
             <x>486</x>
-            <y>251</y>
+            <y>55</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2326,7 +2196,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2343,10 +2213,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
+            <width>451</width>
             <wuid>-74439178:16b93487e3a:-7ca5</wuid>
             <x>486</x>
-            <y>301</y>
+            <y>90</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2366,7 +2236,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2383,10 +2253,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
+            <width>451</width>
             <wuid>-74439178:16b93487e3a:-7c94</wuid>
             <x>486</x>
-            <y>351</y>
+            <y>125</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2406,7 +2276,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2423,10 +2293,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
+            <width>451</width>
             <wuid>-74439178:16b93487e3a:-7c83</wuid>
             <x>486</x>
-            <y>397</y>
+            <y>160</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2446,7 +2316,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2463,10 +2333,10 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
+            <width>451</width>
             <wuid>-74439178:16b93487e3a:-7c72</wuid>
             <x>486</x>
-            <y>445</y>
+            <y>195</y>
           </widget>
           <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
             <actions hook="false" hook_all="false" />
@@ -2486,7 +2356,7 @@
               <color red="192" green="192" blue="192" />
             </foreground_color>
             <group_name></group_name>
-            <height>40</height>
+            <height>25</height>
             <macros>
               <include_parent_macros>true</include_parent_macros>
             </macros>
@@ -2503,10 +2373,330 @@
             <tooltip></tooltip>
             <visible>false</visible>
             <widget_type>Linking Container</widget_type>
-            <width>400</width>
+            <width>451</width>
             <wuid>-74439178:16b93487e3a:-7c61</wuid>
             <x>486</x>
-            <y>492</y>
+            <y>230</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>25</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_23</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5d2a</wuid>
+            <x>486</x>
+            <y>265</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>25</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_24</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5d0e</wuid>
+            <x>486</x>
+            <y>300</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>25</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_25</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5cf7</wuid>
+            <x>486</x>
+            <y>335</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>25</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_26</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-5c91</wuid>
+            <x>486</x>
+            <y>370</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>25</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_27</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-41d5</wuid>
+            <x>486</x>
+            <y>405</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>25</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_28</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-41bb</wuid>
+            <x>486</x>
+            <y>440</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>25</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_29</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-41a4</wuid>
+            <x>486</x>
+            <y>475</y>
+          </widget>
+          <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+            <actions hook="false" hook_all="false" />
+            <background_color>
+              <color red="240" green="240" blue="240" />
+            </background_color>
+            <border_color>
+              <color red="0" green="128" blue="255" />
+            </border_color>
+            <border_style>0</border_style>
+            <border_width>1</border_width>
+            <enabled>true</enabled>
+            <font>
+              <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+            </font>
+            <foreground_color>
+              <color red="192" green="192" blue="192" />
+            </foreground_color>
+            <group_name></group_name>
+            <height>25</height>
+            <macros>
+              <include_parent_macros>true</include_parent_macros>
+            </macros>
+            <name>pos_30</name>
+            <opi_file>param_move.opi</opi_file>
+            <resize_behaviour>3</resize_behaviour>
+            <rules />
+            <scale_options>
+              <width_scalable>true</width_scalable>
+              <height_scalable>true</height_scalable>
+              <keep_wh_ratio>false</keep_wh_ratio>
+            </scale_options>
+            <scripts />
+            <tooltip></tooltip>
+            <visible>false</visible>
+            <widget_type>Linking Container</widget_type>
+            <width>451</width>
+            <wuid>-610e831b:171971644fa:-418d</wuid>
+            <x>486</x>
+            <y>510</y>
           </widget>
         </widget>
       </widget>
@@ -2528,7 +2718,7 @@
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
-        <height>548</height>
+        <height>551</height>
         <lock_children>false</lock_children>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -2546,7 +2736,7 @@
         <transparent>true</transparent>
         <visible>false</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>1043</width>
+        <width>965</width>
         <wuid>269791f0:16c4d21b35a:-7eef</wuid>
         <x>1</x>
         <y>1</y>
@@ -2585,7 +2775,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7da7</wuid>
           <x>6</x>
           <y>42</y>
@@ -2625,7 +2815,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7d85</wuid>
           <x>6</x>
           <y>76</y>
@@ -2665,7 +2855,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7bdf</wuid>
           <x>6</x>
           <y>110</y>
@@ -2705,7 +2895,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7bd0</wuid>
           <x>6</x>
           <y>144</y>
@@ -2871,7 +3061,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7a4f</wuid>
           <x>6</x>
           <y>178</y>
@@ -2911,7 +3101,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7a46</wuid>
           <x>6</x>
           <y>212</y>
@@ -2951,7 +3141,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7a3d</wuid>
           <x>6</x>
           <y>246</y>
@@ -2991,7 +3181,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7a34</wuid>
           <x>6</x>
           <y>280</y>
@@ -3031,7 +3221,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7a21</wuid>
           <x>6</x>
           <y>314</y>
@@ -3071,7 +3261,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7a18</wuid>
           <x>6</x>
           <y>348</y>
@@ -3111,7 +3301,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7a0f</wuid>
           <x>6</x>
           <y>382</y>
@@ -3151,7 +3341,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-7a06</wuid>
           <x>6</x>
           <y>416</y>
@@ -3191,7 +3381,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-79f3</wuid>
           <x>6</x>
           <y>450</y>
@@ -3231,7 +3421,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-73a6cc78:16c4d49c33b:-79ea</wuid>
           <x>6</x>
           <y>484</y>
@@ -3255,7 +3445,7 @@
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
-        <height>548</height>
+        <height>551</height>
         <lock_children>false</lock_children>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -3273,7 +3463,7 @@
         <transparent>true</transparent>
         <visible>false</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>1043</width>
+        <width>965</width>
         <wuid>1749b20a:16e12d5448a:-7b90</wuid>
         <x>1</x>
         <y>1</y>
@@ -4084,8 +4274,8 @@
           <widget_type>Linking Container</widget_type>
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-72f6</wuid>
-          <x>3</x>
-          <y>492</y>
+          <x>372</x>
+          <y>42</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4125,7 +4315,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6d19</wuid>
           <x>372</x>
-          <y>42</y>
+          <y>72</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4165,7 +4355,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6d08</wuid>
           <x>372</x>
-          <y>72</y>
+          <y>102</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4205,7 +4395,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6cf3</wuid>
           <x>372</x>
-          <y>102</y>
+          <y>132</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4245,7 +4435,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6ce2</wuid>
           <x>372</x>
-          <y>132</y>
+          <y>162</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4285,7 +4475,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6cd1</wuid>
           <x>372</x>
-          <y>162</y>
+          <y>192</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4325,7 +4515,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6cc0</wuid>
           <x>372</x>
-          <y>192</y>
+          <y>222</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4365,7 +4555,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6caf</wuid>
           <x>372</x>
-          <y>222</y>
+          <y>252</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4405,7 +4595,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6c9e</wuid>
           <x>372</x>
-          <y>252</y>
+          <y>282</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4445,7 +4635,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6c8d</wuid>
           <x>372</x>
-          <y>282</y>
+          <y>312</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4485,7 +4675,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6c7c</wuid>
           <x>372</x>
-          <y>312</y>
+          <y>342</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4525,7 +4715,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6c6b</wuid>
           <x>372</x>
-          <y>342</y>
+          <y>372</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4565,7 +4755,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6c5a</wuid>
           <x>372</x>
-          <y>372</y>
+          <y>402</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4605,7 +4795,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6c49</wuid>
           <x>372</x>
-          <y>402</y>
+          <y>432</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4645,87 +4835,7 @@
           <width>343</width>
           <wuid>1749b20a:16e12d5448a:-6c38</wuid>
           <x>372</x>
-          <y>432</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>31</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>align_31</name>
-          <opi_file>param_align.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>343</width>
-          <wuid>1749b20a:16e12d5448a:-6c27</wuid>
-          <x>372</x>
           <y>462</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <foreground_color>
-            <color red="192" green="192" blue="192" />
-          </foreground_color>
-          <group_name></group_name>
-          <height>31</height>
-          <macros>
-            <include_parent_macros>true</include_parent_macros>
-          </macros>
-          <name>align_32</name>
-          <opi_file>param_align.opi</opi_file>
-          <resize_behaviour>3</resize_behaviour>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <tooltip></tooltip>
-          <visible>false</visible>
-          <widget_type>Linking Container</widget_type>
-          <width>343</width>
-          <wuid>1749b20a:16e12d5448a:-6c16</wuid>
-          <x>372</x>
-          <y>492</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4868,13 +4978,12 @@
           <border_width>1</border_width>
           <enabled>true</enabled>
           <font>
-            <opifont.name fontName="Segoe UI" height="18" style="1" pixels="false">ISIS_Header1_NEW
-                      </opifont.name>
+            <opifont.name fontName="Segoe UI" height="14" style="1" pixels="false">ISIS_Header2_NEW</opifont.name>
           </font>
           <foreground_color>
             <color name="ISIS_Red" red="255" green="0" blue="0" />
           </foreground_color>
-          <height>32</height>
+          <height>25</height>
           <horizontal_alignment>1</horizontal_alignment>
           <name>Label</name>
           <rules>
@@ -4891,18 +5000,17 @@
             <keep_wh_ratio>false</keep_wh_ratio>
           </scale_options>
           <scripts />
-          <text>Positions can only be defined in manager Mode. Use the IBEX menu to enter manager mode.&#xD;
-                  </text>
+          <text>Positions can only be defined in manager Mode. Use the IBEX menu to enter manager mode.</text>
           <tooltip></tooltip>
           <transparent>true</transparent>
           <vertical_alignment>1</vertical_alignment>
           <visible>true</visible>
           <widget_type>Label</widget_type>
-          <width>679</width>
+          <width>950</width>
           <wrap_words>false</wrap_words>
           <wuid>-6796b6b8:16e83f3b706:-7474</wuid>
-          <x>36</x>
-          <y>522</y>
+          <x>3</x>
+          <y>504</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -4965,7 +5073,7 @@
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
-        <height>548</height>
+        <height>551</height>
         <lock_children>false</lock_children>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -4983,7 +5091,7 @@
         <transparent>true</transparent>
         <visible>false</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>1043</width>
+        <width>965</width>
         <wuid>-1a23f225:16f22c032ad:-7cb6</wuid>
         <x>1</x>
         <y>1</y>
@@ -5022,7 +5130,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7ca0</wuid>
           <x>6</x>
           <y>36</y>
@@ -5188,7 +5296,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7c1a</wuid>
           <x>6</x>
           <y>66</y>
@@ -5228,7 +5336,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7c0b</wuid>
           <x>6</x>
           <y>96</y>
@@ -5268,7 +5376,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7bfc</wuid>
           <x>6</x>
           <y>126</y>
@@ -5308,7 +5416,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7bed</wuid>
           <x>6</x>
           <y>156</y>
@@ -5348,7 +5456,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7bde</wuid>
           <x>6</x>
           <y>186</y>
@@ -5388,7 +5496,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7bb5</wuid>
           <x>6</x>
           <y>216</y>
@@ -5428,7 +5536,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7baa</wuid>
           <x>6</x>
           <y>246</y>
@@ -5468,7 +5576,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7b9f</wuid>
           <x>6</x>
           <y>276</y>
@@ -5508,7 +5616,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7b94</wuid>
           <x>6</x>
           <y>306</y>
@@ -5548,7 +5656,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7b89</wuid>
           <x>6</x>
           <y>336</y>
@@ -5588,7 +5696,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7b7e</wuid>
           <x>6</x>
           <y>366</y>
@@ -5628,7 +5736,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7b65</wuid>
           <x>6</x>
           <y>396</y>
@@ -5668,7 +5776,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7b5a</wuid>
           <x>6</x>
           <y>426</y>
@@ -5708,7 +5816,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7b4f</wuid>
           <x>6</x>
           <y>456</y>
@@ -5748,7 +5856,7 @@
           <tooltip></tooltip>
           <visible>true</visible>
           <widget_type>Linking Container</widget_type>
-          <width>1027</width>
+          <width>950</width>
           <wuid>-1a23f225:16f22c032ad:-7b44</wuid>
           <x>6</x>
           <y>486</y>
@@ -5772,7 +5880,7 @@
         <foreground_color>
           <color red="192" green="192" blue="192" />
         </foreground_color>
-        <height>548</height>
+        <height>551</height>
         <lock_children>false</lock_children>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -5790,7 +5898,7 @@
         <transparent>true</transparent>
         <visible>false</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>1043</width>
+        <width>965</width>
         <wuid>-4fa8d0d3:170e865f099:-7c70</wuid>
         <x>1</x>
         <y>1</y>
@@ -5840,7 +5948,7 @@ $(pv_value)</tooltip>
           <vertical_alignment>0</vertical_alignment>
           <visible>true</visible>
           <widget_type>Text Update</widget_type>
-          <width>1021</width>
+          <width>940</width>
           <wrap_words>true</wrap_words>
           <wuid>-4fa8d0d3:170e865f099:-7c4a</wuid>
           <x>12</x>
@@ -5925,7 +6033,7 @@ $(pv_value)</tooltip>
           <width>164</width>
           <wrap_words>true</wrap_words>
           <wuid>-4fa8d0d3:170e865f099:-7c48</wuid>
-          <x>869</x>
+          <x>788</x>
           <y>18</y>
         </widget>
       </widget>
@@ -6016,10 +6124,10 @@ $(pv_value)</tooltip>
           </tooltip>
       <visible>true</visible>
       <widget_type>Action Button</widget_type>
-      <width>1045</width>
+      <width>967</width>
       <wuid>-744b7940:165a9b5d31a:-7632</wuid>
       <x>0</x>
-      <y>612</y>
+      <y>610</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_inout.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_inout.opi
@@ -15,7 +15,7 @@
     <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
-  <height>33</height>
+  <height>24</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
     <PARAM_ROOT>$(PV_ROOT)</PARAM_ROOT>
@@ -30,7 +30,7 @@
   <show_ruler>true</show_ruler>
   <snap_to_geometry>true</snap_to_geometry>
   <widget_type>Display</widget_type>
-  <width>398</width>
+  <width>440</width>
   <wuid>450885f3:157944e4d4b:-797d</wuid>
   <x>0</x>
   <y>0</y>
@@ -92,7 +92,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>32</height>
+    <height>24</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -120,7 +120,7 @@
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>397</width>
+    <width>440</width>
     <wuid>37845bd:16e609d6b03:-7fb3</wuid>
     <x>0</x>
     <y>0</y>
@@ -148,7 +148,7 @@
       <foreground_color>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
-      <height>28</height>
+      <height>20</height>
       <image></image>
       <name>Button_1</name>
       <push_action_index>0</push_action_index>
@@ -168,9 +168,9 @@
 $(pv_value)</tooltip>
       <visible>true</visible>
       <widget_type>Action Button</widget_type>
-      <width>39</width>
+      <width>55</width>
       <wuid>21a0ac39:169e7b419e1:-7e25</wuid>
-      <x>351</x>
+      <x>380</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -191,7 +191,7 @@ $(pv_value)</tooltip>
       <foreground_color>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
-      <height>20</height>
+      <height>18</height>
       <horizontal_alignment>2</horizontal_alignment>
       <name>Label</name>
       <rules />
@@ -207,11 +207,11 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>127</width>
+      <width>130</width>
       <wrap_words>false</wrap_words>
       <wuid>-13168dce:16b323bd04e:-73cb</wuid>
-      <x>17</x>
-      <y>4</y>
+      <x>20</x>
+      <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -236,7 +236,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
       <format_type>0</format_type>
-      <height>20</height>
+      <height>18</height>
       <horizontal_alignment>0</horizontal_alignment>
       <name>Text Update</name>
       <precision>0</precision>
@@ -262,8 +262,8 @@ $(pv_value)</tooltip>
       <width>50</width>
       <wrap_words>false</wrap_words>
       <wuid>21a0ac39:169e7b419e1:-7e24</wuid>
-      <x>214</x>
-      <y>4</y>
+      <x>230</x>
+      <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -286,7 +286,7 @@ $(pv_value)</tooltip>
       <foreground_color>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
-      <height>28</height>
+      <height>20</height>
       <horizontal>true</horizontal>
       <items_from_pv>true</items_from_pv>
       <name>ChoiceBtn</name>
@@ -320,9 +320,9 @@ $(pv_value)</tooltip>
 $(pv_value)</tooltip>
       <visible>true</visible>
       <widget_type>Choice Button</widget_type>
-      <width>65</width>
+      <width>75</width>
       <wuid>-4a9cdc4b:169e3e25b89:-7e0b</wuid>
-      <x>271</x>
+      <x>295</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -348,7 +348,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
       <format_type>0</format_type>
-      <height>20</height>
+      <height>18</height>
       <horizontal_alignment>0</horizontal_alignment>
       <name>Text Update_1</name>
       <precision>0</precision>
@@ -383,8 +383,8 @@ $(pv_value)</tooltip>
       <width>50</width>
       <wrap_words>false</wrap_words>
       <wuid>21a0ac39:169e7b419e1:-7e22</wuid>
-      <x>156</x>
-      <y>4</y>
+      <x>170</x>
+      <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.symbol.bool.BoolMonitorWidget" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -419,7 +419,7 @@ $(pv_value)</tooltip>
       <foreground_color>
         <color red="0" green="202" blue="0" />
       </foreground_color>
-      <height>21</height>
+      <height>18</height>
       <image_file></image_file>
       <name>Boolean Symbol Monitor</name>
       <no_animation>false</no_animation>
@@ -460,7 +460,7 @@ $(pv_value)</tooltip>
       <width>18</width>
       <wuid>-13168dce:16b323bd04e:-7291</wuid>
       <x>0</x>
-      <y>3</y>
+      <y>0</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
@@ -15,7 +15,7 @@
     <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
-  <height>33</height>
+  <height>24</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
     <PARAM_ROOT>$(PV_ROOT)</PARAM_ROOT>
@@ -30,7 +30,7 @@
   <show_ruler>true</show_ruler>
   <snap_to_geometry>true</snap_to_geometry>
   <widget_type>Display</widget_type>
-  <width>398</width>
+  <width>440</width>
   <wuid>450885f3:157944e4d4b:-797d</wuid>
   <x>0</x>
   <y>0</y>
@@ -52,7 +52,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>32</height>
+    <height>24</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -80,7 +80,7 @@
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>397</width>
+    <width>440</width>
     <wuid>-16c8e940:165f1448c04:-7e27</wuid>
     <x>0</x>
     <y>0</y>
@@ -108,7 +108,7 @@
       <foreground_color>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
-      <height>28</height>
+      <height>20</height>
       <image></image>
       <name>Button_1</name>
       <push_action_index>0</push_action_index>
@@ -128,9 +128,9 @@
 $(pv_value)</tooltip>
       <visible>true</visible>
       <widget_type>Action Button</widget_type>
-      <width>39</width>
+      <width>55</width>
       <wuid>-744b7940:165a9b5d31a:-7a6a</wuid>
-      <x>351</x>
+      <x>380</x>
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -156,7 +156,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
       <format_type>0</format_type>
-      <height>20</height>
+      <height>18</height>
       <horizontal_alignment>0</horizontal_alignment>
       <name>Text Update</name>
       <precision>0</precision>
@@ -182,8 +182,8 @@ $(pv_value)</tooltip>
       <width>50</width>
       <wrap_words>false</wrap_words>
       <wuid>-e03d447:166346877c1:-7bdd</wuid>
-      <x>214</x>
-      <y>4</y>
+      <x>230</x>
+      <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
       <actions hook="false" hook_all="false" />
@@ -209,7 +209,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
       <format_type>0</format_type>
-      <height>20</height>
+      <height>18</height>
       <horizontal_alignment>0</horizontal_alignment>
       <limits_from_pv>false</limits_from_pv>
       <maximum>1.7976931348623157E308</maximum>
@@ -251,10 +251,10 @@ $(pv_value)</tooltip>
       <transparent>false</transparent>
       <visible>true</visible>
       <widget_type>Text Input</widget_type>
-      <width>60</width>
+      <width>75</width>
       <wuid>-e03d447:166346877c1:-7bdc</wuid>
-      <x>273</x>
-      <y>4</y>
+      <x>295</x>
+      <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -279,7 +279,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
       <format_type>0</format_type>
-      <height>20</height>
+      <height>18</height>
       <horizontal_alignment>0</horizontal_alignment>
       <name>Text Update_1</name>
       <precision>0</precision>
@@ -314,8 +314,8 @@ $(pv_value)</tooltip>
       <width>50</width>
       <wrap_words>false</wrap_words>
       <wuid>-5cc9c870:167650cec59:-7fdd</wuid>
-      <x>156</x>
-      <y>4</y>
+      <x>170</x>
+      <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -335,7 +335,7 @@ $(pv_value)</tooltip>
       <foreground_color>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
-      <height>20</height>
+      <height>18</height>
       <horizontal_alignment>2</horizontal_alignment>
       <name>Label</name>
       <rules />
@@ -351,11 +351,11 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>127</width>
+      <width>130</width>
       <wrap_words>false</wrap_words>
       <wuid>-744b7940:165a9b5d31a:-67c9</wuid>
-      <x>17</x>
-      <y>4</y>
+      <x>20</x>
+      <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.symbol.bool.BoolMonitorWidget" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -390,7 +390,7 @@ $(pv_value)</tooltip>
       <foreground_color>
         <color name="ISIS_Trace_2" red="33" green="179" blue="33" />
       </foreground_color>
-      <height>21</height>
+      <height>18</height>
       <image_file></image_file>
       <name>Boolean Symbol Monitor</name>
       <no_animation>false</no_animation>
@@ -431,7 +431,7 @@ $(pv_value)</tooltip>
       <width>18</width>
       <wuid>-13168dce:16b323bd04e:-727f</wuid>
       <x>0</x>
-      <y>3</y>
+      <y>0</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
@@ -54,9 +54,9 @@ def sort_out_list(pv, widget_name_prefix, macro_prefix, has_type, max):
         else:
             widget.setPropertyValue("visible", False)
 
-sort_out_list(pvs[2], "align_", "PARAM", True, 32)
+sort_out_list(pvs[2], "align_", "PARAM", True, 30)
 sort_out_list(pvs[1], "Correction_", "COR", False, 14)            
-sort_out_list(pvs[0], "pos_", "PARAM", True, 22)
+sort_out_list(pvs[0], "pos_", "PARAM", True, 30)
 sort_out_list(pvs[3], "Value_", "VALUE", True, 16)
 
 

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/set_point_column_labels.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/set_point_column_labels.opi
@@ -1,6 +1,6 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
-  <actions hook="false" hook_all="false"/>
+  <actions hook="false" hook_all="false" />
   <auto_scale_widgets>
     <auto_scale_widgets>false</auto_scale_widgets>
     <min_width>-1</min_width>
@@ -8,20 +8,20 @@
   </auto_scale_widgets>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
-    <color red="240" green="240" blue="240"/>
+    <color red="240" green="240" blue="240" />
   </background_color>
   <boy_version>5.1.0.201707071649</boy_version>
   <foreground_color>
-    <color red="192" green="192" blue="192"/>
+    <color red="192" green="192" blue="192" />
   </foreground_color>
   <grid_space>6</grid_space>
   <height>600</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <name/>
-  <rules/>
-  <scripts/>
+  <name></name>
+  <rules />
+  <scripts />
   <show_close_button>true</show_close_button>
   <show_edit_range>true</show_edit_range>
   <show_grid>true</show_grid>
@@ -33,12 +33,12 @@
   <x>-1</x>
   <y>-1</y>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </background_color>
     <border_color>
-      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255"/>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -48,38 +48,38 @@
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>19</height>
+    <height>16</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <name>Grouping Container_2</name>
-    <rules/>
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <show_scrollbar>true</show_scrollbar>
-    <tooltip/>
+    <tooltip></tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>181</width>
+    <width>200</width>
     <wuid>-166f7f1c:16bdb17a9a5:-74cb</wuid>
     <x>0</x>
     <y>0</y>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
+      <actions hook="false" hook_all="false" />
       <auto_size>false</auto_size>
       <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255"/>
+        <color red="0" green="128" blue="255" />
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -88,18 +88,18 @@
         <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
       </font>
       <foreground_color>
-        <color name="ISIS_Standard_Button" red="187" green="187" blue="187"/>
+        <color name="ISIS_Standard_Button" red="187" green="187" blue="187" />
       </foreground_color>
-      <height>19</height>
+      <height>15</height>
       <horizontal_alignment>1</horizontal_alignment>
       <name>Label Record Value</name>
-      <rules/>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts/>
+      <scripts />
       <text>RBV</text>
       <tooltip>Current value on device.</tooltip>
       <transparent>true</transparent>
@@ -113,13 +113,13 @@
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
+      <actions hook="false" hook_all="false" />
       <auto_size>false</auto_size>
       <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255"/>
+        <color red="0" green="128" blue="255" />
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -128,18 +128,18 @@
         <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
       </font>
       <foreground_color>
-        <color name="ISIS_Standard_Button" red="187" green="187" blue="187"/>
+        <color name="ISIS_Standard_Button" red="187" green="187" blue="187" />
       </foreground_color>
-      <height>19</height>
+      <height>15</height>
       <horizontal_alignment>1</horizontal_alignment>
       <name>Label Record Value_1</name>
-      <rules/>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts/>
+      <scripts />
       <text>SP:RBV</text>
       <tooltip>Last set point value sent to device.</tooltip>
       <transparent>true</transparent>
@@ -153,13 +153,13 @@
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false"/>
+      <actions hook="false" hook_all="false" />
       <auto_size>false</auto_size>
       <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255"/>
+        <color red="0" green="128" blue="255" />
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -168,18 +168,18 @@
         <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
       </font>
       <foreground_color>
-        <color name="ISIS_Standard_Button" red="187" green="187" blue="187"/>
+        <color name="ISIS_Standard_Button" red="187" green="187" blue="187" />
       </foreground_color>
-      <height>19</height>
+      <height>15</height>
       <horizontal_alignment>1</horizontal_alignment>
       <name>Label Record Value</name>
-      <rules/>
+      <rules />
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts/>
+      <scripts />
       <text>SP</text>
       <tooltip>Set point value that will be sent on next move.</tooltip>
       <transparent>true</transparent>
@@ -189,15 +189,15 @@
       <width>49</width>
       <wrap_words>false</wrap_words>
       <wuid>-166f7f1c:16bdb17a9a5:-74c8</wuid>
-      <x>130</x>
+      <x>138</x>
       <y>0</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-    <actions hook="false" hook_all="false"/>
+    <actions hook="false" hook_all="false" />
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+      <color name="ISIS_Border" red="0" green="0" blue="0" />
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -207,25 +207,25 @@
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
     </foreground_color>
     <height>1</height>
-    <image/>
+    <image></image>
     <name>Dummy</name>
     <push_action_index>0</push_action_index>
-    <pv_name/>
-    <pv_value/>
-    <rules/>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts />
     <style>1</style>
-    <text/>
+    <text></text>
     <toggle_button>false</toggle_button>
-    <tooltip/>
+    <tooltip></tooltip>
     <visible>true</visible>
     <widget_type>Action Button</widget_type>
     <width>1</width>


### PR DESCRIPTION
### Description of work

Changed Reflectometry front panel OPI so that:

> - Slit gaps and sample stack parameters are displayed on the reflectometry front panel OPI using the param_move.opi (same as all other parameters)
> - The layout is adjusted to reasonably fit everything
> - ~The "important parameters" panel is populated dynamically based on a tag given to reflectometry parameters at the config level~
> - The "important parameters" panel is now a linking container that can be swapped out in the future depending on the current instrument (same as slits and sample stack)

plus

- Compressed controls for individual parameters so that we can fit more of them in the available space on other instruments (e.g. POLREF: 5 slits, 6 sample stack axes)
-Increased number of parameters that can be displayed on the "All Parameters" panel from 22 to 30 (we were hitting the limit on SURF)

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4967

### Acceptance criteria

- Layout is clear and every relevant control is shown.

### Unit tests

None (OPI only)

### System tests

None (OPI only)

### Documentation

None

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

