### PR TITLE
Fix refl OPI script

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/setPositionMacros.py
@@ -36,7 +36,7 @@ def _add_macros(widget, name, value):
 
 def sort_out_list(pv, widget_name_prefix, macro_prefix, has_type, max):
     value = PVUtil.getStringArray(pv)
-    value = "".join(chr(int(i)) for i in value[:-1])
+    value = "".join(chr(int(i)) for i in value)
     value = zlib.decompress(value.decode("hex"))
     params = json.loads(value)
 


### PR DESCRIPTION
### Description of work

Needed to modify the script to make it work with reflectometry IOC in python 3. I'm guessing that the compressed/hexed message used to include some terminator and now it does not.

Related PR: https://github.com/ISISComputingGroup/EPICS-inst_servers/pull/293

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4884

### Acceptance criteria

- [ ] Reflectometry front panel displays correctly when using the py3 reflectometry server.

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

