### PR TITLE
Sorting action now defaults to none

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
@@ -75,7 +75,7 @@ public abstract class DataboundTable<TRow> extends Composite {
     private ObservableListContentProvider<TRow> contentProvider = new ObservableListContentProvider<TRow>();
 
     /*A listener for whenever the contents of the table are sorted.*/
-    private Optional<Runnable> sortAction;
+    private Optional<Runnable> sortAction = Optional.empty();
 
     /**
      * Instantiates a new databound table.


### PR DESCRIPTION
### Description of work

Fixes issue where table sorting was broken

To test:
* Start your instrument
* Start the GUI on the latest master
* Go to IOC -> Start/stop IOCs
* Click on one of the headings of the table
* The table should sort 

### System tests

See https://github.com/ISISComputingGroup/System_Tests_UI_E4/pull/49

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

