### PR TITLE
Remove dummy call to load_script

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
@@ -18,7 +18,7 @@ from check_OPI_format_utils.xy_graph import get_traces_with_different_buffer_siz
 from check_opi_format_tests import TestCheckOpiFormatMethods
 
 # Directory to iterate through
-DEFAULT_ROOT_DIR = r"./resources/"
+DEFAULT_ROOT_DIR = r"."
 
 # Specify a logs directory
 DEFAULT_LOGS_DIR = r"./check_OPI_format_logs/"

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Commands.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Commands.java
@@ -43,8 +43,7 @@ public final class Commands {
 	public static final String GENIE_INITIALISATION_CMDS = 
 			"import matplotlib \n"
 			+ "matplotlib.use('module://genie_python.matplotlib_backend.ibex_web_backend') \n"
-			+ "from genie_python.genie_startup import * \n" 
-			+ "load_script(None, globals()) \n";
+			+ "from genie_python.genie_startup import * \n";
 	
 	
     private Commands() {


### PR DESCRIPTION
### Description of work

Removed call to load_script that did nothing

To test:
* Start the scripting perspective and confirm you can still call genie python commands through`g.begin()` and also through `begin()`

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

