### PR TITLE
Fix script definition path issues

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ScriptGeneratorJsonFileHandlerTest.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ScriptGeneratorJsonFileHandlerTest.java
@@ -1,6 +1,8 @@
 package uk.ac.stfc.isis.ibex.scriptgenerator.tests;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -27,15 +29,15 @@ public class ScriptGeneratorJsonFileHandlerTest {
 	String dateAndTime = "20/03/2010 00:00";
 	PreferenceSupplier prefSupplier = mock(PreferenceSupplier.class);
 	public ScriptGeneratorJsonFileHandler fileHandler = new ScriptGeneratorJsonFileHandler();
-	String scriptDefName = "scriptDefTest.py";
-	String JsonFileName =  "jsonFileTest.json";
+	Path scriptDefName = Path.of("scriptDefTest.py");
+	Path JsonFileName =  Path.of("jsonFileTest.json");
 	final String scriptDefContent = "from genie_python.genie_script_generator import ScriptDefinition";
 	
 	final String actualJsonContent = String.format("{\r\n" + 
 			"  \"version_JSON_format\": \"1\",\r\n" + 
 			"  \"script_generator_version\": \"\",\r\n" + 
 			"  \"date_and_time\": \"%s\",\r\n" + 
-			"  \"script_definition_file_path\": \"C:/ScriptDefinitions/imat.py\",\r\n" + 
+			"  \"script_definition_file_path\": \"C:\\\\ScriptDefinitions\\\\imat.py\",\r\n" + 
 			"  \"script_definition_file_git_hash\": \"\",\r\n" + 
 			"  \"genie_python_version\": \"%s\",\r\n" + 
 			"  \"script_definition_content\": \"%s\",\r\n" + 
@@ -85,10 +87,12 @@ public class ScriptGeneratorJsonFileHandlerTest {
 	
 		try {
 			String scriptDeftwo = "this is script definition";
+			Path jsonFile = Path.of("jsonfile");
+			Path pythonFile = Path.of("pythonFile");
 			ScriptGeneratorJsonFileHandler fileHandlerSpy = Mockito.spy(fileHandler);
-			Mockito.doReturn(actualJsonContent).when(fileHandlerSpy).readFileContent("jsonFile");
-			Mockito.doReturn(scriptDeftwo).when(fileHandlerSpy).readFileContent("pythonFile");
-			fileHandlerSpy.getParameterValues("jsonFile", "pythonFile", new ArrayList<JavaActionParameter>());
+			Mockito.doReturn(actualJsonContent).when(fileHandlerSpy).readFileContent(jsonFile);
+			Mockito.doReturn(scriptDeftwo).when(fileHandlerSpy).readFileContent(pythonFile);
+			fileHandlerSpy.getParameterValues(jsonFile, pythonFile, new ArrayList<JavaActionParameter>());
 		} catch (UnsupportedOperationException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -148,7 +152,7 @@ public class ScriptGeneratorJsonFileHandlerTest {
 		List<ScriptGeneratorAction> actions = new ArrayList<ScriptGeneratorAction>();
 		actions.add(new ScriptGeneratorAction(actionOne));
 	
-		String actual = fileHandlerTemp.createJsonString(actions, scriptDefContent, "C:/ScriptDefinitions/imat.py");
+		String actual = fileHandlerTemp.createJsonString(actions, scriptDefContent, Paths.get("C:/ScriptDefinitions/imat.py"));
 		// remove carriage return and test
 		assertEquals(actualJsonContent.replace("\r", ""), actual);
 	}

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorJsonFileHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorJsonFileHandler.java
@@ -5,7 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -49,7 +49,7 @@ public class ScriptGeneratorJsonFileHandler {
 	 * @param scriptDefPath path of script definition used to create data file
 	 * @param absoluteFilePath absolute file path to save data file
 	 */
-	public void saveParameters(List<ScriptGeneratorAction> scriptGenContent, String scriptDefPath, String absoluteFilePath) throws InterruptedException, ExecutionException {
+	public void saveParameters(List<ScriptGeneratorAction> scriptGenContent, Path scriptDefPath, String absoluteFilePath) throws InterruptedException, ExecutionException {
 		try {
 			
 			String content = createJsonString(scriptGenContent, readFileContent(scriptDefPath), scriptDefPath);
@@ -68,7 +68,7 @@ public class ScriptGeneratorJsonFileHandler {
 	 * @return JSON string 
 	 * @throws IOException
 	 */
-	public String createJsonString(List<ScriptGeneratorAction> scriptGenContent, String scriptDefContent, String scriptDefPath) {
+	public String createJsonString(List<ScriptGeneratorAction> scriptGenContent, String scriptDefContent, Path scriptDefPath) {
 		
 		List<ScriptGeneratorActionConverter> actions = new ArrayList<ScriptGeneratorActionConverter>();
 		actions.add(new ScriptGeneratorActionConverter("default", convertScriptGenContent(scriptGenContent)));
@@ -85,7 +85,7 @@ public class ScriptGeneratorJsonFileHandler {
 	 * @return mapped values and parameter
 	 * @throws ScriptDefinitionNotMatched script definition used to load and save the data file does not match
 	 */
-	public List<Map<JavaActionParameter, String>> getParameterValues(String filePath, String scriptDefinitionPath, List<JavaActionParameter> currentActionsParams) throws ScriptDefinitionNotMatched,
+	public List<Map<JavaActionParameter, String>> getParameterValues(Path filePath, Path scriptDefinitionPath, List<JavaActionParameter> currentActionsParams) throws ScriptDefinitionNotMatched,
 	UnsupportedOperationException {
 		List<Map<JavaActionParameter, String>> newMappedParameterToValues = Collections.emptyList();
 		try {
@@ -174,8 +174,8 @@ public class ScriptGeneratorJsonFileHandler {
 	 * @param filePath file path
 	 * @return string of JSON content
 	 */
-	 public String readFileContent(String filePath) throws IOException {
-		String content = new String(Files.readAllBytes(Paths.get(filePath)));
+	 public String readFileContent(Path filePath) throws IOException {
+		String content = new String(Files.readAllBytes(filePath));
 		return content;
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -602,7 +602,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 						"Tried to generate a script with no script definition selected to generate it with"));
 		try {
 			if (areParamsValid()) {
-				String filePath = getScriptDefinitionPath(scriptDefinition).toString();
+				Path filePath = getScriptDefinitionPath(scriptDefinition);
 				String jsonContent = scriptGenFileHandler.createJsonString(scriptGeneratorTable.getActions(), scriptGenFileHandler.readFileContent(filePath), filePath);
 				generator.refreshGeneratedScript(scriptGeneratorTable, scriptDefinition, jsonContent);
 			} else {
@@ -644,10 +644,10 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	 * @throws NoScriptDefinitionSelectedException when script definition has not been selected
 	 * @throws ScriptDefinitionNotMatched when the script definition used to generate data file does not match with the one used to load it
 	 */
-	public void loadParameterValues(String fileName) throws NoScriptDefinitionSelectedException, ScriptDefinitionNotMatched, UnsupportedOperationException {
+	public void loadParameterValues(Path fileName) throws NoScriptDefinitionSelectedException, ScriptDefinitionNotMatched, UnsupportedOperationException {
 		ScriptDefinitionWrapper scriptDefinition = getScriptDefinition()
 				.orElseThrow(() -> new NoScriptDefinitionSelectedException("No Configuration Selected"));
-		List<Map<JavaActionParameter, String>> list = scriptGenFileHandler.getParameterValues(fileName, getScriptDefinitionPath(scriptDefinition).toString(), getActionParameters());
+		List<Map<JavaActionParameter, String>> list = scriptGenFileHandler.getParameterValues(fileName, getScriptDefinitionPath(scriptDefinition), getActionParameters());
 		scriptGeneratorTable.addMultipleActions(list);
 	}
 	
@@ -663,11 +663,11 @@ public class ScriptGeneratorSingleton extends ModelObject {
 				.orElseThrow(() -> new NoScriptDefinitionSelectedException("No Configuration Selected"));
 		
 		try {
-			if (!filePath.contains(JSON_EXT)) {
+			if (!filePath.endsWith(JSON_EXT)) {
 				//Strip out other any pre-existing file extension and add JSON extension
 				filePath = filePath.substring(0, filePath.lastIndexOf('.')) + JSON_EXT;
 			}
-			scriptGenFileHandler.saveParameters(this.scriptGeneratorTable.getActions(), getScriptDefinitionPath(scriptDefinition).toString(), filePath);
+			scriptGenFileHandler.saveParameters(scriptGeneratorTable.getActions(), getScriptDefinitionPath(scriptDefinition), filePath);
 		} catch (InterruptedException | ExecutionException e) {
 			firePropertyChange(THREAD_ERROR_PROPERTY, threadError, true);
 			LOG.error(e);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -21,6 +21,8 @@ package uk.ac.stfc.isis.ibex.scriptgenerator;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -202,8 +204,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	 * The constructor, will create without a script definition loader and without loading
 	 * an initial script definition.
 	 */
-	public ScriptGeneratorSingleton() {
-	    
+	public ScriptGeneratorSingleton() {   
 	}
 
 	/**
@@ -223,6 +224,10 @@ public class ScriptGeneratorSingleton extends ModelObject {
 		setUp();
 	}
 
+	private Path getScriptDefinitionPath(ScriptDefinitionWrapper scriptDefinition) {
+		return Paths.get(preferenceSupplier.scriptGeneratorScriptDefinitionFolders(), scriptDefinition.getName() + PYTHON_EXT);
+	}
+	
 	/**
 	 * Called by the constructor with three arguments during tests or in the View
 	 * Model constructor to set up the class. Set up listeners for the generator.
@@ -597,8 +602,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 						"Tried to generate a script with no script definition selected to generate it with"));
 		try {
 			if (areParamsValid()) {
-				String filePath =  preferenceSupplier.scriptGeneratorScriptDefinitionFolders()
-						+ scriptDefinition.getName() + PYTHON_EXT;
+				String filePath = getScriptDefinitionPath(scriptDefinition).toString();
 				String jsonContent = scriptGenFileHandler.createJsonString(scriptGeneratorTable.getActions(), scriptGenFileHandler.readFileContent(filePath), filePath);
 				generator.refreshGeneratedScript(scriptGeneratorTable, scriptDefinition, jsonContent);
 			} else {
@@ -643,8 +647,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	public void loadParameterValues(String fileName) throws NoScriptDefinitionSelectedException, ScriptDefinitionNotMatched, UnsupportedOperationException {
 		ScriptDefinitionWrapper scriptDefinition = getScriptDefinition()
 				.orElseThrow(() -> new NoScriptDefinitionSelectedException("No Configuration Selected"));
-		String currentDefinitionPath = preferenceSupplier.scriptGeneratorScriptDefinitionFolders() + scriptDefinition.getName() + PYTHON_EXT;
-		List<Map<JavaActionParameter, String>> list = scriptGenFileHandler.getParameterValues(fileName, currentDefinitionPath, getActionParameters());
+		List<Map<JavaActionParameter, String>> list = scriptGenFileHandler.getParameterValues(fileName, getScriptDefinitionPath(scriptDefinition).toString(), getActionParameters());
 		scriptGeneratorTable.addMultipleActions(list);
 	}
 	
@@ -664,8 +667,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 				//Strip out other any pre-existing file extension and add JSON extension
 				filePath = filePath.substring(0, filePath.lastIndexOf('.')) + JSON_EXT;
 			}
-			scriptGenFileHandler.saveParameters(this.scriptGeneratorTable.getActions(), 
-					preferenceSupplier.scriptGeneratorScriptDefinitionFolders() + scriptDefinition.getName() + PYTHON_EXT, filePath);
+			scriptGenFileHandler.saveParameters(this.scriptGeneratorTable.getActions(), getScriptDefinitionPath(scriptDefinition).toString(), filePath);
 		} catch (InterruptedException | ExecutionException e) {
 			firePropertyChange(THREAD_ERROR_PROPERTY, threadError, true);
 			LOG.error(e);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/ParametersConverter.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/ParametersConverter.java
@@ -1,5 +1,6 @@
 package uk.ac.stfc.isis.ibex.scriptgenerator.generation;
 
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -78,14 +79,14 @@ public class ParametersConverter {
 	 * @param geniePythonVersion Current version of genie python
 	 */
 	public ParametersConverter(String version, List<ScriptGeneratorActionConverter> actions, String content,
-			String scriptGeneratorVersion, String dateAndTime, String scriptDefinitionFilePath,
+			String scriptGeneratorVersion, String dateAndTime, Path scriptDefinitionFilePath,
 			String scriptDefinitionFileGitHash, String geniePythonVersion) {
 		this.versionJSONFormat = version;
 		this.actions = actions;
 		this.scriptDefinitionContent = content;
 		this.scriptGeneratorVersion = scriptGeneratorVersion;
 		this.dateAndTime = dateAndTime;
-		this.scriptDefinitionFilePath = scriptDefinitionFilePath;
+		this.scriptDefinitionFilePath = scriptDefinitionFilePath.toString();
 		this.scriptDefinitionFileGitHash = scriptDefinitionFileGitHash;
 		this.geniePythonVersion = geniePythonVersion;
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -1,6 +1,7 @@
 package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
 
 import java.net.URL;
+import java.nio.file.Paths;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.List;
@@ -800,7 +801,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
 		// filename will be null if user has clicked cancel button
 		if (selectedFile.isPresent()) {
 			try {
-				scriptGeneratorModel.loadParameterValues(selectedFile.get());
+				scriptGeneratorModel.loadParameterValues(Paths.get(selectedFile.get()));
 			} catch (NoScriptDefinitionSelectedException e) {
 				LOG.error(e);
 				MessageDialog.openWarning(DISPLAY.getActiveShell(), "No script definition selection", 


### PR DESCRIPTION
### Description of work

Fixed issue where if the script definition path was specified badly then a script could not be generated.

### To Test

* Rename `C:\ScriptDefinitions` to something else e.g. `C:\Not_ScriptDefinitions`
* Modify `uk.ac.stfc.isis.ibex.preferences/script_definitions_folder` in `plugin_customization.ini` to point to `C:\Not_ScriptDefinitions` (note no trailing slash)
* On master try and generate a script and confirm that the generate script button does nothing
* On this branch confirm that you can generate the script

### Unit tests

Unit tests updated, confirm they still run

### System tests

Was caught by squish tests, should hopefully fix them

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

