### PR TITLE
Set Different directory for script generator release build via jenkins

### DIFF
--- a/build/jenkins_build_script_generator.bat
+++ b/build/jenkins_build_script_generator.bat
@@ -38,7 +38,7 @@ set TARGET_DIR=built_script_gen
 
 REM Don't group these. Bat expands whole if at once, not sequentially
 if "%RELEASE%" == "YES" (
-    set RELEASE_DIR=p:\Kits$\CompGroup\ICP\Releases\%GIT_BRANCH:~8%
+    set RELEASE_DIR=p:\Kits$\CompGroup\ICP\Releases\script_generator_release\%GIT_BRANCH:~8%
     set RELEASE_VERSION=%GIT_BRANCH:~8%    
 ) else (
     set RELEASE_VERSION=devel-%GIT_COMMIT:~0,7%


### PR DESCRIPTION
### Description of work

Added multibranch pipeline in Jenkins to build script generator release version.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5418

### Acceptance criteria

- The build process assigns an identifiable release number to the stand-alone Script Generator.
- The build process copies the stand-alone Script Generator to the appropriate release folder.
- New Jenkins pipeline for script generator release build is available as `scriptgenerator_release` in  http://epics-jenkins.isis.rl.ac.uk/

### Note:
The release folder is located in the share inside `script_generator_release`

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [x] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

