### PR TITLE
Fixed tabbing for estimate column

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
@@ -51,6 +51,7 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
     
 	private final ScriptGeneratorViewModel scriptGeneratorViewModel;
 	private boolean shiftCellFocusToNewlyAddedRow = false;
+	private static final  Integer NON_EDITABLE_COLUMNS = 2;
 	
 	/**
      * Default constructor for the table. Creates all the correct columns.
@@ -104,7 +105,7 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
 					
 					// Add new action if tab is pressed by user in the last cell of the table.
 					if (nextCell.getNeighbor(ViewerCell.BELOW, false) == null 
-					        && (viewer.getTable().getColumnCount() - 1 == currentlyFocusedColumn)) {
+					        && (viewer.getTable().getColumnCount() - NON_EDITABLE_COLUMNS == currentlyFocusedColumn)) {
 					    
                     	scriptGeneratorViewModel.addEmptyAction();
                     	shiftCellFocusToNewlyAddedRow = true;


### PR DESCRIPTION
### Description of work

Fixed tabbing on the script generator so that a new row is created when tabbing from the last editable column.

To test:
* Add an action to the script generator
* Click on a field to make it editable
* Continually tab across and confirm a new action is created when you get to the end of the row

### System tests

See https://github.com/ISISComputingGroup/System_Tests_UI_E4/pull/57

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

