### PR TITLE
Ticket5463 bundling genie python

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
+++ b/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IPreferencesService;
@@ -82,7 +84,7 @@ public class PreferenceSupplier {
     /**
      * The path to the developer's genie python.
      */
-	private static final String DEFAULT_PYTHON_3_INTERPRETER_PATH = "C:\\Instrument\\Apps\\Python3\\python.exe";
+	private static final String DEFAULT_PYTHON_3_INTERPRETER_PATH = "C:\\Instrument\\Apps\\Python3\\pytshon.exe";
 	
 	/**
      * The default for the location of Python.
@@ -96,16 +98,20 @@ public class PreferenceSupplier {
 	 * @return The string path to the python executable.
 	 * @throws IOException if python could not be found.
 	 */
-	public static String getBundledPythonPath() {
-		try {
-			String pythonPath = relativePathToFull(PYTHON_RELATIVE_PATH);
+	public static String getPythonPath() {
+		String pythonPath = Path.forWindows(DEFAULT_PYTHON_3_INTERPRETER_PATH).toOSString();
+		if (Files.exists(Paths.get(pythonPath))) {
 			LOG.info("getDefaultPythonPath found python at: " + pythonPath);
-			return relativePathToFull(PYTHON_RELATIVE_PATH);
-		} catch (IOException e) {
-			String pythonPath = Path.forWindows(DEFAULT_PYTHON_3_INTERPRETER_PATH).toOSString();
-			LOG.info("getDefaultPythonPath found python at: " + pythonPath);
-			return pythonPath;
+		} else {
+			try {
+				pythonPath = relativePathToFull(PYTHON_RELATIVE_PATH);
+				LOG.info("getDefaultPythonPath found python at: " + pythonPath);
+			} catch (IOException e) {
+				LOG.error("Bundled Python not found");
+			}
+			
 		}
+		return pythonPath;
 	}
 
 	

--- a/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
+++ b/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
@@ -84,7 +84,7 @@ public class PreferenceSupplier {
     /**
      * The path to the developer's genie python.
      */
-	private static final String DEFAULT_PYTHON_3_INTERPRETER_PATH = "C:\\Instrument\\Apps\\Python3\\pytshon.exe";
+	private static final String DEFAULT_PYTHON_3_INTERPRETER_PATH = "C:\\Instrument\\Apps\\Python3\\python.exe";
 	
 	/**
      * The default for the location of Python.

--- a/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
+++ b/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
@@ -77,23 +77,19 @@ public class PreferenceSupplier {
     private static final String PYTHON_INTERPRETER_PATH = "python_interpreter_path";
     
     /**
-     * The relative path to python.
+     * The relative path to the bundled Python.
      */
     private static final String PYTHON_RELATIVE_PATH = "/resources/Python3/python.exe";
     
     /**
-     * The path to the developer's genie python.
+     * The path to the instrument/developer's genie python.
      */
 	private static final String DEFAULT_PYTHON_3_INTERPRETER_PATH = "C:\\Instrument\\Apps\\Python3\\python.exe";
-	
-	/**
-     * The default for the location of Python.
-     */
-    private static final String DEFAULT_PYTHON_2_INTERPRETER_PATH = "C:\\Instrument\\Apps\\Python\\python.exe";
+
 
 	
 	/**
-	 * Gets the python that's been bundled with the gui, unless it hasn't been bundled and then gets the dev python.
+	 * Gets the installed Python, unless it hasn't been bundled and then gets the Python bundled with the gui.
 	 * 
 	 * @return The string path to the python executable.
 	 * @throws IOException if python could not be found.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
@@ -184,7 +184,7 @@ public class PythonInterface extends ModelObject {
 	 * @return The path to the bundled python 3 interpreter.
 	 */
 	private String python3InterpreterPath() {
-		return PreferenceSupplier.getBundledPythonPath();
+		return PreferenceSupplier.getPythonPath();
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/GeniePythonConsoleFactory.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/GeniePythonConsoleFactory.java
@@ -152,7 +152,7 @@ public class GeniePythonConsoleFactory extends PydevConsoleFactory {
 	 */
 	PydevConsoleInterpreter createGeniePydevInterpreter() throws Exception {
 		IInterpreterManager manager = InterpreterManagersAPI.getPythonInterpreterManager();
-		IInterpreterInfo interpreterInfo = manager.createInterpreterInfo(new PreferenceSupplier().pythonInterpreterPath(),
+		IInterpreterInfo interpreterInfo = manager.createInterpreterInfo(PreferenceSupplier.getPythonPath(),
 				monitor, false);
 
 		PydevIProcessFactory iprocessFactory = new PydevIProcessFactory();

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PyDevConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PyDevConfiguration.java
@@ -42,7 +42,7 @@ public final class PyDevConfiguration {
 	public static void configure() {
 		IInterpreterManager iMan = InterpreterManagersAPI.getPythonInterpreterManager(true);
 		NullProgressMonitor monitor = new NullProgressMonitor();
-		IInterpreterInfo interpreterInfo = iMan.createInterpreterInfo(new PreferenceSupplier().pythonInterpreterPath(),
+		IInterpreterInfo interpreterInfo = iMan.createInterpreterInfo(PreferenceSupplier.getPythonPath(),
 				monitor, false);
 		iMan.setInfos(new IInterpreterInfo[] {interpreterInfo}, Collections.<String>emptySet(), monitor);
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PythonInterpreterProviderFactory.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PythonInterpreterProviderFactory.java
@@ -31,6 +31,6 @@ public class PythonInterpreterProviderFactory extends AbstractInterpreterProvide
 	
 	@Override
 	public IInterpreterProvider[] getInterpreterProviders(InterpreterType type) {
-		return AlreadyInstalledInterpreterProvider.create(INTERPRETER_PROVIDER_ID, new PreferenceSupplier().pythonInterpreterPath());
+		return AlreadyInstalledInterpreterProvider.create(INTERPRETER_PROVIDER_ID, PreferenceSupplier.getPythonPath());
 	}
 }


### PR DESCRIPTION
### Description of work

Scripting console and Script generator to use system install of genie python and if not available, revert to using bundled python.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5463

### Acceptance criteria

- [ ] The script generator should prefer to use the normal install of genier_python and only look for the bundled version if there isn't a normal one. (This means if a user installs a module into genie_python it will be available in the script generator)
- [ ] Anywhere else in the GUI using python (mostly the scripting console window) should also do the same. Meaning that if the `normal` genie_python isn't found it will look at the bundled version

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

