### PR TITLE
Ticket 4569: Disable advanced view when not in manager mode

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/waveguide_aperture/waveguide_aperture.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/waveguide_aperture/waveguide_aperture.opi
@@ -55,7 +55,14 @@
     </macros>
     <minimum_tab_height>10</minimum_tab_height>
     <name>Tabbed Container</name>
-    <rules />
+    <rules>
+      <rule name="EnableOnManagerMode" prop_id="tab_1_enabled" out_exp="true">
+        <exp bool_exp="true">
+          <value>pv0 == 1</value>
+        </exp>
+        <pv trig="true">$(P)CS:MANAGER</pv>
+      </rule>
+    </rules>
     <scale_options>
       <width_scalable>false</width_scalable>
       <height_scalable>false</height_scalable>
@@ -77,7 +84,7 @@
     <tab_1_background_color>
       <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
     </tab_1_background_color>
-    <tab_1_enabled>true</tab_1_enabled>
+    <tab_1_enabled>false</tab_1_enabled>
     <tab_1_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_1_font>
@@ -670,7 +677,7 @@ $(pv_value)</tooltip>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
-      <enabled>true</enabled>
+      <enabled>false</enabled>
       <fc>false</fc>
       <font>
         <opifont.name fontName="Arial" height="9" style="0" pixels="false">ISIS_Label_Small</opifont.name>
@@ -710,7 +717,7 @@ $(pv_value)</tooltip>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
         <fc>false</fc>
         <font>
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
@@ -751,7 +758,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
           </font>
@@ -792,7 +799,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
           </font>
@@ -833,7 +840,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
           </font>
@@ -883,7 +890,7 @@ $(pv_value)</tooltip>
           </bulb_border_color>
           <data_type>0</data_type>
           <effect_3d>true</effect_3d>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -941,7 +948,7 @@ $(pv_value)</tooltip>
           </bulb_border_color>
           <data_type>0</data_type>
           <effect_3d>false</effect_3d>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">Default Bold</opifont.name>
           </font>
@@ -999,7 +1006,7 @@ $(pv_value)</tooltip>
           </bulb_border_color>
           <data_type>0</data_type>
           <effect_3d>false</effect_3d>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">Default Bold</opifont.name>
           </font>
@@ -1050,7 +1057,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1094,7 +1101,7 @@ $(pv_value)</tooltip>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
         <fc>false</fc>
         <font>
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
@@ -1134,7 +1141,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1175,7 +1182,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1216,7 +1223,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1257,7 +1264,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1298,7 +1305,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1339,7 +1346,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1380,7 +1387,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1421,7 +1428,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1462,7 +1469,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1503,7 +1510,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
           </font>
@@ -1545,7 +1552,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="18" style="1" pixels="false">ISIS_Header1_NEW</opifont.name>
           </font>
@@ -1586,7 +1593,7 @@ $(pv_value)</tooltip>
           </border_color>
           <border_style>0</border_style>
           <border_width>1</border_width>
-          <enabled>true</enabled>
+          <enabled>false</enabled>
           <font>
             <opifont.name fontName="Segoe UI" height="18" style="1" pixels="false">ISIS_Header1_NEW</opifont.name>
           </font>
@@ -1659,5 +1666,69 @@ $(pv_value)</tooltip>
     <wuid>6d5edd67:171feae85f0:-32d0</wuid>
     <x>0</x>
     <y>0</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Rectangle" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <alarm_pulsing>false</alarm_pulsing>
+    <alpha>0</alpha>
+    <anti_alias>true</anti_alias>
+    <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+    <background_color>
+      <color red="30" green="144" blue="255" />
+    </background_color>
+    <bg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </bg_gradient_color>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fg_gradient_color>
+      <color red="255" green="255" blue="255" />
+    </fg_gradient_color>
+    <fill_level>0.0</fill_level>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color red="255" green="0" blue="0" />
+    </foreground_color>
+    <gradient>false</gradient>
+    <height>29</height>
+    <horizontal_fill>false</horizontal_fill>
+    <line_color>
+      <color red="128" green="0" blue="255" />
+    </line_color>
+    <line_style>0</line_style>
+    <line_width>0</line_width>
+    <name>AdvancedTabTooltip</name>
+    <pv_name></pv_name>
+    <pv_value />
+    <rules>
+      <rule name="Rule" prop_id="tooltip" out_exp="false">
+        <exp bool_exp="pv0 == 0">
+          <value>Advanced control only available under manager mode </value>
+        </exp>
+        <pv trig="true">$(P)CS:MANAGER</pv>
+      </rule>
+    </rules>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <visible>true</visible>
+    <widget_type>Rectangle</widget_type>
+    <width>67</width>
+    <wuid>-66e57a2f:173387097ca:-7db7</wuid>
+    <x>36</x>
+    <y>38</y>
   </widget>
 </display>


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/4569

### To Test

* Open the aperture/waveguide OPI
* Confirm advanced tab cannot be selected and there is a tooltip explaining why
* Switch to manager mode and confirm you can select the tab

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

