### PR TITLE
Swap target platform order

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
+++ b/base/uk.ac.stfc.isis.ibex.targetplatform/uk.ac.stfc.isis.ibex.targetplatform.target
@@ -124,14 +124,15 @@
 	</location>
 </locations>
 <environment>
-<os>win32</os>
-<ws>win32</ws>
+<os>linux</os>
+<ws>gtk</ws>
 <arch>x86_64</arch>
 <nl>en_GB</nl>
 </environment>
+<!-- Note: eclipse target platform editor will default to the last specified environment, so specify linux first and then windows. Maven is happy building both. -->
 <environment>
-<os>linux</os>
-<ws>gtk</ws>
+<os>win32</os>
+<ws>win32</ws>
 <arch>x86_64</arch>
 <nl>en_GB</nl>
 </environment>


### PR DESCRIPTION
While maven is happy building both specified target platforms, the eclipse IDE seems to default to using whichever is specified last. Specify windows last.

To review:
- Verify maven build still produces both `linux` and `win32` builds in `base\uk.ac.stfc.isis.ibex.e4.client.product\target\products\ibex.product`
- Verify you can launch from eclipse successfully after reloading target platform