### PR TITLE
Ticket5558 cancel saves macros

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/META-INF/MANIFEST.MF
@@ -12,5 +12,6 @@ Require-Bundle: org.junit;bundle-version="4.11.0",
  org.hamcrest.generator;bundle-version="1.3.0",
  org.hamcrest.integration;bundle-version="1.3.0",
  org.hamcrest.library;bundle-version="1.3.0",
- org.hamcrest.text;bundle-version="1.1.0"
+ org.hamcrest.text;bundle-version="1.1.0",
+ uk.ac.stfc.isis.ibex.configserver
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.ui.configserver.tests

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/tests/TempIocTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/tests/TempIocTest.java
@@ -23,10 +23,14 @@ package uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs.tests;
 
 import static org.junit.Assert.*;
 
+import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
+import uk.ac.stfc.isis.ibex.configserver.configuration.Macro;
+import uk.ac.stfc.isis.ibex.configserver.configuration.Macro.HasDefault;
 import uk.ac.stfc.isis.ibex.configserver.configuration.SimLevel;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
 import uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs.dialog.TempEditableIoc;
@@ -157,5 +161,33 @@ public class TempIocTest {
 
         // Assert
         assertEquals(expected, actual);
+    }
+    
+    @Test
+    public void GIVEN_ioc_set_WHEN_changing_macros_THEN_macros_do_not_write_through_to_underlying_ioc_until_saved() {
+        var testMacros = List.of(
+            new Macro("name_ignored", "inital_value", "", "", "", HasDefault.NO)
+        );
+        
+        var underlyingIoc = new EditableIoc(new Ioc(""), "");
+        underlyingIoc.setMacros(testMacros);
+        
+        var tempEditableIoc = new TempEditableIoc(underlyingIoc);
+        
+        // Set value in the Temp IOC
+        for (Macro macro : tempEditableIoc.getMacros()) {
+            macro.setValue("some_new_value");
+        }
+        
+        // Before saving the temp IOC, the value should not have propagated down to the underlying IOC.
+        for (Macro macro : underlyingIoc.getMacros()) {
+            assertEquals("inital_value", macro.getValue());
+        }
+        
+        // After saving, the new value should be seen in the underlying IOC.
+        tempEditableIoc.saveIoc();  
+        for (Macro macro : underlyingIoc.getMacros()) {
+            assertEquals("some_new_value", macro.getValue());
+        }
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/dialog/TempEditableIoc.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/dialog/TempEditableIoc.java
@@ -21,6 +21,12 @@
  */
 package uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs.dialog;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+import uk.ac.stfc.isis.ibex.configserver.configuration.Macro;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
 
 /**
@@ -29,6 +35,7 @@ import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
  */
 public class TempEditableIoc extends EditableIoc {
     private final EditableIoc editingIoc;
+    private Collection<Macro> macros;
 
     /**
      * Constructor for the temp IOC.
@@ -39,6 +46,18 @@ public class TempEditableIoc extends EditableIoc {
     public TempEditableIoc(EditableIoc ioc) {
         super(ioc);
         this.editingIoc = ioc;
+        
+        this.macros = deepCopyMacros(editingIoc.getMacros());
+    }
+    
+    @Override
+    public Collection<Macro> getMacros() {
+        return macros;
+    }
+    
+    @Override
+    public void setMacros(final Collection<Macro> macros) {
+        this.macros = deepCopyMacros(macros);
     }
 
     /**
@@ -52,6 +71,19 @@ public class TempEditableIoc extends EditableIoc {
         editingIoc.setPvs(getPvs());
         editingIoc.setPvSets(getPvSets());
         editingIoc.setRemotePvPrefix(getRemotePvPrefix());
+    }
+    
+    /**
+     * Create a deep, fully independent copy of a collection of macros.
+     * @param macros the macros to copy from
+     * @return a deep copy of the macros.
+     */
+    private static final Collection<Macro> deepCopyMacros(final Collection<Macro> macros) {
+        var result = new ArrayList<Macro>();
+        for (Macro macro : macros) {
+            result.add(new Macro(macro));
+        }
+        return result;
     }
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/dialog/TempEditableIoc.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/dialog/TempEditableIoc.java
@@ -23,9 +23,6 @@ package uk.ac.stfc.isis.ibex.ui.configserver.editing.iocs.dialog;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.stream.Collectors;
-
 import uk.ac.stfc.isis.ibex.configserver.configuration.Macro;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableIoc;
 
@@ -50,11 +47,17 @@ public class TempEditableIoc extends EditableIoc {
         this.macros = deepCopyMacros(editingIoc.getMacros());
     }
     
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public Collection<Macro> getMacros() {
         return macros;
     }
     
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void setMacros(final Collection<Macro> macros) {
         this.macros = deepCopyMacros(macros);


### PR DESCRIPTION
### Description of work

Prevent temporary IOCs from "writing through" to the underlying IOC object until they are saved.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5558

### Acceptance criteria

- Bug is fixed
- Added test would have caught the issue

### Unit tests

Unit test added which replicated the bug and proves it is fixed. Should fail on old code.

### System tests

Not added.

### Documentation

Not added.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

