### PR TITLE
Fix log issue by restarting correctly

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/ReceiveSession.java
+++ b/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/ReceiveSession.java
@@ -166,6 +166,7 @@ public class ReceiveSession extends ModelObject {
     protected void addConsumer(Destination dest, MessageParser parser) throws JMSException {
         MessageConsumer consumer = session.createConsumer(dest);
         parser.setActiveMQConsumer(consumer);
+        parser.setRunning(true);
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
+++ b/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
@@ -80,6 +80,7 @@ public abstract class MessageParser<T extends IMessage> implements Runnable {
      *             Thrown if close fails.
      */
     public void closeJMSConsumer() throws JMSException {
+        setRunning(false);
         jmsConsumer.close();
         
         /**
@@ -95,7 +96,6 @@ public abstract class MessageParser<T extends IMessage> implements Runnable {
          * 
          */
         jmsConsumer = null;
-        setRunning(false);
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
+++ b/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
@@ -39,21 +39,12 @@ public abstract class MessageParser<T extends IMessage> implements Runnable {
 
     private static final int TIMEOUT_50_MS = 50;
     private boolean running = true;
-    private Thread thread;
+    private Thread thread = null;
     
     private List<IMessageConsumer<T>> convertedConsumers = new ArrayList<>();
 
     /** Receives messages from the JMS server */
     private MessageConsumer jmsConsumer;
-    
-    /**
-     * Default constructor, will start a thread listening for active MQ
-     * messages.
-     */
-    public MessageParser() {
-        thread = new Thread(this);
-        thread.start();
-    }
 
     /**
      * Start and stop the thread.
@@ -66,6 +57,10 @@ public abstract class MessageParser<T extends IMessage> implements Runnable {
     		throw new IllegalStateException("Cannot start running without a consumer");
     	}
         running = run;
+        if(running && (thread == null || !thread.isAlive())) {
+        	thread = new Thread(this);
+            thread.start();
+        }
     }
     
     /**


### PR DESCRIPTION
### Description of work

On reconnect actually restart the MessageParser thread to receive messages.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5561

### Acceptance criteria

Both before and after I have switched instruments and back the following occur:

- When I send a message through the message simulator in C:\Instrument\Apps\EPICS\ISIS\IocLogServer\master\dev-tools it appears in the IOC log
- When I trigger a log message in the DAE it appears in the DAE perspectives recent log messages

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

