### PR TITLE
Load scripts from repo fixing bug where we couldn't load them

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
@@ -220,9 +220,9 @@ class Generator(object):
            None if there is an error or parameters are invalid, otherwise a string of a generated script.
         """
         if self.areParamsValid(list_of_actions, script_definition):
-            script_definition_file_path = "{}.py".format(script_definition.getName())
-            script_definition_template = self.env.get_template(script_definition_file_path)
             try:
+                script_definition_file_path = "{}.py".format(script_definition.getName())
+                script_definition_template = self.env.get_template(script_definition_file_path)
                 val = str(utilities.compress_and_hex(jsonString))
                 rendered_template = self.template.render(inserted_script_definition=script_definition_template,
                     script_generator_actions=list_of_actions, hexed_value=val)

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
@@ -163,7 +163,7 @@ class Generator(object):
         Set up the template to generate with
         """
         cwd = os.path.dirname(os.path.abspath(__file__))
-        self.loader = FileSystemLoader("{}/templates".format(cwd))
+        self.loader = FileSystemLoader(["{}/templates".format(cwd), repo_path])
         self.env = Environment(loader=self.loader, keep_trailing_newline=True)
         self.template = self.env.get_template('generator_template.py')
 


### PR DESCRIPTION
### Description of work

Squish was failing whilst trying to generate a script (http://epics-jenkins.isis.rl.ac.uk/job/System_Tests_Squish/). This was because we were no longer telling jinja2 where to load script definitions from. This PR adds the repo path where we get the definitions from.

### Ticket

N/A

### Acceptance criteria

I can generate a script and view the generated script when parameters are valid.

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

Was caught by a squish test!

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

