### PR TITLE
Add opi_info.xml checks as part of build

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
@@ -233,7 +233,7 @@ if __name__ == "__main__":
     # for the opi_info.xml check
     print("Testing '{}'".format(os.path.join(root_dir, "opi_info.xml")))
     suite = unittest.TestSuite()
-    suite.addTests([TestOpiInfo(test) for test in loader.getTestCaseNames(TestOpiInfo)])
+    suite.addTests(loader.loadTestsFromTestCase(TestOpiInfo))
     runner = XMLTestRunner(output=os.path.join(logs_dir, "TestOpiInfo"), stream=sys.stdout)
     return_values.append(runner.run(suite).wasSuccessful())
 

--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py
@@ -17,6 +17,8 @@ from xmlrunner import XMLTestRunner
 from check_OPI_format_utils.xy_graph import get_traces_with_different_buffer_sizes, get_trigger_pv
 from check_opi_format_tests import TestCheckOpiFormatMethods
 
+from check_opi_info import TestOpiInfo
+
 # Directory to iterate through
 DEFAULT_ROOT_DIR = r"./resources/"
 
@@ -227,5 +229,12 @@ if __name__ == "__main__":
             suite.addTests([CheckOpiFormat(test, root) for test in loader.getTestCaseNames(CheckOpiFormat)])
         runner = XMLTestRunner(output=os.path.join(logs_dir, filename), stream=sys.stdout)
         return_values.append(runner.run(suite).wasSuccessful())
+
+    # for the opi_info.xml check
+    print("Testing '{}'".format(os.path.join(root_dir, "opi_info.xml")))
+    suite = unittest.TestSuite()
+    suite.addTests([TestOpiInfo(test) for test in loader.getTestCaseNames(TestOpiInfo)])
+    runner = XMLTestRunner(output=os.path.join(logs_dir, "TestOpiInfo"), stream=sys.stdout)
+    return_values.append(runner.run(suite).wasSuccessful())
 
     sys.exit(False in return_values)

--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
@@ -4,39 +4,46 @@ import xml.etree.ElementTree as ET
 import unittest
 
 DEFAULT_ROOT_DIR = os.path.join(os.path.dirname(__file__), "resources")
+OPI_INFO_PATH = os.path.join(DEFAULT_ROOT_DIR, "opi_info.xml")
 
 
 class TestOpiInfo(unittest.TestCase):
     def _check_path_valid(self, path_str):
+        """
+        Checks that the given opi_info.xml entry path is valid.
+        Args:
+            path_str (str): The path to verify (of a device entry in the opi_info.xml file)
+        Returns:
+            string: The error message, or None if there is no error
+        """
         full_path = os.path.join(DEFAULT_ROOT_DIR, path_str)
         # check path exists
         if not os.path.exists(full_path):
-            return ["opi_info.xml error: {} was not found".format(path_str)]
+            return "opi_info.xml error: {} was not found".format(path_str)
 
         # check path has no windows-style backslashes
         if '\\' in path_str:
-            return ['opi_info.xml error: "{}" contains windows-style backslash (\\)!'.format(path_str)]
+            return 'opi_info.xml error: "{}" contains windows-style backslash (\\)!'.format(path_str)
 
         # check file case sensitivity on xml and system
         filesystem_path = win32api.GetLongPathName(win32api.GetShortPathName(full_path)).split("resources\\")[1]
         if path_str != filesystem_path:
-            return ['opi_info.xml error: info path does not match filesystem path - "{}", should be "{}"'
-                    .format(path_str, filesystem_path)]
+            return 'opi_info.xml error: info path does not match filesystem path - "{}", should be "{}"' \
+                .format(path_str, filesystem_path)
 
-        return []
+        return None
 
     def test_opi_info(self):
-        file_path = os.path.join(DEFAULT_ROOT_DIR, "opi_info.xml")
-
         # if opi_info.xml was not found
-        if not os.path.exists(file_path):
-            self.fail("Could not find file path {}".format(file_path))
+        if not os.path.exists(OPI_INFO_PATH):
+            self.fail("Could not find file path {}".format(OPI_INFO_PATH))
 
-        tree = ET.parse(file_path)
+        tree = ET.parse(OPI_INFO_PATH)
         root = tree.getroot()
         errors = []
         for entry in root.iter('path'):
-            errors.extend(self.check_path_valid(entry.text))
+            if self._check_path_valid(entry.text):  # if an error message is returned
+                errors.extend([self._check_path_valid(entry.text)])
 
         if errors:
             self.fail("\n" + "\n".join(errors))

--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
@@ -7,7 +7,7 @@ DEFAULT_ROOT_DIR = os.path.join(os.path.dirname(__file__), "resources")
 
 
 class TestOpiInfo(unittest.TestCase):
-    def check_path_valid(self, path_str):
+    def _check_path_valid(self, path_str):
         full_path = os.path.join(DEFAULT_ROOT_DIR, path_str)
         # check path exists
         if not os.path.exists(full_path):

--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
@@ -42,8 +42,9 @@ class TestOpiInfo(unittest.TestCase):
         root = tree.getroot()
         errors = []
         for entry in root.iter('path'):
-            if self._check_path_valid(entry.text):  # if an error message is returned
-                errors.extend([self._check_path_valid(entry.text)])
+            err_msg = self._check_path_valid(entry.text)
+            if err_msg:  # if an error message is returned
+                errors.extend([err_msg])
 
         if errors:
             self.fail("\n" + "\n".join(errors))

--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
@@ -1,0 +1,42 @@
+import os
+import win32api
+import xml.etree.ElementTree as ET
+import unittest
+
+DEFAULT_ROOT_DIR = os.path.join(os.path.dirname(__file__), "resources")
+
+
+class TestOpiInfo(unittest.TestCase):
+    def check_path_valid(self, path_str):
+        full_path = os.path.join(DEFAULT_ROOT_DIR, path_str)
+        # check path exists
+        if not os.path.exists(full_path):
+            return ["opi_info.xml error: {} was not found".format(path_str)]
+
+        # check path has no windows-style backslashes
+        if '\\' in path_str:
+            return ['opi_info.xml error: "{}" contains windows-style backslash (\\)!'.format(path_str)]
+
+        # check file case sensitivity on xml and system
+        filesystem_path = win32api.GetLongPathName(win32api.GetShortPathName(full_path)).split("resources\\")[1]
+        if path_str != filesystem_path:
+            return ['opi_info.xml error: info path does not match filesystem path - "{}", should be "{}"'
+                    .format(path_str, filesystem_path)]
+
+        return []
+
+    def test_opi_info(self):
+        file_path = os.path.join(DEFAULT_ROOT_DIR, "opi_info.xml")
+
+        # if opi_info.xml was not found
+        if not os.path.exists(file_path):
+            self.fail("Could not find file path {}".format(file_path))
+
+        tree = ET.parse(file_path)
+        root = tree.getroot()
+        errors = ['\r']  # start list with carriage return so multiple errors are listed nicely in the console
+        for entry in root.iter('path'):
+            errors.extend(self.check_path_valid(entry.text))
+
+        if len(errors) and errors != ['\r']:
+            self.fail("\n".join(errors))

--- a/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/check_opi_info.py
@@ -34,9 +34,9 @@ class TestOpiInfo(unittest.TestCase):
 
         tree = ET.parse(file_path)
         root = tree.getroot()
-        errors = ['\r']  # start list with carriage return so multiple errors are listed nicely in the console
+        errors = []
         for entry in root.iter('path'):
             errors.extend(self.check_path_valid(entry.text))
 
-        if len(errors) and errors != ['\r']:
-            self.fail("\n".join(errors))
+        if errors:
+            self.fail("\n" + "\n".join(errors))

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -302,7 +302,7 @@
       <key>Slit motors</key>
       <value>
         <type>JAWS</type>
-        <path>slit_motors.opi</path>
+        <path>jaws/slit_motors_4.opi</path>
         <description>The OPI displaying the motors of a slit.</description>
         <macros>
           <macro>
@@ -1594,24 +1594,6 @@
         </macros>
         <categories>
           <category>Power supplies</category>
-        </categories>
-      </value>
-    </entry>
-    <entry>
-      <key>XY Shutter Arm Beam-stop</key>
-      <value>
-        <type>BEAMSTOP</type>
-        <path>xyShutterArmBeamstop.opi</path>
-        <description>The OPI for the XY Arm Beam-stop with a shutter.</description>
-        <macros>
-          <macro>
-            <name>XYSHUTTERARMBEAMSTOP</name>
-            <description>The XY Arm Shutter Beamstop PV prefix (e.g. MOT).</description>
-            <default/>
-          </macro>
-        </macros>
-        <categories>
-          <category>Miscellaneous motion control</category>
         </categories>
       </value>
     </entry>


### PR DESCRIPTION
### Description of work

1. Added automated `opi_info.xml` checks as part of build which make sure the listed resources are valid
2. Corrected existing issues:
    - changed `slit_motors.opi` to `jaws/slit_motors_4.opi` as old path was invalid
    - removed `XY Shutter Arm Beam-stop` entry as the device was removed in [#4770](https://github.com/ISISComputingGroup/IBEX/issues/4770)

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5522

### Acceptance criteria

- `opi_info.xml` does not contain windows-style paths (i.e. paths containing `\`)
- The files that `opi_info.xml` refers to should exist
- The file paths should be cased the same way on the filesystem and `opi_info.xml`, e.g. `jaws.opi` vs `JAWS.OPI` should fail.
- There is an automated test that checks the above conditions and is run as part of the build.

### Unit tests

Created `class TestOpiInfo(unittest.TestCase)` within `check_opi_info.py`

### System tests

N/A

### Documentation

N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

