### PR TITLE
Ticket5591 Update genie default location to Python3

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
+++ b/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
@@ -160,7 +160,7 @@ public class PreferenceSupplier {
     /**
      * The default for the location of genie_python.
      */
-    private static final String DEFAULT_GENIE_PYTHON_DIRECTORY = "C:\\Instrument\\Apps\\Python\\Lib\\site-packages\\genie_python";
+    private static final String DEFAULT_GENIE_PYTHON_DIRECTORY = "C:\\Instrument\\Apps\\Python3\\Lib\\site-packages\\genie_python";
     
     /**
      * The preference setting for the location of EPICS utils.


### PR DESCRIPTION
### Description of work

Changed the default location of genie_python within `PreferenceSupplier.java` to point to the Python 3 directory so that `sys.path` no longer outputs to the old `...Apps\\Python\\Lib...`

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5591

### Acceptance criteria

`sys.path` contains `Python3` rather than `Python` directories:

e.g.: `'C:\\Instrument\\Apps\\`**`Python3`**`\\Lib\\site-packages\\genie_python'` (good)


and not: `'C:\\Instrument\\Apps\\`**`Python`**`\\Lib\\site-packages\\genie_python'` (bad)

### Unit tests

N/A

### System tests

N/A

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

