### PR TITLE
Display load config warning only when protected configs in list

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/META-INF/MANIFEST.MF
@@ -14,3 +14,4 @@ Require-Bundle: org.junit;bundle-version="4.10.0",
  org.hamcrest.library;bundle-version="1.3.0",
  org.hamcrest.text;bundle-version="1.1.0"
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.configserver.tests
+Import-Package: uk.ac.stfc.isis.ibex.configserver.configuration

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/configuration/HasProtectedElementTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/configuration/HasProtectedElementTest.java
@@ -1,0 +1,162 @@
+
+/*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2020 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.configserver.tests.configuration;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.configserver.configuration.ConfigInfo;
+
+@SuppressWarnings("checkstyle:methodname")
+public class HasProtectedElementTest {
+	
+    @Test
+    public void WHEN_no_elements_THEN_return_false() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+
+        // Act
+    	boolean result = ConfigInfo.hasProtectedElement(infos);
+
+        // Assert
+    	assertEquals(false, result);
+    }
+	
+    @Test
+    public void WHEN_no_protected_elements_THEN_return_false() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+        for (int i = 0; i < 10 ; i++) {
+        	ConfigInfo elem = new ConfigInfo("", false, "", "", "", Collections.emptyList());
+            infos.add(elem);
+        }
+
+        // Act
+    	boolean result = ConfigInfo.hasProtectedElement(infos);
+
+        // Assert
+    	assertEquals(false, result);
+    }
+    
+    @Test
+    public void WHEN_one_element_and_not_protected_THEN_return_true() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+    	ConfigInfo elem = new ConfigInfo("", false, "", "", "", Collections.emptyList());
+        infos.add(elem);
+
+        // Act
+    	boolean result = ConfigInfo.hasProtectedElement(infos);
+
+        // Assert
+    	assertEquals(false, result);
+    }
+    
+    @Test
+    public void WHEN_one_element_and_protected_THEN_return_true() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+    	ConfigInfo elem = new ConfigInfo("", true, "", "", "", Collections.emptyList());
+        infos.add(elem);
+
+        // Act
+    	boolean result = ConfigInfo.hasProtectedElement(infos);
+
+        // Assert
+    	assertEquals(true, result);
+    }
+    
+    @Test
+    public void WHEN_one_protected_element_THEN_return_true() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+        for (int i = 0; i < 9 ; i++) {
+        	ConfigInfo elem = new ConfigInfo("", false, "", "", "", Collections.emptyList());
+            infos.add(elem);
+        }
+    	ConfigInfo elem = new ConfigInfo("", true, "", "", "", Collections.emptyList());
+        infos.add(elem);
+
+        // Act
+    	boolean result = ConfigInfo.hasProtectedElement(infos);
+
+        // Assert
+    	assertEquals(true, result);
+    }
+    
+    @Test
+    public void WHEN_multiple_protected_elements_THEN_return_true() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+        for (int i = 0; i < 10 ; i++) {
+        	if (i%2==0) { 
+        		ConfigInfo elem = new ConfigInfo("", false, "", "", "", Collections.emptyList());
+        		infos.add(elem);
+        	} else { 
+        		ConfigInfo elem = new ConfigInfo("", true, "", "", "", Collections.emptyList());
+        		infos.add(elem);
+        	}
+        }
+
+         // Act
+     	boolean result = ConfigInfo.hasProtectedElement(infos);
+
+         // Assert
+     	assertEquals(true, result);
+    }
+    
+    @Test
+    public void WHEN_all_protected_elements_THEN_return_true() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+        for (int i = 0; i < 10 ; i++) {
+    		ConfigInfo elem = new ConfigInfo("", true, "", "", "", Collections.emptyList());
+    		infos.add(elem);
+        }
+
+         // Act
+     	boolean result = ConfigInfo.hasProtectedElement(infos);
+
+         // Assert
+     	assertEquals(true, result);
+    }
+    
+    @Test
+    public void WHEN_null_collection_THEN_return_false() {
+        // Arrange
+    	Collection<ConfigInfo> infos = null;
+
+        // Act
+    	boolean result = ConfigInfo.hasProtectedElement(infos);
+
+        // Assert
+    	assertEquals(false, result);
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -120,7 +120,7 @@ public class ConfigInfo {
      * @return The list of config names
      */
     public static Collection<String> names(Collection<ConfigInfo> infos) {
-        if (infos.isEmpty()) {
+    	if (infos == null || infos.isEmpty()) {
             return Collections.emptyList();
         }
 
@@ -136,10 +136,11 @@ public class ConfigInfo {
     /**
      * returns config/Component names and its protection status.
      * @param infos
+     *            The list of ConfigInfos
      * @return collection of Pair i.e config/comp name and its protection flag
      */
     public static Map<String, Boolean> mapNamesWithTheirProtectionFlag(Collection<ConfigInfo> infos) {
-        if (infos.isEmpty()) {
+    	if (infos == null || infos.isEmpty()) {
             return Collections.emptyMap();
         }
         Map<String, Boolean> namesWithProtectionFlag = new HashMap<String, Boolean>();
@@ -151,23 +152,18 @@ public class ConfigInfo {
     }
     
     /**
-     * Checks if there is a protected configuration/comp within the given ConfigInfos objects.
+     * Checks if there is a protected configuration/component element within the given ConfigInfo collection.
      * @param infos
-     * @return boolean: True if a protected configuration exists within given infos, False if not
+     *            The list of ConfigInfos
+     * @return boolean: True if a protected configuration exists within given infos list, False if not
      */
-    public static Boolean hasProtectedConfigs(Collection<ConfigInfo> infos) {
-        if (infos.isEmpty()) {
+    public static boolean hasProtectedElement(Collection<ConfigInfo> infos) {
+    	if (infos == null) {
             return false;
         }
-        
-        Boolean returnVal = false;
-        for (ConfigInfo config: infos) {
-        	if (config.isProtected == true) {
-        		returnVal = true;
-        		break;
-        	}
-        }
-    	
+
+        boolean returnVal = infos.stream().anyMatch(config -> config.isProtected == true);
+
     	return returnVal;
     }
 

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -120,9 +120,10 @@ public class ConfigInfo {
      * @return The list of config names
      */
     public static Collection<String> names(Collection<ConfigInfo> infos) {
-        if (infos == null) {
+        if (infos.isEmpty()) {
             return Collections.emptyList();
         }
+
 
         return Lists.newArrayList(Iterables.transform(infos, new Function<ConfigInfo, String>() {
             @Override
@@ -138,7 +139,7 @@ public class ConfigInfo {
      * @return collection of Pair i.e config/comp name and its protection flag
      */
     public static Map<String, Boolean> mapNamesWithTheirProtectionFlag(Collection<ConfigInfo> infos) {
-        if (infos == null) {
+        if (infos.isEmpty()) {
             return Collections.emptyMap();
         }
         Map<String, Boolean> namesWithProtectionFlag = new HashMap<String, Boolean>();
@@ -150,23 +151,12 @@ public class ConfigInfo {
     }
     
     /**
-     * Returns Configuration/Component names and their protection status, excluding the current configuration
-     * @param infos
-     * @return collection of pair config/comp Name and Protection Flag (e.g. {<name>=<prot. status>, ...}), excluding the current configuration
-     */
-    public static Map<String, Boolean> mapNamesWithTheirProtectionFlagWithoutCurrent(Collection<ConfigInfo> infos) {
-    	Map<String, Boolean> filteredResults = mapNamesWithTheirProtectionFlag(infos);
-    	filteredResults.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().name());
-    	return filteredResults;
-    }
-    
-    /**
-     * Checks if there is a protected configuration/comp within the given ConfigInfos objects
+     * Checks if there is a protected configuration/comp within the given ConfigInfos objects.
      * @param infos
      * @return boolean: True if a protected configuration exists within given infos, False if not
      */
     public static Boolean hasProtectedConfigs(Collection<ConfigInfo> infos) {
-        if (infos == null) {
+        if (infos.isEmpty()) {
             return false;
         }
         

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -160,13 +160,15 @@ public class ConfigInfo {
             return false;
         }
         
+        Boolean returnVal = false;
         for (ConfigInfo config: infos) {
         	if (config.isProtected == true) {
-        		return true;
+        		returnVal = true;
+        		break;
         	}
         }
     	
-    	return false;
+    	return returnVal;
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -135,7 +135,7 @@ public class ConfigInfo {
     /**
      * returns config/Component names and its protection status.
      * @param infos
-     * @return collection of Pair i.e config/comp name and its proteciton flag
+     * @return collection of Pair i.e config/comp name and its protection flag
      */
     public static Map<String, Boolean> mapNamesWithTheirProtectionFlag(Collection<ConfigInfo> infos) {
         if (infos == null) {
@@ -147,6 +147,36 @@ public class ConfigInfo {
         }
         
         return namesWithProtectionFlag;
+    }
+    
+    /**
+     * Returns Configuration/Component names and their protection status, excluding the current configuration
+     * @param infos
+     * @return collection of pair config/comp Name and Protection Flag (e.g. {<name>=<prot. status>, ...}), excluding the current configuration
+     */
+    public static Map<String, Boolean> mapNamesWithTheirProtectionFlagWithoutCurrent(Collection<ConfigInfo> infos) {
+    	Map<String, Boolean> filteredResults = mapNamesWithTheirProtectionFlag(infos);
+    	filteredResults.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().name());
+    	return filteredResults;
+    }
+    
+    /**
+     * Checks if there is a protected configuration/comp within the given ConfigInfos objects
+     * @param infos
+     * @return boolean: True if a protected configuration exists within given infos, False if not
+     */
+    public static Boolean hasProtectedConfigs(Collection<ConfigInfo> infos) {
+        if (infos == null) {
+            return false;
+        }
+        
+        for (ConfigInfo config: infos) {
+        	if (config.isProtected == true) {
+        		return true;
+        	}
+        }
+    	
+    	return false;
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
@@ -124,20 +124,27 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
         } else {
             names = ConfigInfo.namesWithoutCurrent(available).toArray(new String[0]);
         }
+         
 		Arrays.sort(names, String.CASE_INSENSITIVE_ORDER);
 		
 		setItems(names, compOrConfigNamesWithFlags);
 		
-		Group group = new Group(container, SWT.SHADOW_IN);
-		group.setLayout(new RowLayout(SWT.HORIZONTAL));
-		        
-	    Label messageImageLabel = new Label(group, SWT.NONE);
-            messageImageLabel.setImage(JFaceResources.
-                getImage(DLG_IMG_MESSAGE_WARNING)); 
-
-        Label messageLabel = new Label(group, SWT.NONE);
-        messageLabel.setFont(JFaceResources.getDialogFont());
-        messageLabel.setText("Represents Protected " + getTypeString());
+		// show protected configuration message only if relevant (the list has protected configurations)
+		Boolean hasProtectedConfigs = ConfigInfo.hasProtectedConfigs(available);
+		if (hasProtectedConfigs)
+		{
+			Group group = new Group(container, SWT.SHADOW_IN);
+			group.setLayout(new RowLayout(SWT.HORIZONTAL));
+			        
+			
+		    Label messageImageLabel = new Label(group, SWT.NONE);
+	            messageImageLabel.setImage(JFaceResources.
+	                getImage(DLG_IMG_MESSAGE_WARNING)); 
+	
+	        Label messageLabel = new Label(group, SWT.NONE);
+	        messageLabel.setFont(JFaceResources.getDialogFont());
+	        messageLabel.setText("Represents Protected " + getTypeString());
+		}
 			
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
@@ -130,20 +130,17 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
 		setItems(names, compOrConfigNamesWithFlags);
 		
 		// show protected configuration message only if relevant (the list has protected configurations)
-		Boolean hasProtectedConfigs = ConfigInfo.hasProtectedConfigs(available);
-		if (hasProtectedConfigs)
-		{
+		Boolean hasProtectedConfigs = ConfigInfo.hasProtectedElement(available);
+		if (hasProtectedConfigs) {
 			Group group = new Group(container, SWT.SHADOW_IN);
 			group.setLayout(new RowLayout(SWT.HORIZONTAL));
-			        
 			
-		    Label messageImageLabel = new Label(group, SWT.NONE);
-	            messageImageLabel.setImage(JFaceResources.
-	                getImage(DLG_IMG_MESSAGE_WARNING)); 
-	
-	        Label messageLabel = new Label(group, SWT.NONE);
-	        messageLabel.setFont(JFaceResources.getDialogFont());
-	        messageLabel.setText("Represents Protected " + getTypeString());
+			Label messageImageLabel = new Label(group, SWT.NONE);
+			messageImageLabel.setImage(JFaceResources.getImage(DLG_IMG_MESSAGE_WARNING)); 
+			
+			Label messageLabel = new Label(group, SWT.NONE);
+			messageLabel.setFont(JFaceResources.getDialogFont());
+			messageLabel.setText("Represents Protected " + getTypeString());
 		}
 			
 	}


### PR DESCRIPTION

### Description of work

Changed the Load Configuration dialogue so that there is no protected configurations warning message when there are none in the list. 
If at least one protected configuration is in the dialogue list, then the message will be displayed.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5062

### Acceptance criteria

- Warning message and icon are shown only when there is a protected config in the selection list

### Unit tests

N/A

### System tests

N/A

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

