### PR TITLE
Added config descriptions column to dialog

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/configuration/ConfigInfoTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/configuration/ConfigInfoTest.java
@@ -1,0 +1,139 @@
+
+/*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2020 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+/**
+ * 
+ */
+package uk.ac.stfc.isis.ibex.configserver.tests.configuration;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.configserver.configuration.ConfigInfo;
+
+@SuppressWarnings("checkstyle:methodname")
+public class ConfigInfoTest {
+
+	private static final String NAME = "name";
+	private static final String DESCRIPTION = "description";
+	
+    @Test
+    public void GIVEN_no_items_WHEN_get_names_THEN_return_empty_list() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+
+         // Act
+     	Collection<String> result = ConfigInfo.names(infos);
+
+         // Assert
+     	assertEquals(Collections.emptyList(), result);
+    }
+	
+    @Test
+    public void GIVEN_one_item_WHEN_get_names_THEN_return_name() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+		ConfigInfo elem = new ConfigInfo(NAME, false, "", "", "", Collections.emptyList());
+		infos.add(elem);
+		
+     	Collection<String> expected = Arrays.asList(NAME);
+
+         // Act
+     	Collection<String> result = ConfigInfo.names(infos);
+
+         // Assert
+     	assertEquals(expected, result);
+    }
+    
+    @Test
+    public void GIVEN_multiple_items_WHEN_get_names_THEN_return_names() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+        for (int i = 0; i < 10 ; i++) {
+    		ConfigInfo elem = new ConfigInfo(NAME + i, false, "", "", "", Collections.emptyList());
+    		infos.add(elem);
+        }
+        
+        Collection<String> expected = new ArrayList<String>();
+        for (int i = 0; i < 10; i++) {
+        	expected.add(NAME + i);
+        }
+
+         // Act
+     	Collection<String> result = ConfigInfo.names(infos);
+
+         // Assert
+     	assertEquals(expected, result);
+    }
+    
+    @Test
+    public void GIVEN_no_items_WHEN_get_descriptions_THEN_return_empty_list() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+
+         // Act
+     	Collection<String> result = ConfigInfo.descriptions(infos);
+
+         // Assert
+     	assertEquals(Collections.emptyList(), result);
+    }
+	
+    @Test
+    public void GIVEN_one_item_WHEN_get_descriptions_THEN_return_name() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+		ConfigInfo elem = new ConfigInfo("", false, DESCRIPTION, "", "", Collections.emptyList());
+		infos.add(elem);
+		
+     	Collection<String> expected = Arrays.asList(DESCRIPTION);
+
+         // Act
+     	Collection<String> result = ConfigInfo.descriptions(infos);
+
+         // Assert
+     	assertEquals(expected, result);
+    }
+    
+    @Test
+    public void GIVEN_multiple_items_WHEN_get_descriptions_THEN_return_descriptions() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+        for (int i = 0; i < 10 ; i++) {
+    		ConfigInfo elem = new ConfigInfo("", false, DESCRIPTION + i, "", "", Collections.emptyList());
+    		infos.add(elem);
+        }
+        
+        Collection<String> expected = new ArrayList<String>();
+        for (int i = 0; i < 10; i++) {
+        	expected.add(DESCRIPTION + i);
+        }
+
+         // Act
+     	Collection<String> result = ConfigInfo.descriptions(infos);
+
+         // Assert
+     	assertEquals(expected, result);
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/configuration/ConfigInfoTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/configuration/ConfigInfoTest.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import org.junit.Test;
 
@@ -132,6 +134,53 @@ public class ConfigInfoTest {
 
          // Act
      	Collection<String> result = ConfigInfo.descriptions(infos);
+
+         // Assert
+     	assertEquals(expected, result);
+    }
+    
+    @Test
+    public void GIVEN_no_items_WHEN_get_namesAndDescriptions_THEN_return_empty_list() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+
+         // Act
+     	SortedMap<String, String> result = ConfigInfo.namesAndDescriptions(infos);
+
+         // Assert
+     	assertEquals(true, result.isEmpty());
+    }
+	
+    @Test
+    public void GIVEN_one_item_WHEN_get_namesAndDescriptions_THEN_return_name() {
+        // Arrange
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+		ConfigInfo elem = new ConfigInfo(NAME, false, DESCRIPTION, "", "", Collections.emptyList());
+		infos.add(elem);
+		
+		SortedMap<String, String> expected = new TreeMap<String, String>();
+		expected.put(NAME, DESCRIPTION);
+
+         // Act
+     	SortedMap<String, String> result = ConfigInfo.namesAndDescriptions(infos);
+
+         // Assert
+     	assertEquals(expected, result);
+    }
+    
+    @Test
+    public void GIVEN_multiple_items_WHEN_get_namesAndDescriptions_THEN_return_descriptions() {
+        // Arrange
+    	SortedMap<String, String> expected = new TreeMap<String, String>();
+    	Collection<ConfigInfo> infos = new ArrayList<ConfigInfo>();
+        for (int i = 0; i < 10 ; i++) {
+    		ConfigInfo elem = new ConfigInfo(NAME + i, false, DESCRIPTION + i, "", "", Collections.emptyList());
+    		infos.add(elem);
+    		expected.put(NAME + i, DESCRIPTION + i);
+        }
+        
+         // Act
+        SortedMap<String, String> result = ConfigInfo.namesAndDescriptions(infos);
 
          // Assert
      	assertEquals(expected, result);

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -182,7 +182,7 @@ public class ConfigInfo {
      */
     public static SortedMap<String, String> namesAndDescriptions(Collection<ConfigInfo> infos) {
     	if (infos == null || infos.isEmpty()) {
-    		return new TreeMap<String, String>();
+    		return Collections.emptySortedMap();
     	}
     	
     	SortedMap<String, String> result = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -125,12 +125,9 @@ public class ConfigInfo {
             return Collections.emptyList();
         }
 
-        return Lists.newArrayList(Iterables.transform(infos, new Function<ConfigInfo, String>() {
-            @Override
-            public String apply(ConfigInfo info) {
-                return info.name();
-            }
-        }));
+        return infos.stream()
+                .map(ConfigInfo::name)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
     
     /**

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
@@ -103,8 +105,8 @@ public class ConfigInfo {
      *            The list of ConfigInfos
      * @return The list of config names without that of the current config
      */
-    public static Collection<String> namesWithoutCurrent(Collection<ConfigInfo> infos) {
-        Collection<String> filteredNames = names(infos);
+    public static List<String> namesWithoutCurrent(Collection<ConfigInfo> infos) {
+        List<String> filteredNames = names(infos);
         filteredNames.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().name());
         return filteredNames;
     }
@@ -116,14 +118,14 @@ public class ConfigInfo {
      *            The list of ConfigInfos
      * @return The list of configuration/component names
      */
-    public static Collection<String> names(Collection<ConfigInfo> infos) {
+    public static List<String> names(Collection<ConfigInfo> infos) {
         if (infos == null || infos.isEmpty()) {
             return Collections.emptyList();
         }
 
         return infos.stream()
                 .map(ConfigInfo::name)
-                .collect(Collectors.toCollection(ArrayList::new));
+                .collect(Collectors.toList());
     }
     
     /**
@@ -134,8 +136,8 @@ public class ConfigInfo {
      *            The list of ConfigInfos
      * @return The list of configuration/component descriptions without the current one
      */
-    public static Collection<String> descriptionsWithoutCurrent(Collection<ConfigInfo> infos) {
-        Collection<String> filteredDescriptions = descriptions(infos);
+    public static List<String> descriptionsWithoutCurrent(Collection<ConfigInfo> infos) {
+        List<String> filteredDescriptions = descriptions(infos);
         filteredDescriptions.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().description());
         return filteredDescriptions;
     }
@@ -147,14 +149,49 @@ public class ConfigInfo {
      *            The list of ConfigInfos
      * @return The list of configuration/component descriptions
      */
-    public static Collection<String> descriptions(Collection<ConfigInfo> infos) {
+    public static List<String> descriptions(Collection<ConfigInfo> infos) {
         if (infos == null) {
             return Collections.emptyList();
         }
 
         return infos.stream()
                 .map(ConfigInfo::description)
-                .collect(Collectors.toCollection(ArrayList::new));
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Returns a sorted map with the names and descriptions of all ConfigInfo objects passed in
+     * excluding that of the current configuration or component.
+     * 
+     * @param infos
+     *            The list of ConfigInfos
+     * @return The sorted map of configuration/component descriptions without the current one
+     */
+    public static SortedMap<String, String> namesAndDescriptionsWithoutCurrent(Collection<ConfigInfo> infos) {
+        SortedMap<String, String> filteredNamesAndDescriptions = namesAndDescriptions(infos);
+        filteredNamesAndDescriptions.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().description());
+        return filteredNamesAndDescriptions;
+    }
+    
+    /**
+     * Returns a sorted map with the names and descriptions of all ConfigInfo objects passed in.
+     * 
+     * @param infos
+     *            The list of ConfigInfos
+     * @return The sorted map of configuration/component descriptions without the current one
+     */
+    public static SortedMap<String, String> namesAndDescriptions(Collection<ConfigInfo> infos) {
+    	if (infos == null || infos.isEmpty()) {
+    		return new TreeMap<String, String>();
+    	}
+    	
+    	SortedMap<String, String> result = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+    	
+    	for (ConfigInfo config : infos) {
+    		result.put(config.name, config.description);
+    	}
+    	
+    	return result;
     }
     
     /**

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -133,6 +133,40 @@ public class ConfigInfo {
     }
     
     /**
+     * Returns just the descriptions of all config info objects passed in excluding
+     * that of the current config.
+     * 
+     * @param infos
+     *            The list of ConfigInfos
+     * @return The list of config descriptions without that of the current config
+     */
+    public static Collection<String> descriptionsWithoutCurrent(Collection<ConfigInfo> infos) {
+        Collection<String> filteredDescriptions = descriptions(infos);
+        filteredDescriptions.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().description());
+        return filteredDescriptions;
+    }
+    
+    /**
+     * Reduces a list of ConfigInfo objects to a list of their descriptions only.
+     * 
+     * @param infos
+     *            The list of ConfigInfos
+     * @return The list of config descriptions
+     */
+    public static Collection<String> descriptions(Collection<ConfigInfo> infos) {
+        if (infos == null) {
+            return Collections.emptyList();
+        }
+
+        return Lists.newArrayList(Iterables.transform(infos, new Function<ConfigInfo, String>() {
+            @Override
+            public String apply(ConfigInfo info) {
+                return info.description();
+            }
+        }));
+    }
+    
+    /**
      * returns config/Component names and its protection status.
      * @param infos
      * @return collection of Pair i.e config/comp name and its proteciton flag

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -150,7 +150,7 @@ public class ConfigInfo {
      * @return The list of configuration/component descriptions
      */
     public static List<String> descriptions(Collection<ConfigInfo> infos) {
-        if (infos == null) {
+        if (infos == null || infos.isEmpty()) {
             return Collections.emptyList();
         }
 
@@ -200,7 +200,7 @@ public class ConfigInfo {
      * @return collection of pair i.e configuration/component name and its protection flag
      */
     public static Map<String, Boolean> mapNamesWithTheirProtectionFlag(Collection<ConfigInfo> infos) {
-        if (infos == null) {
+        if (infos == null || infos.isEmpty()) {
             return Collections.emptyMap();
         }
         Map<String, Boolean> namesWithProtectionFlag = new HashMap<String, Boolean>();

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -158,12 +159,9 @@ public class ConfigInfo {
             return Collections.emptyList();
         }
 
-        return Lists.newArrayList(Iterables.transform(infos, new Function<ConfigInfo, String>() {
-            @Override
-            public String apply(ConfigInfo info) {
-                return info.description();
-            }
-        }));
+        return infos.stream()
+                .map(ConfigInfo::description)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
     
     /**

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -27,10 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
 
 /**
@@ -118,10 +114,10 @@ public class ConfigInfo {
      * 
      * @param infos
      *            The list of ConfigInfos
-     * @return The list of config names
+     * @return The list of configuration/component names
      */
     public static Collection<String> names(Collection<ConfigInfo> infos) {
-        if (infos == null) {
+        if (infos == null || infos.isEmpty()) {
             return Collections.emptyList();
         }
 
@@ -131,12 +127,12 @@ public class ConfigInfo {
     }
     
     /**
-     * Returns just the descriptions of all config info objects passed in excluding
-     * that of the current config.
+     * Returns just the descriptions of all ConfigInfo objects passed in excluding
+     * that of the current configuration/component.
      * 
      * @param infos
      *            The list of ConfigInfos
-     * @return The list of config descriptions without that of the current config
+     * @return The list of configuration/component descriptions without the current one
      */
     public static Collection<String> descriptionsWithoutCurrent(Collection<ConfigInfo> infos) {
         Collection<String> filteredDescriptions = descriptions(infos);
@@ -149,7 +145,7 @@ public class ConfigInfo {
      * 
      * @param infos
      *            The list of ConfigInfos
-     * @return The list of config descriptions
+     * @return The list of configuration/component descriptions
      */
     public static Collection<String> descriptions(Collection<ConfigInfo> infos) {
         if (infos == null) {
@@ -162,9 +158,9 @@ public class ConfigInfo {
     }
     
     /**
-     * returns config/Component names and its protection status.
+     * returns configuration/component names and its protection status.
      * @param infos
-     * @return collection of Pair i.e config/comp name and its proteciton flag
+     * @return collection of pair i.e configuration/component name and its protection flag
      */
     public static Map<String, Boolean> mapNamesWithTheirProtectionFlag(Collection<ConfigInfo> infos) {
         if (infos == null) {

--- a/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/SynopticInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic/src/uk/ac/stfc/isis/ibex/synoptic/SynopticInfo.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.synoptic;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import uk.ac.stfc.isis.ibex.synoptic.internal.Variables;
@@ -85,10 +86,10 @@ public class SynopticInfo {
      * @param infos The synoptics to get the names from.
      * @return A list of synoptic names.
      */
-	public static Collection<String> names(Collection<SynopticInfo> infos) {
-		if (infos == null) {
-			return Collections.emptyList();
-		}
+	public static List<String> names(Collection<SynopticInfo> infos) {
+        if (infos == null || infos.isEmpty()) {
+            return Collections.emptyList();
+        }
 		
 		return infos.stream().map(s -> s.name()).collect(Collectors.toList());		
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/DeleteComponentsDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/DeleteComponentsDialog.java
@@ -22,6 +22,7 @@
 package uk.ac.stfc.isis.ibex.ui.configserver.dialogs;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.swt.graphics.Image;
@@ -61,7 +62,7 @@ public class DeleteComponentsDialog extends MultipleConfigsSelectionDialog {
      * @param names The component names
      */
     @Override
-    protected void setItems(String[] names) {
+    protected void setItems(List<String> names) {
         super.setItems(names);
         for (TableItem item : items.getItems()) {
             if (compsInUse.contains(item.getText())) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
@@ -113,7 +115,7 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
        /* The following ensures that double clicking on the description/white space doesn't
         * launch the process using a description/null as the name.
         */    
-       List<String> names = (List<String>) ConfigInfo.names(available);
+       List<String> names = ConfigInfo.names(available);
        boolean anyMatch = selectedItems.stream().anyMatch(names::contains);
        if (anyMatch) {
     	   selected = asString(items.getSelection());
@@ -129,18 +131,14 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
         List<String> columnNames = Arrays.asList("Name", "Description");
         items = createTable(container, SWT.BORDER | SWT.V_SCROLL | extraListOptions, columnNames);
 
-        List<String> names;
-        List<String> descriptions;
+        SortedMap<String, String> namesAndDescriptions = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
         if (includeCurrent) {
-            names = (List<String>) ConfigInfo.names(available);
-            descriptions = (List<String>) ConfigInfo.descriptions(available);
+            namesAndDescriptions = ConfigInfo.namesAndDescriptions(available);
         } else {
-            names = (List<String>) ConfigInfo.namesWithoutCurrent(available);
-            descriptions = (List<String>) ConfigInfo.descriptionsWithoutCurrent(available);
+        	namesAndDescriptions = ConfigInfo.namesAndDescriptionsWithoutCurrent(available);
         }
-		names.sort(String.CASE_INSENSITIVE_ORDER);
-		
-		setMultipleColumnItems(names, descriptions, compOrConfigNamesWithFlags);
+        
+		setMultipleColumnItems(namesAndDescriptions, compOrConfigNamesWithFlags);
 		
 		Group group = new Group(container, SWT.SHADOW_IN);
 		group.setLayout(new RowLayout(SWT.HORIZONTAL));

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
@@ -20,8 +20,8 @@
 package uk.ac.stfc.isis.ibex.ui.configserver.dialogs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -114,7 +114,7 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
         * launch the process using a description/null as the name.
         */    
        List<String> names = (List<String>) ConfigInfo.names(available);
-       boolean anyMatch = selectedItems.stream().anyMatch(new HashSet<>(names)::contains);
+       boolean anyMatch = selectedItems.stream().anyMatch(names::contains);
        if (anyMatch) {
     	   selected = asString(items.getSelection());
     	   super.okPressed();
@@ -126,7 +126,8 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
 	    
 		Label lblSelect = new Label(container, SWT.NONE);
         lblSelect.setText("Select " + getTypeString() + ":");
-        items = createTable(container, SWT.BORDER | SWT.V_SCROLL | extraListOptions);
+        List<String> columnNames = Arrays.asList("Name", "Description");
+        items = createTable(container, SWT.BORDER | SWT.V_SCROLL | extraListOptions, columnNames);
 
         List<String> names;
         List<String> descriptions;

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.ui.configserver.dialogs;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -105,11 +106,20 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
 		return selected;
 	}
 
-	@Override
-	protected void okPressed() {
-        selected = asString(items.getSelection());
-		super.okPressed();
-	}
+    @Override
+   protected void okPressed() {
+       Collection<String> selectedItems = asString(items.getSelection());
+       
+       /* The following ensures that double clicking on the description/white space doesn't
+        * launch the process using a description/null as the name.
+        */    
+       List<String> names = (List<String>) ConfigInfo.names(available);
+       boolean anyMatch = selectedItems.stream().anyMatch(new HashSet<>(names)::contains);
+       if (anyMatch) {
+    	   selected = asString(items.getSelection());
+    	   super.okPressed();
+       }
+   }
 
 	@Override
     protected void createSelection(Composite container) {
@@ -117,7 +127,6 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
 		Label lblSelect = new Label(container, SWT.NONE);
         lblSelect.setText("Select " + getTypeString() + ":");
         items = createTable(container, SWT.BORDER | SWT.V_SCROLL | extraListOptions);
-        
 
         List<String> names;
         List<String> descriptions;

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
@@ -20,8 +20,8 @@
 package uk.ac.stfc.isis.ibex.ui.configserver.dialogs;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jface.resource.JFaceResources;
@@ -119,16 +119,16 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
         items = createTable(container, SWT.BORDER | SWT.V_SCROLL | extraListOptions);
         
 
-        String[] names;
-        String[] descriptions;
+        List<String> names;
+        List<String> descriptions;
         if (includeCurrent) {
-            names = ConfigInfo.names(available).toArray(new String[0]);
-            descriptions = ConfigInfo.descriptions(available).toArray(new String[0]);
+            names = (List<String>) ConfigInfo.names(available);
+            descriptions = (List<String>) ConfigInfo.descriptions(available);
         } else {
-            names = ConfigInfo.namesWithoutCurrent(available).toArray(new String[0]);
-            descriptions = ConfigInfo.descriptionsWithoutCurrent(available).toArray(new String[0]);
+            names = (List<String>) ConfigInfo.namesWithoutCurrent(available);
+            descriptions = (List<String>) ConfigInfo.descriptionsWithoutCurrent(available);
         }
-		Arrays.sort(names, String.CASE_INSENSITIVE_ORDER);
+		names.sort(String.CASE_INSENSITIVE_ORDER);
 		
 		setMultipleColumnItems(names, descriptions, compOrConfigNamesWithFlags);
 		

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/MultipleConfigsSelectionDialog.java
@@ -117,16 +117,20 @@ public class MultipleConfigsSelectionDialog extends SelectionDialog {
 		Label lblSelect = new Label(container, SWT.NONE);
         lblSelect.setText("Select " + getTypeString() + ":");
         items = createTable(container, SWT.BORDER | SWT.V_SCROLL | extraListOptions);
+        
 
         String[] names;
+        String[] descriptions;
         if (includeCurrent) {
             names = ConfigInfo.names(available).toArray(new String[0]);
+            descriptions = ConfigInfo.descriptions(available).toArray(new String[0]);
         } else {
             names = ConfigInfo.namesWithoutCurrent(available).toArray(new String[0]);
+            descriptions = ConfigInfo.descriptionsWithoutCurrent(available).toArray(new String[0]);
         }
 		Arrays.sort(names, String.CASE_INSENSITIVE_ORDER);
 		
-		setItems(names, compOrConfigNamesWithFlags);
+		setMultipleColumnItems(names, descriptions, compOrConfigNamesWithFlags);
 		
 		Group group = new Group(container, SWT.SHADOW_IN);
 		group.setLayout(new RowLayout(SWT.HORIZONTAL));

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/RecentConfigSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/RecentConfigSelectionDialog.java
@@ -23,18 +23,23 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.logging.log4j.Logger;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.TableItem;
 
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.ui.dialogs.SelectionDialog;
 
 	/**
  * Dialog for asking the user to select a multiple configurations or components.
  */
 public class RecentConfigSelectionDialog extends SelectionDialog {
+	
+	private static final Logger LOG = IsisLog.getLogger(RecentConfigSelectionDialog.class);
+	
      /**
      * The collection of the available configurations/components for the user to
      * select from.
@@ -127,7 +132,8 @@ public class RecentConfigSelectionDialog extends SelectionDialog {
          this.items.clearAll();
          int i = 0;
          String[] columns = new String[2];
-         if (timestamps.size() == 0) {
+         if (timestamps.size() != names.size()) {
+             LOG.error("Got mismatched timestamps and names");
              setItems(names);
          } else {
              for (String name : names) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/RecentConfigSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/RecentConfigSelectionDialog.java
@@ -19,29 +19,22 @@
 package uk.ac.stfc.isis.ibex.ui.configserver.dialogs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 
-import org.eclipse.jface.layout.TableColumnLayout;
-import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.swt.widgets.Table;
-import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 
-import uk.ac.stfc.isis.ibex.ui.dialogs.BasicSelectionDialog;
+import uk.ac.stfc.isis.ibex.ui.dialogs.SelectionDialog;
 
 	/**
  * Dialog for asking the user to select a multiple configurations or components.
  */
-public class RecentConfigSelectionDialog extends BasicSelectionDialog {
+public class RecentConfigSelectionDialog extends SelectionDialog {
      /**
      * The collection of the available configurations/components for the user to
      * select from.
@@ -96,7 +89,7 @@ public class RecentConfigSelectionDialog extends BasicSelectionDialog {
         /* The following ensures that double clicking on a time stamp/white space doesn't
          * launch the load process using a time stamp/null as a configuration name.
          */
-        boolean anyMatch = selectedItems.stream().anyMatch(new HashSet<>(recentConfigs)::contains);
+        boolean anyMatch = selectedItems.stream().anyMatch(recentConfigs::contains);
         if (anyMatch) {
         	selectedConfigs = asString(items.getSelection());
         	super.okPressed();
@@ -107,7 +100,8 @@ public class RecentConfigSelectionDialog extends BasicSelectionDialog {
     protected void createSelection(Composite container) {
     	 Label lblSelect = new Label(container, SWT.NONE);
          lblSelect.setText("Select configuration:");
-         items = createTable(container, SWT.BORDER | SWT.V_SCROLL | extraListOptions);
+         List<String> columnNames = Arrays.asList("Configuration", "Last updated");
+         items = createTable(container, SWT.BORDER | SWT.V_SCROLL | extraListOptions, columnNames);
          setMultipleColumnItems(recentConfigs, recentTimestamps);
      }
       /**
@@ -119,46 +113,7 @@ public class RecentConfigSelectionDialog extends BasicSelectionDialog {
      public String selectedConfig() {
          return selectedConfigs.toArray(new String[1])[0];
      }
-      /**
-      * Creates and returns a table pre-configured with a two columned layout.
-      * 
-      * @param parent
-      *            The parent composite
-      * @param style
-      *            The style settings
-      * @return The table object
-      */
-     @Override
-     protected Table createTable(Composite parent, int style) {
-		Composite tableComposite = new Composite(parent, SWT.NONE);
-		tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		Table table = new Table(tableComposite, style | SWT.FULL_SELECTION);
-		table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-		TableColumnLayout tableColumnLayout = new TableColumnLayout();
-		TableColumn firstColumn = new TableColumn(table, SWT.NONE);
-		tableColumnLayout.setColumnData(firstColumn, new ColumnWeightData(1));
-		firstColumn.setText("Configuration");
-		firstColumn.setResizable(true);
-		 
-		TableColumn secondColumn = new TableColumn(table, SWT.NONE);
-		tableColumnLayout.setColumnData(secondColumn, new ColumnWeightData(1));
-		secondColumn.setText("Last modified");
-		secondColumn.setResizable(true);
-		tableComposite.setLayout(tableColumnLayout);
-		table.setHeaderVisible(true);
-		         
-		         
-		table.addSelectionListener(new SelectionAdapter() {
-              @Override
-             public void widgetSelected(SelectionEvent e) {
-                 int index = table.getSelectionIndex();
-                 TableItem item = table.getSelection()[0];
-             }
-             
-         });
-         
-          return table;
-     }
+     
       /**
       * Sets a list of configurations and their time stamps as items in a
       * selection table with two columns.

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/RecentConfigSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/RecentConfigSelectionDialog.java
@@ -109,13 +109,7 @@ public class RecentConfigSelectionDialog extends BasicSelectionDialog {
     	 Label lblSelect = new Label(container, SWT.NONE);
          lblSelect.setText("Select configuration:");
          items = createTable(container, SWT.BORDER | SWT.V_SCROLL | extraListOptions);
-         setMultipleColumnItems(configNamesToArray(), timestampsToArray());
-     }
-      private String[] configNamesToArray() {
-         return recentConfigs.toArray(new String[0]);
-     }
-      private String[] timestampsToArray() {
-         return recentTimestamps.toArray(new String[0]);
+         setMultipleColumnItems(recentConfigs, recentTimestamps);
      }
       /**
       * Get the name of the configuration/component that the user has chosen.
@@ -175,26 +169,29 @@ public class RecentConfigSelectionDialog extends BasicSelectionDialog {
       * @param timestamps
       *            The time stamps for the recent configurations.
       */
-     protected void setMultipleColumnItems(String[] names, String[] timestamps) {
+     protected void setMultipleColumnItems(List<String> names, List<String> timestamps) {
          this.items.clearAll();
          int i = 0;
          String[] columns = new String[2];
-         if (timestamps.length == 0) {
+         if (timestamps.size() == 0) {
              setItems(names);
          } else {
              for (String name : names) {
                  TableItem item = new TableItem(this.items, SWT.NONE);
                  columns[0] = name;
-                 columns[1] = timestamps[i];
+                 columns[1] = timestamps.get(i);
                  item.setText(columns);
                  
                  i++;
              }
          }
-         i = 0;
      }
-      @Override
-     protected boolean isResizable() {
-         return true;
-     }
+     
+	 /**
+	  * {@inheritDoc}
+	  */
+	 @Override
+	 protected boolean isResizable() {
+	     return true;
+	 }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/RecentConfigSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/dialogs/RecentConfigSelectionDialog.java
@@ -18,8 +18,9 @@
 
 package uk.ac.stfc.isis.ibex.ui.configserver.dialogs;
 
- import java.util.ArrayList;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import org.eclipse.jface.layout.TableColumnLayout;
@@ -92,17 +93,15 @@ public class RecentConfigSelectionDialog extends BasicSelectionDialog {
     protected void okPressed() {
         Collection<String> selectedItems = asString(items.getSelection());
         
-        /* The following ensures that double clicking on a time stamp doesn't
-         * launch the load process using a time stamp as a config name.
+        /* The following ensures that double clicking on a time stamp/white space doesn't
+         * launch the load process using a time stamp/null as a configuration name.
          */
-        for (String item : selectedItems) {
-            for (String configName : recentConfigs) {
-                if (item.equals(configName)) {
-                    selectedConfigs = asString(items.getSelection());
-                    super.okPressed();
-                }
-            }
+        boolean anyMatch = selectedItems.stream().anyMatch(new HashSet<>(recentConfigs)::contains);
+        if (anyMatch) {
+        	selectedConfigs = asString(items.getSelection());
+        	super.okPressed();
         }
+        
     }
      @Override
     protected void createSelection(Composite container) {
@@ -131,25 +130,25 @@ public class RecentConfigSelectionDialog extends BasicSelectionDialog {
       */
      @Override
      protected Table createTable(Composite parent, int style) {
-         Composite tableComposite = new Composite(parent, SWT.NONE);
-         tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-         Table table = new Table(tableComposite, style | SWT.FULL_SELECTION);
-         table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-          TableColumnLayout tableColumnLayout = new TableColumnLayout();
-          TableColumn firstColumn = new TableColumn(table, SWT.NONE);
-         tableColumnLayout.setColumnData(firstColumn, new ColumnWeightData(1));
-         firstColumn.setText("Configuration");
-         firstColumn.setResizable(true);
-         
-         TableColumn secondColumn = new TableColumn(table, SWT.NONE);
-         tableColumnLayout.setColumnData(secondColumn, new ColumnWeightData(1));
-         secondColumn.setText("Last modified");
-         secondColumn.setResizable(true);
-          tableComposite.setLayout(tableColumnLayout);
-         table.setHeaderVisible(true);
-         
-         
-         table.addSelectionListener(new SelectionAdapter() {
+		Composite tableComposite = new Composite(parent, SWT.NONE);
+		tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		Table table = new Table(tableComposite, style | SWT.FULL_SELECTION);
+		table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+		TableColumnLayout tableColumnLayout = new TableColumnLayout();
+		TableColumn firstColumn = new TableColumn(table, SWT.NONE);
+		tableColumnLayout.setColumnData(firstColumn, new ColumnWeightData(1));
+		firstColumn.setText("Configuration");
+		firstColumn.setResizable(true);
+		 
+		TableColumn secondColumn = new TableColumn(table, SWT.NONE);
+		tableColumnLayout.setColumnData(secondColumn, new ColumnWeightData(1));
+		secondColumn.setText("Last modified");
+		secondColumn.setResizable(true);
+		tableComposite.setLayout(tableColumnLayout);
+		table.setHeaderVisible(true);
+		         
+		         
+		table.addSelectionListener(new SelectionAdapter() {
               @Override
              public void widgetSelected(SelectionEvent e) {
                  int index = table.getSelectionIndex();

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/MultipleSynopticsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/MultipleSynopticsSelectionDialog.java
@@ -82,7 +82,7 @@ public class MultipleSynopticsSelectionDialog extends SelectionDialog {
 
         List<String> columnNames = Arrays.asList("Name");
         items = createTable(container, SWT.BORDER | SWT.V_SCROLL | SWT.MULTI, columnNames);
-        List<String> names = (List<String>) SynopticInfo.names(available);
+        List<String> names = SynopticInfo.names(available);
         setItems(names);
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/MultipleSynopticsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/MultipleSynopticsSelectionDialog.java
@@ -20,6 +20,7 @@
 package uk.ac.stfc.isis.ibex.ui.synoptic.editor.dialogs;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -79,7 +80,8 @@ public class MultipleSynopticsSelectionDialog extends SelectionDialog {
 		Label lblSelect = new Label(container, SWT.NONE);
         lblSelect.setText("Select synoptics:");
 
-        items = createTable(container, SWT.BORDER | SWT.V_SCROLL | SWT.MULTI);
+        List<String> columnNames = Arrays.asList("Name");
+        items = createTable(container, SWT.BORDER | SWT.V_SCROLL | SWT.MULTI, columnNames);
         List<String> names = (List<String>) SynopticInfo.names(available);
         setItems(names);
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/MultipleSynopticsSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/MultipleSynopticsSelectionDialog.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.ui.synoptic.editor.dialogs;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -79,7 +80,8 @@ public class MultipleSynopticsSelectionDialog extends SelectionDialog {
         lblSelect.setText("Select synoptics:");
 
         items = createTable(container, SWT.BORDER | SWT.V_SCROLL | SWT.MULTI);
-        setItems(SynopticInfo.names(available).toArray(new String[0]));
+        List<String> names = (List<String>) SynopticInfo.names(available);
+        setItems(names);
 	}
 	
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticSelectionDialog.java
@@ -23,6 +23,7 @@ package uk.ac.stfc.isis.ibex.ui.synoptic;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -78,9 +79,9 @@ public class SynopticSelectionDialog extends SelectionDialog {
         List<String> columnNames = Arrays.asList("Name");
         items = createTable(container, SWT.BORDER | SWT.V_SCROLL, columnNames);
 
-		List<String> names = (List<String>) SynopticInfo.names(available);
-		names.sort(String.CASE_INSENSITIVE_ORDER);
-
+        List<String> names = SynopticInfo.names(available).stream()
+						    	.sorted(String.CASE_INSENSITIVE_ORDER)
+						    	.collect(Collectors.toList());
         setItems(names);
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticSelectionDialog.java
@@ -20,6 +20,7 @@
 
 package uk.ac.stfc.isis.ibex.ui.synoptic;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -74,7 +75,8 @@ public class SynopticSelectionDialog extends SelectionDialog {
 		Label lblSelect = new Label(container, SWT.NONE);
         lblSelect.setText("Select synoptic:");
 		
-        items = createTable(container, SWT.BORDER | SWT.V_SCROLL);
+        List<String> columnNames = Arrays.asList("Name");
+        items = createTable(container, SWT.BORDER | SWT.V_SCROLL, columnNames);
 
 		List<String> names = (List<String>) SynopticInfo.names(available);
 		names.sort(String.CASE_INSENSITIVE_ORDER);

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/SynopticSelectionDialog.java
@@ -20,8 +20,8 @@
 
 package uk.ac.stfc.isis.ibex.ui.synoptic;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -76,8 +76,8 @@ public class SynopticSelectionDialog extends SelectionDialog {
 		
         items = createTable(container, SWT.BORDER | SWT.V_SCROLL);
 
-		String[] names = SynopticInfo.names(available).toArray(new String[0]);
-		Arrays.sort(names, String.CASE_INSENSITIVE_ORDER);
+		List<String> names = (List<String>) SynopticInfo.names(available);
+		names.sort(String.CASE_INSENSITIVE_ORDER);
 
         setItems(names);
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
@@ -191,4 +191,38 @@ public abstract class BasicSelectionDialog extends Dialog {
             item.setText(name);
         }
     }
+    
+    /**
+    * Sets a list of configuration names and their description as items in a
+    * selection table with two columns.
+    * 
+    * @param names
+    *            The names of the recent configurations.
+    * @param descriptions
+    *            The descriptions for the recent configurations.            
+    * @param configNamesWithFlags
+    *             Names of the configuration and its protection flag
+    */
+   protected void setMultipleColumnItems(String[] names, String[] descriptions, Map<String, Boolean> configNamesWithFlags) {
+       this.items.clearAll();
+       int i = 0;
+       String[] columns = new String[2];
+       if (descriptions.length == 0) {
+           setItems(names, configNamesWithFlags);
+       } else {
+           for (String name : names) {
+               TableItem item = new TableItem(this.items, SWT.NONE);
+               columns[0] = name;
+               columns[1] = descriptions[i];
+               item.setText(columns);
+               if (configNamesWithFlags.get(name)) {
+                   item.setImage(JFaceResources.
+                           getImage(DLG_IMG_MESSAGE_WARNING));   
+               }
+               
+               i++;
+           }
+       }
+       i = 0;
+   }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.ui.dialogs;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jface.dialogs.Dialog;
@@ -40,6 +41,9 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 
+import org.apache.logging.log4j.Logger;
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+
 /**
  * Generic selection dialog class.
  */
@@ -48,6 +52,8 @@ public abstract class BasicSelectionDialog extends Dialog {
 
     private String title;
 
+	private static final Logger LOG = IsisLog.getLogger(BasicSelectionDialog.class);
+    
     /**
      * The single column table for displaying the list of items to select from.
      */
@@ -166,7 +172,7 @@ public abstract class BasicSelectionDialog extends Dialog {
      * @param configNamesWithFlags
      *            Names of the configuration and its protection flag
      */
-    protected void setItems(String[] names, Map<String, Boolean> configNamesWithFlags) {
+    protected void setItems(List<String> names, Map<String, Boolean> configNamesWithFlags) {
         this.items.clearAll();
         for (String name : names) {
             TableItem item = new TableItem(this.items, SWT.NONE);
@@ -184,7 +190,7 @@ public abstract class BasicSelectionDialog extends Dialog {
      * @param names
      *            The names
      */
-    protected void setItems(String[] names) {
+    protected void setItems(List<String> names) {
         this.items.clearAll();
         for (String name : names) {
             TableItem item = new TableItem(this.items, SWT.NONE);
@@ -203,18 +209,18 @@ public abstract class BasicSelectionDialog extends Dialog {
     * @param configNamesWithFlags
     *             Names of the configuration and its protection flag
     */
-   protected void setMultipleColumnItems(String[] names, String[] descriptions, Map<String, Boolean> configNamesWithFlags) {
+   protected void setMultipleColumnItems(List<String> names, List<String> descriptions, Map<String, Boolean> configNamesWithFlags) {
        this.items.clearAll();
        int i = 0;
        String[] columns = new String[2];
-       if (descriptions.length != names.length) {
+       if (descriptions.size() != names.size()) {
            LOG.error("Got mismatched descriptions and names");
            setItems(names, configNamesWithFlags);
        } else {
            for (String name : names) {
                TableItem item = new TableItem(this.items, SWT.NONE);
                columns[0] = name;
-               columns[1] = descriptions[i];
+               columns[1] = descriptions.get(i);
                item.setText(columns);
                if (configNamesWithFlags.get(name)) {
                    item.setImage(JFaceResources.
@@ -224,6 +230,5 @@ public abstract class BasicSelectionDialog extends Dialog {
                i++;
            }
        }
-       i = 0;
    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
@@ -55,7 +55,7 @@ public abstract class BasicSelectionDialog extends Dialog {
 	private static final Logger LOG = IsisLog.getLogger(BasicSelectionDialog.class);
     
     /**
-     * The single column table for displaying the list of items to select from.
+     * A single or multiple-column table for displaying the list of items to select from.
      */
     public Table items;
 
@@ -153,7 +153,7 @@ public abstract class BasicSelectionDialog extends Dialog {
 
     /**
      * Abstract method that creates and returns a table pre-configured with
-     * single column layout.
+     * a single or multiple column layout.
      * 
      * @param parent
      *            The parent composite
@@ -161,7 +161,7 @@ public abstract class BasicSelectionDialog extends Dialog {
      *            The style settings
      * @return The table object
      */
-    protected abstract Table createTable(Composite parent, int style);
+    protected abstract Table createTable(Composite parent, int style, List<String> columnNames);
 
     /**
      * Sets a list of names as items in the selection table specifically for deleting config dialog.

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
@@ -207,7 +207,8 @@ public abstract class BasicSelectionDialog extends Dialog {
        this.items.clearAll();
        int i = 0;
        String[] columns = new String[2];
-       if (descriptions.length == 0) {
+       if (descriptions.length != names.length) {
+           LOG.error("Got mismatched descriptions and names");
            setItems(names, configNamesWithFlags);
        } else {
            for (String name : names) {

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedMap;
 
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
@@ -41,9 +43,6 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 
-import org.apache.logging.log4j.Logger;
-import uk.ac.stfc.isis.ibex.logger.IsisLog;
-
 /**
  * Generic selection dialog class.
  */
@@ -51,8 +50,6 @@ import uk.ac.stfc.isis.ibex.logger.IsisLog;
 public abstract class BasicSelectionDialog extends Dialog {
 
     private String title;
-
-	private static final Logger LOG = IsisLog.getLogger(BasicSelectionDialog.class);
     
     /**
      * A single or multiple-column table for displaying the list of items to select from.
@@ -159,6 +156,8 @@ public abstract class BasicSelectionDialog extends Dialog {
      *            The parent composite
      * @param style
      *            The style settings
+     * @param columnNames
+     * 			  The names (and number) of table columns
      * @return The table object
      */
     protected abstract Table createTable(Composite parent, int style, List<String> columnNames);
@@ -202,32 +201,24 @@ public abstract class BasicSelectionDialog extends Dialog {
     * Sets a list of configuration names and their description as items in a
     * selection table with two columns.
     * 
-    * @param names
-    *            The names of the recent configurations.
-    * @param descriptions
-    *            The descriptions for the recent configurations.            
+    * @param namesAndDescriptions
+    *             A map containing the names and descriptions of the recent configurations in key/value pairs.      
     * @param configNamesWithFlags
     *             Names of the configuration and its protection flag
     */
-   protected void setMultipleColumnItems(List<String> names, List<String> descriptions, Map<String, Boolean> configNamesWithFlags) {
+   protected void setMultipleColumnItems(SortedMap<String, String> namesAndDescriptions, Map<String, Boolean> configNamesWithFlags) {
        this.items.clearAll();
-       int i = 0;
        String[] columns = new String[2];
-       if (descriptions.size() != names.size()) {
-           LOG.error("Got mismatched descriptions and names");
-           setItems(names, configNamesWithFlags);
-       } else {
-           for (String name : names) {
-               TableItem item = new TableItem(this.items, SWT.NONE);
-               columns[0] = name;
-               columns[1] = descriptions.get(i);
-               item.setText(columns);
-               if (configNamesWithFlags.get(name)) {
-                   item.setImage(JFaceResources.
-                           getImage(DLG_IMG_MESSAGE_WARNING));   
-               }
-               
-               i++;
+
+       for (Entry<String, String> entry : namesAndDescriptions.entrySet()) {
+           TableItem item = new TableItem(this.items, SWT.NONE);
+           columns[0] = entry.getKey();
+           columns[1] = entry.getValue();
+           
+           item.setText(columns);
+           if (configNamesWithFlags.get(entry.getKey())) {
+               item.setImage(JFaceResources.
+                       getImage(DLG_IMG_MESSAGE_WARNING));   
            }
        }
    }

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
@@ -89,6 +89,9 @@ public abstract class SelectionDialog extends BasicSelectionDialog {
 
     }
     
+    /**
+     * {@inheritDoc}
+     */
     @Override
    protected boolean isResizable() {
     	return true;

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
@@ -22,11 +22,15 @@ package uk.ac.stfc.isis.ibex.ui.dialogs;
 import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TableItem;
 
 /**
  * Generic selection dialog class.
@@ -42,9 +46,9 @@ public abstract class SelectionDialog extends BasicSelectionDialog {
     protected SelectionDialog(Shell parentShell, String title) {
         super(parentShell, title);
     }
-
+    
     /**
-     * Creates and returns a table pre-configured with single column layout.
+     * Creates and returns a table pre-configured with a two columned layout.
      * 
      * @param parent
      *            The parent composite
@@ -54,17 +58,39 @@ public abstract class SelectionDialog extends BasicSelectionDialog {
      */
     @Override
     protected Table createTable(Composite parent, int style) {
-        Composite tableComposite = new Composite(parent, SWT.NONE);
-        tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-        Table table = new Table(tableComposite, style);
-        table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+	    Composite tableComposite = new Composite(parent, SWT.NONE);
+	    tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+	    Table table = new Table(tableComposite, style);
+	    table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 
-        TableColumn singleColumn = new TableColumn(table, SWT.NONE);
-        TableColumnLayout tableColumnLayout = new TableColumnLayout();
-        tableColumnLayout.setColumnData(singleColumn, new ColumnWeightData(1));
+	    TableColumnLayout tableColumnLayout = new TableColumnLayout();
+
+	    TableColumn firstColumn = new TableColumn(table, SWT.NONE);
+        tableColumnLayout.setColumnData(firstColumn, new ColumnWeightData(1));
+        firstColumn.setText("Name");
+        firstColumn.setResizable(true);
+        firstColumn.setMoveable(true);
+        firstColumn.setToolTipText("Name of the configuration");
+
+        TableColumn secondColumn = new TableColumn(table, SWT.NONE);
+        tableColumnLayout.setColumnData(secondColumn, new ColumnWeightData(1));
+        secondColumn.setText("Description");
+        secondColumn.setResizable(true);
+        secondColumn.setMoveable(true);
+        secondColumn.setToolTipText("Description of the configuration");
+       
         tableComposite.setLayout(tableColumnLayout);
 
-        return table;
-    }
+        table.setHeaderVisible(true);
+        Display display = table.getDisplay();
+        table.setHeaderBackground(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND_GRADIENT));
 
+        return table;
+
+    }
+    
+    @Override
+   protected boolean isResizable() {
+    	return true;
+   }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
@@ -22,15 +22,11 @@ package uk.ac.stfc.isis.ibex.ui.dialogs;
 import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
-import org.eclipse.swt.widgets.TableItem;
 
 /**
  * Generic selection dialog class.
@@ -65,35 +61,31 @@ public abstract class SelectionDialog extends BasicSelectionDialog {
 
 	    TableColumnLayout tableColumnLayout = new TableColumnLayout();
 
-	    TableColumn firstColumn = new TableColumn(table, SWT.NONE);
-        tableColumnLayout.setColumnData(firstColumn, new ColumnWeightData(1));
-        firstColumn.setText("Name");
-        firstColumn.setResizable(true);
-        firstColumn.setMoveable(true);
-        firstColumn.setToolTipText("Name of the configuration");
+		TableColumn namesColumn = new TableColumn(table, SWT.NONE);
+		tableColumnLayout.setColumnData(namesColumn, new ColumnWeightData(1));
+		namesColumn.setText("Name");
+		namesColumn.setResizable(true);
+		namesColumn.setMoveable(true);
 
-        TableColumn secondColumn = new TableColumn(table, SWT.NONE);
-        tableColumnLayout.setColumnData(secondColumn, new ColumnWeightData(1));
-        secondColumn.setText("Description");
-        secondColumn.setResizable(true);
-        secondColumn.setMoveable(true);
-        secondColumn.setToolTipText("Description of the configuration");
+        TableColumn descriptionsColumn = new TableColumn(table, SWT.NONE);
+        tableColumnLayout.setColumnData(descriptionsColumn, new ColumnWeightData(1));
+        descriptionsColumn.setText("Description");
+        descriptionsColumn.setResizable(true);
+        descriptionsColumn.setMoveable(true);
        
         tableComposite.setLayout(tableColumnLayout);
 
         table.setHeaderVisible(true);
-        Display display = table.getDisplay();
-        table.setHeaderBackground(display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND_GRADIENT));
 
         return table;
 
     }
     
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-   protected boolean isResizable() {
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+    protected boolean isResizable() {
     	return true;
-   }
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
@@ -56,7 +56,7 @@ public abstract class SelectionDialog extends BasicSelectionDialog {
     protected Table createTable(Composite parent, int style) {
 	    Composite tableComposite = new Composite(parent, SWT.NONE);
 	    tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-	    Table table = new Table(tableComposite, style);
+	    Table table = new Table(tableComposite, style | SWT.FULL_SELECTION);
 	    table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 
 	    TableColumnLayout tableColumnLayout = new TableColumnLayout();
@@ -65,13 +65,11 @@ public abstract class SelectionDialog extends BasicSelectionDialog {
 		tableColumnLayout.setColumnData(namesColumn, new ColumnWeightData(1));
 		namesColumn.setText("Name");
 		namesColumn.setResizable(true);
-		namesColumn.setMoveable(true);
 
         TableColumn descriptionsColumn = new TableColumn(table, SWT.NONE);
         tableColumnLayout.setColumnData(descriptionsColumn, new ColumnWeightData(1));
         descriptionsColumn.setText("Description");
         descriptionsColumn.setResizable(true);
-        descriptionsColumn.setMoveable(true);
        
         tableComposite.setLayout(tableColumnLayout);
 

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/SelectionDialog.java
@@ -19,6 +19,8 @@
 
 package uk.ac.stfc.isis.ibex.ui.dialogs;
 
+import java.util.List;
+
 import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.jface.viewers.ColumnWeightData;
 import org.eclipse.swt.SWT;
@@ -44,16 +46,18 @@ public abstract class SelectionDialog extends BasicSelectionDialog {
     }
     
     /**
-     * Creates and returns a table pre-configured with a two columned layout.
+     * Creates and returns a table pre-configured with either a single or multiple-column layout.
      * 
      * @param parent
      *            The parent composite
      * @param style
      *            The style settings
+     * @param columnNames
+     * 			  The column name(s). If only one column, header will be hidden.
      * @return The table object
      */
     @Override
-    protected Table createTable(Composite parent, int style) {
+    protected Table createTable(Composite parent, int style, List<String> columnNames) {
 	    Composite tableComposite = new Composite(parent, SWT.NONE);
 	    tableComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 	    Table table = new Table(tableComposite, style | SWT.FULL_SELECTION);
@@ -61,22 +65,20 @@ public abstract class SelectionDialog extends BasicSelectionDialog {
 
 	    TableColumnLayout tableColumnLayout = new TableColumnLayout();
 
-		TableColumn namesColumn = new TableColumn(table, SWT.NONE);
-		tableColumnLayout.setColumnData(namesColumn, new ColumnWeightData(1));
-		namesColumn.setText("Name");
-		namesColumn.setResizable(true);
-
-        TableColumn descriptionsColumn = new TableColumn(table, SWT.NONE);
-        tableColumnLayout.setColumnData(descriptionsColumn, new ColumnWeightData(1));
-        descriptionsColumn.setText("Description");
-        descriptionsColumn.setResizable(true);
-       
+	    for (String name : columnNames) {
+	    	TableColumn column = new TableColumn(table, SWT.NONE);
+	    	tableColumnLayout.setColumnData(column, new ColumnWeightData(1));
+	    	column.setText(name);
+	    	column.setResizable(true);
+	    }
+	    
         tableComposite.setLayout(tableColumnLayout);
-
-        table.setHeaderVisible(true);
+        
+        if (columnNames.size() > 1) {
+        	table.setHeaderVisible(true);
+        }
 
         return table;
-
     }
     
 	/**


### PR DESCRIPTION
### Description of work

Added "Description" column to the configurations and component list selection dialog tables.
(Load/Edit/Delete)

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4800

### Acceptance criteria

* Name of configuration to show alongside the description before loading the configuration.

### Unit tests

N/A

### System tests

Manual testing: Open the Configurations Load/Edit/Delete or Components Edit/Delete selection dialogs, see that list table has two columns (Name and Description) of the config/component.

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

