### PR TITLE
Ticket4479 journal viewer page number control

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.journal.tests/src/uk/ac/stfc/isis/ibex/journal/tests/JournalCalcTotalPagesTest.java
+++ b/base/uk.ac.stfc.isis.ibex.journal.tests/src/uk/ac/stfc/isis/ibex/journal/tests/JournalCalcTotalPagesTest.java
@@ -1,0 +1,94 @@
+
+/*
+ * This file is part of the ISIS IBEX application. Copyright (C) 2012-2019
+ * Science & Technology Facilities Council. All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful. This program
+ * and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution. EXCEPT AS
+ * EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM AND
+ * ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND. See the Eclipse Public License v1.0 for more
+ * details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0 along with
+ * this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+package uk.ac.stfc.isis.ibex.journal.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.stfc.isis.ibex.journal.JournalModel;
+
+/**
+ * Test the Journal SQL Statement.
+ */
+@SuppressWarnings("checkstyle:methodname")
+public class JournalCalcTotalPagesTest {
+    
+	private JournalModel model;
+	
+    @Before
+    public void setUp() {
+        model = new JournalModel(null);
+    }
+
+    @Test
+    public void GIVEN_no_results_THEN_return_correct_total_pages() {
+    	// Arrange
+    	int resultsNumber = 0;
+    	
+    	// Act
+    	int totalPages = model.calcTotalPages(resultsNumber);
+    	
+    	// Assert
+    	assertEquals(1, totalPages);
+    	
+    }
+    
+    @Test
+    public void GIVEN_one_result_THEN_return_correct_total_pages() {
+    	// Arrange
+    	int resultsNumber = 1;
+    	
+    	// Act
+    	int totalPages = model.calcTotalPages(resultsNumber);
+    	
+    	// Assert
+    	assertEquals(1, totalPages);
+    	
+    }
+    
+    @Test
+    public void GIVEN_25_results_THEN_return_correct_total_pages() {
+    	// Arrange
+    	int resultsNumber = 25;
+    	
+    	// Act
+    	int totalPages = model.calcTotalPages(resultsNumber);
+    	
+    	// Assert
+    	assertEquals(1, totalPages);
+    	
+    }
+    
+    @Test
+    public void GIVEN_26_results_THEN_return_correct_total_pages() {
+    	// Arrange
+    	int resultsNumber = 26;
+    	
+    	// Act
+    	int totalPages = model.calcTotalPages(resultsNumber);
+    	
+    	// Assert
+    	assertEquals(2, totalPages);
+    	
+    }
+    
+}

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -308,7 +308,7 @@ public class JournalModel extends ModelObject {
     }
     
     public CompletableFuture<Void> setPageNumber(int pageNumber) {
-        this.pageNumber = pageNumber;
+    	updatePageNumber(pageNumber);
         return refresh();
     }
 

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -328,10 +328,14 @@ public class JournalModel extends ModelObject {
 		return PAGE_SIZE;
 	}
 	
+	/**
+	 * Calculates the maximum number of pages.
+	 * @param totalResults The number of results.
+	 * @return The max page number, lowest is 1.
+	 */
 	public int calcTotalPages(int totalResults) {
 		int returnVal = (int) Math.ceil(totalResults / (double) this.getPageSize());
-		if (returnVal == 0) { returnVal = 1; }
-		return returnVal;
+		return Math.max(returnVal, 1);
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -34,8 +34,6 @@ import java.util.concurrent.Executors;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jface.preference.IPreferenceStore;
 
-import java.sql.PreparedStatement;
-
 import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.journal.preferences.PreferenceConstants;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -193,7 +191,7 @@ public class JournalModel extends ModelObject {
     }
     
     private void updateRunsCount(Connection connection, JournalSearch search) throws SQLException {
-    	ResultSet rs = constructCountFieldsSQLQuery(connection, search).executeQuery();
+    	ResultSet rs = search.constructCountQuery(connection).executeQuery();
     	if (!rs.next()) {
     		throw new RuntimeException("No results returned from SQL query to count rows.");
     	}
@@ -201,19 +199,6 @@ public class JournalModel extends ModelObject {
 	    setTotalResults(rs.getInt(1));
 	    setResultsNumber(rs.getInt(1));
 	    rs.close();
-    }
-    
-    /**
-     * Constructs a SQL query which gets the number of runs available.
-     * 
-     * NOTE: Ensure that arbitrary strings cannot be inserted into this query, maliciously or 
-     * accidentally as that could lead to a SQL injection vulnerability.
-     * 
-     * @return a SQL prepared statement ready to be executed.
-     * @throws SQLException if a SQL exception occurred while preparing the statement
-     */
-    private PreparedStatement constructCountFieldsSQLQuery(Connection connection, JournalSearch search) throws SQLException {
-    	return search.constructCountQuery(connection);
     }
     
     /**

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -110,10 +110,11 @@ public class JournalModel extends ModelObject {
                 String password = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_PASSWORD);
 
                 connection = Rdb.connectToDatabase(schema, user, password).getConnection();
-
+                
                 setMessage("");
-                setLastUpdate(new Date());
                 searchUpdateRuns(connection, search);
+                setLastUpdate(new Date());
+
                 activeSearch = search;
             } catch (Exception ex) {
                 setMessage(Rdb.getError(ex).toString());
@@ -341,18 +342,18 @@ public class JournalModel extends ModelObject {
      * @return The number of total results and currently displayed entries.
      */
     public String getResultsInfo() {
-    	int startEntry;
-    	int endEntry;
+    	int entryFrom;
+    	int entryTo;
     	System.out.println("361:" + resultsNumber);
     	if (resultsNumber != 0) {
-	    	startEntry = (pageNumber - 1) * PAGE_SIZE + 1;
-	    	endEntry = startEntry + PAGE_SIZE - 1;
-	    	if (endEntry > resultsNumber) { endEntry = resultsNumber; }
+	    	entryFrom = (pageNumber - 1) * PAGE_SIZE + 1;
+	    	entryTo = entryFrom + PAGE_SIZE - 1;
+	    	if (entryTo > resultsNumber) { entryTo = resultsNumber; }
     	} else {
-    		startEntry = endEntry = 0;
+    		entryFrom = entryTo = 0;
     	}
     	
-    	return String.format("Entries %d-%d of %d", startEntry, endEntry, resultsNumber);
+    	return String.format("Entries %d-%d of %d", entryFrom, entryTo, resultsNumber);
     }
     
     /**

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -110,7 +110,7 @@ public class JournalModel extends ModelObject {
                 String password = preferenceStore.getString(PreferenceConstants.P_JOURNAL_SQL_PASSWORD);
 
                 connection = Rdb.connectToDatabase(schema, user, password).getConnection();
-                
+
                 setMessage("");
                 setLastUpdate(new Date());
                 searchUpdateRuns(connection, search);
@@ -137,6 +137,7 @@ public class JournalModel extends ModelObject {
      */
     public void clearModel() {
     	setRuns(Collections.<JournalRow>emptyList());
+    	this.updatePageNumber(1);
         lastUpdate = null;
     }
     
@@ -302,7 +303,11 @@ public class JournalModel extends ModelObject {
      * @param pageNumber The new page number.
      * @return a CompleteableFuture
      */
-    public CompletableFuture<Void> setPage(int pageNumber) {
+    public void updatePageNumber(int pageNumber) {
+		firePropertyChange("pageNumber", this.pageNumber, this.pageNumber = pageNumber);
+    }
+    
+    public CompletableFuture<Void> setPageNumber(int pageNumber) {
         this.pageNumber = pageNumber;
         return refresh();
     }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -323,8 +323,8 @@ public class JournalModel extends ModelObject {
     	return PAGE_SIZE;
     }
     
-    private int calcTotalPages(int totalResults) {
-    	int returnVal = (int) Math.ceil(totalResults / (double) PAGE_SIZE);
+    public int calcTotalPages(int totalResults) {
+    	int returnVal = (int) Math.ceil(totalResults / (double) this.getPageSize());
     	if (returnVal == 0) { returnVal = 1; }
     	return returnVal;
 	}

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -198,7 +198,7 @@ public class JournalModel extends ModelObject {
     		throw new RuntimeException("No results returned from SQL query to count rows.");
     	}
 
-	    setTotalResults(rs.getInt(1));
+    	setPageMax(calcTotalPages(rs.getInt(1)));
 	    setResultsNumber(rs.getInt(1));
 	    setResultsInfo(this.getResultsInfo());
 	    rs.close();
@@ -317,8 +317,10 @@ public class JournalModel extends ModelObject {
         return pageNumber;
     }
     
-    private void setTotalResults(int totalResults) {
-    	setPageMax((int) Math.ceil(totalResults / (double) PAGE_SIZE));
+    private int calcTotalPages(int totalResults) {
+    	int returnVal = (int) Math.ceil(totalResults / (double) PAGE_SIZE);
+    	if (returnVal == 0) { returnVal = 1; }
+    	return returnVal;
 	}
     
     /**

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -70,6 +70,7 @@ public class JournalModel extends ModelObject {
     private int pageNumber = 1;
     private int pageMax = 1;
     private int resultsNumber = 0;
+    private String resultsInfo = "";
     
     // The most recent or active search
     // Used so the search is remembered when changing the page number or refreshing
@@ -112,8 +113,8 @@ public class JournalModel extends ModelObject {
                 connection = Rdb.connectToDatabase(schema, user, password).getConnection();
                 
                 setMessage("");
-                searchUpdateRuns(connection, search);
                 setLastUpdate(new Date());
+                searchUpdateRuns(connection, search);
 
                 activeSearch = search;
             } catch (Exception ex) {
@@ -196,9 +197,10 @@ public class JournalModel extends ModelObject {
     	if (!rs.next()) {
     		throw new RuntimeException("No results returned from SQL query to count rows.");
     	}
-    	System.out.println("200:" + rs.getInt(1));
+
 	    setTotalResults(rs.getInt(1));
 	    setResultsNumber(rs.getInt(1));
+	    setResultsInfo(this.getResultsInfo());
 	    rs.close();
     }
     
@@ -337,6 +339,10 @@ public class JournalModel extends ModelObject {
     	this.resultsNumber = resultsNumber;
     }
     
+    private void setResultsInfo(String info) {
+    	firePropertyChange("resultsInfo", this.resultsInfo, this.resultsInfo = info);
+    }
+    
     /**
      * Returns the number of total current results and the currently displayed results depending on page and page size.
      * @return The number of total results and currently displayed entries.
@@ -344,7 +350,7 @@ public class JournalModel extends ModelObject {
     public String getResultsInfo() {
     	int entryFrom;
     	int entryTo;
-    	System.out.println("361:" + resultsNumber);
+
     	if (resultsNumber != 0) {
 	    	entryFrom = (pageNumber - 1) * PAGE_SIZE + 1;
 	    	entryTo = entryFrom + PAGE_SIZE - 1;
@@ -352,7 +358,7 @@ public class JournalModel extends ModelObject {
     	} else {
     		entryFrom = entryTo = 0;
     	}
-    	
+
     	return String.format("Entries %d-%d of %d", entryFrom, entryTo, resultsNumber);
     }
     

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -197,10 +197,10 @@ public class JournalModel extends ModelObject {
     	if (!rs.next()) {
     		throw new RuntimeException("No results returned from SQL query to count rows.");
     	}
-
+    	
     	setPageMax(calcTotalPages(rs.getInt(1)));
-	    setResultsNumber(rs.getInt(1));
-	    rs.close();
+    	setResultsNumber(rs.getInt(1));
+    	rs.close();
     }
     
     /**
@@ -303,96 +303,96 @@ public class JournalModel extends ModelObject {
      * @param pageNumber The new page number.
      * @return a CompleteableFuture
      */
-    public void updatePageNumber(int pageNumber) {
+	public void updatePageNumber(int pageNumber) {
 		firePropertyChange("pageNumber", this.pageNumber, this.pageNumber = pageNumber);
-    }
-    
-    public CompletableFuture<Void> setPageNumber(int pageNumber) {
-    	updatePageNumber(pageNumber);
-        return refresh();
-    }
-
-    /**
-     * Returns the current page number.
-     * @return The page number.
-     */
-    public int getPage() {
-        return pageNumber;
-    }
-    
-    /**
-     * Returns the PAGE_SIZE constant
-     * @return PAGE_SIZE constant
-     */
-    public int getPageSize() {
-    	return PAGE_SIZE;
-    }
-    
-    public int calcTotalPages(int totalResults) {
-    	int returnVal = (int) Math.ceil(totalResults / (double) this.getPageSize());
-    	if (returnVal == 0) { returnVal = 1; }
-    	return returnVal;
 	}
-    
-    /**
-     * Returns the number of entry results from last run.
-     * @return Number of entry results.
-     */
-    public int getResultsNumber() {
-    	return resultsNumber;
-    }
-    
-    /**
-     * Sets the total results number.
-     * 
-     * @param totalResults The number of results.
-     * @return a CompleteableFuture
-     */
-    private void setResultsNumber(int resultsNumber) {
-    	firePropertyChange("resultsNumber", this.resultsNumber, this.resultsNumber = resultsNumber);	
-    }
-    
-    /**
-     * The maximum page number that can be selected.
-     * @param max the new maximum selectable page number
-     */
-    public void setPageMax(int max) {
-    	firePropertyChange("pageMax", this.pageMax, this.pageMax = max);
-    }
-
-    /**
-     * Gets the maximum page number with data in it.
-     * @return the maximum page number
-     */
+	
+	public CompletableFuture<Void> setPageNumber(int pageNumber) {
+		updatePageNumber(pageNumber);
+		return refresh();
+	}
+	
+	/**
+	 * Returns the current page number.
+	 * @return The page number.
+	 */
+	public int getPage() {
+	    return pageNumber;
+	}
+	
+	/**
+	 * Returns the PAGE_SIZE constant
+	 * @return PAGE_SIZE constant
+	 */
+	public int getPageSize() {
+		return PAGE_SIZE;
+	}
+	
+	public int calcTotalPages(int totalResults) {
+		int returnVal = (int) Math.ceil(totalResults / (double) this.getPageSize());
+		if (returnVal == 0) { returnVal = 1; }
+		return returnVal;
+	}
+	
+	/**
+	 * Returns the number of entry results from last run.
+	 * @return Number of entry results.
+	 */
+	public int getResultsNumber() {
+		return resultsNumber;
+	}
+	
+	/**
+	 * Sets the total results number.
+	 * 
+	 * @param totalResults The number of results.
+	 * @return a CompleteableFuture
+	 */
+	private void setResultsNumber(int resultsNumber) {
+		firePropertyChange("resultsNumber", this.resultsNumber, this.resultsNumber = resultsNumber);	
+	}
+	
+	/**
+	 * The maximum page number that can be selected.
+	 * @param max the new maximum selectable page number
+	 */
+	public void setPageMax(int max) {
+		firePropertyChange("pageMax", this.pageMax, this.pageMax = max);
+	}
+	
+	/**
+	 * Gets the maximum page number with data in it.
+	 * @return the maximum page number
+	 */
 	public int getPageMax() {
 		return pageMax;
 	}
+	
+	/**
+	 * @return the searchableFields
+	 */
+	public List<JournalField> getSearchableFields() {
+	    return SEARCHABLE_FIELDS;
+	}
+	
+	/**
+	 * Sorts by the specified field, and swaps the direction if already active.
+	 * @param field The field to sort by
+	 * @return a CompleteableFuture
+	 */
+	public CompletableFuture<Void> sortBy(JournalField field) {
+	    JournalSort primarySort = activeSearch.getPrimarySort();
+	    
+	    if (primarySort.sortField == field) {
+	        primarySort.swapDirection();
+	    } else {
+	        activeSearch.clearSorts();
+	        if (field != JournalField.RUN_NUMBER) {
+	            activeSearch.addSort(field);
+	        }
+	        activeSearch.addSort(JournalField.RUN_NUMBER);
+	    }
 
-    /**
-     * @return the searchableFields
-     */
-    public List<JournalField> getSearchableFields() {
-        return SEARCHABLE_FIELDS;
-    }
-
-    /**
-     * Sorts by the specified field, and swaps the direction if already active.
-     * @param field The field to sort by
-     * @return a CompleteableFuture
-     */
-    public CompletableFuture<Void> sortBy(JournalField field) {
-        JournalSort primarySort = activeSearch.getPrimarySort();
-        
-        if (primarySort.sortField == field) {
-            primarySort.swapDirection();
-        } else {
-            activeSearch.clearSorts();
-            if (field != JournalField.RUN_NUMBER) {
-                activeSearch.addSort(field);
-            }
-            activeSearch.addSort(JournalField.RUN_NUMBER);
-        }
-
-        return refresh();
-    }
+    return refresh();
+}
 }

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -72,6 +72,8 @@ public class JournalModel extends ModelObject {
     private int pageNumber = 1;
     private int pageMax = 1;
     
+    private int resultsNumber = 0;
+    
     // The most recent or active search
     // Used so the search is remembered when changing the page number or refreshing
     private JournalSearch activeSearch = new EmptySearch();
@@ -328,8 +330,36 @@ public class JournalModel extends ModelObject {
     }
     
     private void setTotalResults(int totalResults) {
+    	this.resultsNumber = totalResults;
     	setPageMax((int) Math.ceil(totalResults / (double) PAGE_SIZE));
 	}
+    
+    /**
+     * Returns the number of entry results.
+     * @return Number of entry results.
+     */
+    public int getResultsNumber() {
+    	return resultsNumber;
+    }
+    
+    /**
+     * Returns the number of all results and the currently displayed results depending on page and page size.
+     * E.g. "26-50 of 140"
+     * @return The number of total results and currently displayed entries.
+     */
+    public String getResultsInfo() {
+    	int startEntry;
+    	int endEntry;
+    	if (resultsNumber != 0) {
+	    	startEntry = (pageNumber - 1) * PAGE_SIZE + 1;
+	    	endEntry = startEntry + PAGE_SIZE - 1;
+	    	if (endEntry > resultsNumber) { endEntry = resultsNumber; }
+    	} else {
+    		startEntry = endEntry = 0;
+    	}
+    	
+    	return String.format("Entries %d-%d of %d", startEntry, endEntry, resultsNumber);
+    }
     
     /**
      * The maximum page number that can be selected.

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -70,7 +70,6 @@ public class JournalModel extends ModelObject {
     private int pageNumber = 1;
     private int pageMax = 1;
     private int resultsNumber = 0;
-    private String resultsInfo = "";
     
     // The most recent or active search
     // Used so the search is remembered when changing the page number or refreshing
@@ -200,7 +199,6 @@ public class JournalModel extends ModelObject {
 
     	setPageMax(calcTotalPages(rs.getInt(1)));
 	    setResultsNumber(rs.getInt(1));
-	    setResultsInfo(this.getResultsInfo());
 	    rs.close();
     }
     
@@ -317,6 +315,14 @@ public class JournalModel extends ModelObject {
         return pageNumber;
     }
     
+    /**
+     * Returns the PAGE_SIZE constant
+     * @return PAGE_SIZE constant
+     */
+    public int getPageSize() {
+    	return PAGE_SIZE;
+    }
+    
     private int calcTotalPages(int totalResults) {
     	int returnVal = (int) Math.ceil(totalResults / (double) PAGE_SIZE);
     	if (returnVal == 0) { returnVal = 1; }
@@ -338,30 +344,7 @@ public class JournalModel extends ModelObject {
      * @return a CompleteableFuture
      */
     private void setResultsNumber(int resultsNumber) {
-    	this.resultsNumber = resultsNumber;
-    }
-    
-    private void setResultsInfo(String info) {
-    	firePropertyChange("resultsInfo", this.resultsInfo, this.resultsInfo = info);
-    }
-    
-    /**
-     * Returns the number of total current results and the currently displayed results depending on page and page size.
-     * @return The number of total results and currently displayed entries.
-     */
-    public String getResultsInfo() {
-    	int entryFrom;
-    	int entryTo;
-
-    	if (resultsNumber != 0) {
-	    	entryFrom = (pageNumber - 1) * PAGE_SIZE + 1;
-	    	entryTo = entryFrom + PAGE_SIZE - 1;
-	    	if (entryTo > resultsNumber) { entryTo = resultsNumber; }
-    	} else {
-    		entryFrom = entryTo = 0;
-    	}
-
-    	return String.format("Entries %d-%d of %d", entryFrom, entryTo, resultsNumber);
+    	firePropertyChange("resultsNumber", this.resultsNumber, this.resultsNumber = resultsNumber);	
     }
     
     /**
@@ -369,7 +352,7 @@ public class JournalModel extends ModelObject {
      * @param max the new maximum selectable page number
      */
     public void setPageMax(int max) {
-    	firePropertyChange("pageNumberMax", this.pageMax, this.pageMax = max);
+    	firePropertyChange("pageMax", this.pageMax, this.pageMax = max);
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalSearch.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalSearch.java
@@ -77,14 +77,12 @@ public abstract class JournalSearch {
     }
 
     /**
-     * Constructs a prepared statement for counting the number of returned journal entries
-     * from the database.
+     * Constructs an SQL prepared statement which gets the number of runs available.
      * 
      * @param connection
      *            the SQL connection to use
-     * @return An SQL PreparedStatement
-     * @throws SQLException
-     *             - If there was an error while querying the database
+     * @return An SQL prepared statement ready to be executed.
+     * @throws SQLException if a SQL exception occurred while preparing the statement
      */
     public PreparedStatement constructCountQuery(Connection connection) throws SQLException {
         StringBuilder query = new StringBuilder(COUNT);

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalSearch.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalSearch.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
  */
 public abstract class JournalSearch {
     private static final String SELECT = "SELECT * FROM journal_entries";
+    private static final String COUNT = "SELECT COUNT(*) FROM journal_entries";
     protected final JournalField field;
     private ArrayList<JournalSort> sorts = new ArrayList<JournalSort>();
     {
@@ -75,6 +76,26 @@ public abstract class JournalSearch {
         return st;
     }
 
+    /**
+     * Constructs a prepared statement for counting the number of returned journal entries
+     * from the database.
+     * 
+     * @param connection
+     *            the SQL connection to use
+     * @return An SQL PreparedStatement
+     * @throws SQLException
+     *             - If there was an error while querying the database
+     */
+    public PreparedStatement constructCountQuery(Connection connection) throws SQLException {
+        StringBuilder query = new StringBuilder(COUNT);
+
+        query.append(createWhereTemplate());
+        PreparedStatement st = connection.prepareStatement(query.toString());
+        fillTemplate(st);
+        
+        return st;
+    }
+    
     /**
      * @return A string containing the WHERE section of the query.
      */

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
@@ -178,4 +178,200 @@ public class JournalViewModelTest {
         assertEquals(expected, actual);
      
     }
+    
+    @Test
+    public void GIVEN_on_page_0_page_size_0_results_0_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(0);
+    	when(model.getPageSize()).thenReturn(0);
+    	when(model.getPage()).thenReturn(0);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 0-0 of 0", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_1_page_size_1_results_1_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(1);
+    	when(model.getPageSize()).thenReturn(1);
+    	when(model.getPage()).thenReturn(1);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 1-1 of 1", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_1_page_size_0_results_1_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(1);
+    	when(model.getPageSize()).thenReturn(0);
+    	when(model.getPage()).thenReturn(1);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 0-0 of 1", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_0_page_size_1_results_1_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(1);
+    	when(model.getPageSize()).thenReturn(1);
+    	when(model.getPage()).thenReturn(0);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 0-0 of 1", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_1_page_size_1_results_0_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(0);
+    	when(model.getPageSize()).thenReturn(1);
+    	when(model.getPage()).thenReturn(1);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 0-0 of 0", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_1_page_size_1_results_2_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(2);
+    	when(model.getPageSize()).thenReturn(1);
+    	when(model.getPage()).thenReturn(1);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 1-1 of 2", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_1_page_size_2_results_1_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(1);
+    	when(model.getPageSize()).thenReturn(2);
+    	when(model.getPage()).thenReturn(1);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 1-1 of 1", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_1_page_size_2_results_2_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(2);
+    	when(model.getPageSize()).thenReturn(2);
+    	when(model.getPage()).thenReturn(1);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 1-2 of 2", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_1_page_size_2_results_3_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(3);
+    	when(model.getPageSize()).thenReturn(2);
+    	when(model.getPage()).thenReturn(1);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 1-2 of 3", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_2_page_size_2_results_3_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(3);
+    	when(model.getPageSize()).thenReturn(2);
+    	when(model.getPage()).thenReturn(2);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 3-3 of 3", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_2_page_size_15_results_45_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(45);
+    	when(model.getPageSize()).thenReturn(15);
+    	when(model.getPage()).thenReturn(2);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 16-30 of 45", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_3_page_size_15_results_46_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(46);
+    	when(model.getPageSize()).thenReturn(15);
+    	when(model.getPage()).thenReturn(3);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 31-45 of 46", resultInfo);
+    }
+    
+    @Test
+    public void GIVEN_on_page_4_page_size_15_results_46_THEN_correct_string_returned() {
+    	// Arrange
+    	when(model.getResultsNumber()).thenReturn(46);
+    	when(model.getPageSize()).thenReturn(15);
+    	when(model.getPage()).thenReturn(4);
+    	
+    	// Act
+    	viewModel = new JournalViewModel(model);
+    	String resultInfo = viewModel.getResultsInfo();
+    	
+    	// Assert
+    	assertEquals("Entries 46-46 of 46", resultInfo);
+    }
+    
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java
@@ -191,7 +191,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 0-0 of 0", resultInfo);
+    	assertEquals("0-0 of 0", resultInfo);
     }
     
     @Test
@@ -206,7 +206,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 1-1 of 1", resultInfo);
+    	assertEquals("1-1 of 1", resultInfo);
     }
     
     @Test
@@ -221,7 +221,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 0-0 of 1", resultInfo);
+    	assertEquals("0-0 of 1", resultInfo);
     }
     
     @Test
@@ -236,7 +236,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 0-0 of 1", resultInfo);
+    	assertEquals("0-0 of 1", resultInfo);
     }
     
     @Test
@@ -251,7 +251,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 0-0 of 0", resultInfo);
+    	assertEquals("0-0 of 0", resultInfo);
     }
     
     @Test
@@ -266,7 +266,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 1-1 of 2", resultInfo);
+    	assertEquals("1-1 of 2", resultInfo);
     }
     
     @Test
@@ -281,7 +281,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 1-1 of 1", resultInfo);
+    	assertEquals("1-1 of 1", resultInfo);
     }
     
     @Test
@@ -296,7 +296,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 1-2 of 2", resultInfo);
+    	assertEquals("1-2 of 2", resultInfo);
     }
     
     @Test
@@ -311,7 +311,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 1-2 of 3", resultInfo);
+    	assertEquals("1-2 of 3", resultInfo);
     }
     
     @Test
@@ -326,7 +326,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 3-3 of 3", resultInfo);
+    	assertEquals("3-3 of 3", resultInfo);
     }
     
     @Test
@@ -341,7 +341,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 16-30 of 45", resultInfo);
+    	assertEquals("16-30 of 45", resultInfo);
     }
     
     @Test
@@ -356,7 +356,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 31-45 of 46", resultInfo);
+    	assertEquals("31-45 of 46", resultInfo);
     }
     
     @Test
@@ -371,7 +371,7 @@ public class JournalViewModelTest {
     	String resultInfo = viewModel.getResultsInfo();
     	
     	// Assert
-    	assertEquals("Entries 46-46 of 46", resultInfo);
+    	assertEquals("46-46 of 46", resultInfo);
     }
     
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/META-INF/MANIFEST.MF
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.ui.journalviewer
+Import-Package: uk.ac.stfc.isis.ibex.validators

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/META-INF/MANIFEST.MF
@@ -13,8 +13,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.ui.model.workbench;bundle-version="1.1.100",
  org.eclipse.e4.ui.workbench,
  javax.annotation;bundle-version="1.2.0",
- uk.ac.stfc.isis.ibex.ui.widgets
+ uk.ac.stfc.isis.ibex.ui.widgets,
+ uk.ac.stfc.isis.ibex.validators;bundle-version="1.0.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.ui.journalviewer
-Import-Package: uk.ac.stfc.isis.ibex.validators

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -133,7 +133,7 @@ public class JournalViewerView {
         basicControls.setLayout(rlBasicControls);
 
         lblResults = new Label(basicControls, SWT.WRAP | SWT.LEFT);
-        lblResults.setText(model.getResultsInfo());
+        lblResults.setText("placeholder");
         
         btnPrevPage = new Button(basicControls, SWT.NONE);
         btnPrevPage.setText(" < Newer ");
@@ -300,6 +300,8 @@ public class JournalViewerView {
                 BeanProperties.value("pageNumberMax").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(error),
                 BeanProperties.value("errorMessage").observe(model));
+        bindingContext.bindValue(WidgetProperties.text().observe(lblResults),
+        		BeanProperties.value("resultsInfo").observe(model));
 
         bindingContext.bindValue(WidgetProperties.enabled().observe(btnSearch),
                 BeanProperties.value("enableOrDisableButton").observe(model));
@@ -307,9 +309,6 @@ public class JournalViewerView {
         spinnerPageNumber.addListener(SWT.Selection, e -> {
             setProgressIndicatorsVisible(true);
             model.setPageNumber(spinnerPageNumber.getSelection()).thenAccept(ignored -> setProgressIndicatorsVisible(false));
-            
-            lblResults.setText(model.getResultsInfo());
-            lblResults.requestLayout();  // update layout to resize label upon text change
         });
 
         btnPrevPage.addListener(SWT.Selection, e -> {
@@ -350,6 +349,9 @@ public class JournalViewerView {
                 table.updateTableColumns();
                 updateSortIndicator();
                 table.setRows(model.getRuns());
+                
+                lblResults.requestLayout();  // update layout to resize label upon text change
+                lblResults.setText(model.getResultsInfo());
                 setProgressIndicatorsVisible(false);
         }));
         

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -30,15 +30,10 @@ import org.eclipse.core.databinding.observable.map.ObservableMap;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.FocusEvent;
-import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.layout.RowData;
@@ -46,7 +41,6 @@ import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.ProgressBar;
 import org.eclipse.swt.widgets.TableColumn;
@@ -338,18 +332,12 @@ public class JournalViewerView {
         		model.setPageNumber(Integer.parseInt(textPageNumber.getText()))
         							.thenAccept(ignored -> setProgressIndicatorsVisible(false));
         	}
-        	
+        	textPageNumber.selectAll();
         });
         
-//        textPageNumber.addListener(SWT.MouseDown, e -> {
-//        	System.out.println("Mouse down");
-//        	//textPageNumber.selectAll();
-//        });
-//        
-//        textPageNumber.addListener(SWT.FocusIn, e -> {
-//        	System.out.println("FOCUSED");
-//        	textPageNumber.selectAll();
-//        });
+        textPageNumber.addListener(SWT.FocusIn, e -> {
+        	textPageNumber.selectAll();
+        });
         
         btnNewerPage.addListener(SWT.Selection, e -> {
         	setProgressIndicatorsVisible(true);

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -301,7 +301,7 @@ public class JournalViewerView {
         bindingContext.bindValue(WidgetProperties.text().observe(lblLastUpdate),
                 BeanProperties.value("lastUpdate").observe(model));
         bindingContext.bindValue(WidgetProperties.maximum().observe(spinnerPageNumber),
-                BeanProperties.value("pageNumberMax").observe(model));
+                BeanProperties.value("pageMax").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(error),
                 BeanProperties.value("errorMessage").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(lblResults),
@@ -329,7 +329,7 @@ public class JournalViewerView {
         	int nextPageNumber = spinnerPageNumber.getSelection() + 1;
         	if(nextPageNumber <= spinnerPageNumber.getMaximum()) {
 	        	spinnerPageNumber.setSelection(nextPageNumber);
-	        	spinnerPageNumber.notifyListeners(SWT.Selection, e); 	
+	        	spinnerPageNumber.notifyListeners(SWT.Selection, e);
         	}
         });
 

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -83,10 +83,10 @@ public class JournalViewerView {
 
     private Button btnRefresh;
     private Text textPageNumber;
-    private Button btnNewerPage;
-    private Button btnOlderPage;
-    private Button btnNewestPage;
-    private Button btnOldestPage;
+    private Button btnPrevPage;
+    private Button btnNextPage;
+    private Button btnFirstPage;
+    private Button btnLastPage;
     private SearchInput searchInput;
     private Button btnSearch;
     private ProgressBar progressBar;
@@ -141,26 +141,26 @@ public class JournalViewerView {
 	    lblResultsData.width = 150;
 		lblResults.setLayoutData(lblResultsData);
 	
-		btnNewestPage = new Button(basicControls, SWT.NONE);
-		btnNewestPage.setText("<<");
-	    btnNewestPage.setToolTipText("Most recent entries.");
+		btnFirstPage = new Button(basicControls, SWT.NONE);
+		btnFirstPage.setText("<<");
+	    btnFirstPage.setToolTipText("Go to the first page.");
 	    
-	    btnNewerPage = new Button(basicControls, SWT.NONE);
-	    btnNewerPage.setText(" < Newer ");
-	    btnNewerPage.setToolTipText("Go to newer entries.");
+	    btnPrevPage = new Button(basicControls, SWT.NONE);
+	    btnPrevPage.setText(" < Prev ");
+	    btnPrevPage.setToolTipText("Go to the previous page.");
 	
 	    textPageNumber = new Text(basicControls, SWT.BORDER);
 	    RowData textPageNumberData = new RowData();
 	    textPageNumberData.width = 25;
 	    textPageNumber.setLayoutData(textPageNumberData);
 	
-	    btnOlderPage = new Button(basicControls, SWT.NONE);
-	    btnOlderPage.setText(" Older > ");
-	    btnOlderPage.setToolTipText("Go to older entries.");
+	    btnNextPage = new Button(basicControls, SWT.NONE);
+	    btnNextPage.setText(" Next > ");
+	    btnNextPage.setToolTipText("Go to the next page.");
 	    
-	    btnOldestPage = new Button(basicControls, SWT.NONE);
-	    btnOldestPage.setText(">>");
-	    btnOldestPage.setToolTipText("Least recent entries.");
+	    btnLastPage = new Button(basicControls, SWT.NONE);
+	    btnLastPage.setText(">>");
+	    btnLastPage.setToolTipText("Go to the last page.");
 	
 	    btnRefresh = new Button(basicControls, SWT.NONE);
 	    btnRefresh.setText("Refresh data");
@@ -321,8 +321,19 @@ public class JournalViewerView {
 	    bindingContext.bindValue(WidgetProperties.tooltipText().observe(lblResults),
 	    		BeanProperties.value("resultsInfo").observe(model));
 	
+	    
+	    bindingContext.bindValue(WidgetProperties.enabled().observe(btnPrevPage),
+	            BeanProperties.value("btnPrevPageEnabled").observe(model));
+	    bindingContext.bindValue(WidgetProperties.enabled().observe(btnFirstPage),
+	            BeanProperties.value("btnPrevPageEnabled").observe(model));
+	    
+	    bindingContext.bindValue(WidgetProperties.enabled().observe(btnNextPage),
+	            BeanProperties.value("btnNextPageEnabled").observe(model));   
+	    bindingContext.bindValue(WidgetProperties.enabled().observe(btnLastPage),
+	            BeanProperties.value("btnNextPageEnabled").observe(model));
+	    
 	    bindingContext.bindValue(WidgetProperties.enabled().observe(btnSearch),
-	            BeanProperties.value("enableOrDisableButton").observe(model));
+	            BeanProperties.value("searchButtonEnabled").observe(model));
 
         textPageNumber.addVerifyListener(new NumbersOnlyListener());
         
@@ -339,24 +350,24 @@ public class JournalViewerView {
         	textPageNumber.selectAll();
         });
         
-        btnNewerPage.addListener(SWT.Selection, e -> {
+        btnPrevPage.addListener(SWT.Selection, e -> {
         	setProgressIndicatorsVisible(true);
-        	model.newerPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        	model.prevPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
 
-        btnOlderPage.addListener(SWT.Selection, e -> {
+        btnNextPage.addListener(SWT.Selection, e -> {
         	setProgressIndicatorsVisible(true);
-        	model.olderPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        	model.nextPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
         
-        btnNewestPage.addListener(SWT.Selection, e -> {
+        btnFirstPage.addListener(SWT.Selection, e -> {
         	setProgressIndicatorsVisible(true);
-        	model.newestPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        	model.firstPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
 
-        btnOldestPage.addListener(SWT.Selection, e -> {
+        btnLastPage.addListener(SWT.Selection, e -> {
         	setProgressIndicatorsVisible(true);
-        	model.oldestPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        	model.lastPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
 
         btnRefresh.addListener(SWT.Selection, e -> {

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -74,6 +74,7 @@ public class JournalViewerView {
     private Label lblError;
     private Label lblLastUpdate;
     private Label error;
+    private Label lblResults;
 
     private final DataBindingContext bindingContext = new DataBindingContext();
     private final JournalViewModel model = JournalViewerUI.getDefault().getModel();
@@ -86,8 +87,6 @@ public class JournalViewerView {
     private SearchInput searchInput;
     private Button btnSearch;
     private ProgressBar progressBar;
-    
-    private Label lblResults;
 
     private DataboundTable<JournalRow> table;
 
@@ -123,22 +122,27 @@ public class JournalViewerView {
         Composite controls = new Composite(parent, SWT.FILL);
         RowLayout rlControls = new RowLayout(SWT.HORIZONTAL);
         rlControls.center = true;
+        RowData data = new RowData();
         controls.setLayout(rlControls);
         controls.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
-        
+
         basicControls = new Composite(controls, SWT.NONE);
         RowLayout rlBasicControls = new RowLayout(SWT.HORIZONTAL);
         rlBasicControls.marginTop = 7;
         rlBasicControls.center = true;
         basicControls.setLayout(rlBasicControls);
 
-        lblResults = new Label(basicControls, SWT.WRAP | SWT.LEFT);
+        lblResults = new Label(basicControls, SWT.LEFT | SWT.HORIZONTAL | SWT.BORDER);
         lblResults.setText("placeholder");
-        
+        lblResults.setToolTipText("Currently displayed entries out of total.");
+    	data = new RowData();
+    	data.width = 200;
+    	lblResults.setLayoutData(data);
+
         btnPrevPage = new Button(basicControls, SWT.NONE);
         btnPrevPage.setText(" < Newer ");
         btnPrevPage.setToolTipText("Go to newer entries.");
-        
+
         spinnerPageNumber = new Spinner(basicControls, SWT.BORDER);
         spinnerPageNumber.setMinimum(1);
         spinnerPageNumber.setMaximum(1);
@@ -147,10 +151,10 @@ public class JournalViewerView {
         btnNextPage = new Button(basicControls, SWT.NONE);
         btnNextPage.setText(" Older > ");
         btnNextPage.setToolTipText("Go to older entries.");
-        
+
         btnRefresh = new Button(basicControls, SWT.NONE);
         btnRefresh.setText("Refresh data");
-        
+
         searchControls = new Composite(controls, SWT.NONE);
         RowLayout rlSearchControls = new RowLayout(SWT.HORIZONTAL);
         rlSearchControls.center = true;
@@ -163,14 +167,14 @@ public class JournalViewerView {
         btnSearch = new Button(searchControls, SWT.NONE);
         btnSearch.setLayoutData(new RowData(80, SWT.DEFAULT));
         btnSearch.setText("Search");
-        
+
         btnClear = new Button(searchControls, SWT.NONE);
         btnClear.setText("Clear");
-        
+
         progressBar = new ProgressBar(searchControls, SWT.INDETERMINATE);
         progressBar.setMaximum(80);
         progressBar.setLayoutData(new RowData(100, SWT.DEFAULT));
-        
+
         error = new Label(searchControls, SWT.NONE);
         error.setForeground(parent.getDisplay().getSystemColor(SWT.COLOR_RED));
         error.setLayoutData(new RowData(200, SWT.DEFAULT));
@@ -206,12 +210,12 @@ public class JournalViewerView {
 		            }
 		        }
 			}
-			
+
 			@Override
 			protected ColumnComparator<JournalRow> comparator() {
 				return new NullComparator<>();
 			}
-			
+
 			// Sort table by selected column when a column header is clicked
 			@Override
 			protected SelectionAdapter getColumnSelectionAdapter(final TableColumn column, final int index) {
@@ -226,7 +230,7 @@ public class JournalViewerView {
 		    }
 		};
 		table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
-		
+
 		table.initialise();
 
         lblError = new Label(parent, SWT.NONE);
@@ -352,6 +356,7 @@ public class JournalViewerView {
                 
                 lblResults.requestLayout();  // update layout to resize label upon text change
                 lblResults.setText(model.getResultsInfo());
+                lblResults.setToolTipText(model.getResultsInfo());
                 setProgressIndicatorsVisible(false);
         }));
         

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -81,6 +81,8 @@ public class JournalViewerView {
 
     private Button btnRefresh;
     private Spinner spinnerPageNumber;
+    private Button btnPrevPage;
+    private Button btnNextPage;
     private SearchInput searchInput;
     private Button btnSearch;
     private ProgressBar progressBar;
@@ -129,11 +131,20 @@ public class JournalViewerView {
         basicControls.setLayout(rlBasicControls);
 
         Label lblPage = new Label(basicControls, SWT.NONE);
-        lblPage.setText("Page number: ");
-
+        lblPage.setText("Page: ");
+        
+        btnPrevPage = new Button(basicControls, SWT.NONE);
+        btnPrevPage.setText("< Prev");
+        btnPrevPage.setToolTipText("Previous page");
+        
         spinnerPageNumber = new Spinner(basicControls, SWT.BORDER);
         spinnerPageNumber.setMinimum(1);
+        spinnerPageNumber.setToolTipText("Page number");
 
+        btnNextPage = new Button(basicControls, SWT.NONE);
+        btnNextPage.setText("Next >");
+        btnNextPage.setToolTipText("Next page");
+        
         btnRefresh = new Button(basicControls, SWT.NONE);
         btnRefresh.setText("Refresh data");
         
@@ -286,7 +297,7 @@ public class JournalViewerView {
                 BeanProperties.value("pageNumberMax").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(error),
                 BeanProperties.value("errorMessage").observe(model));
-        
+
         bindingContext.bindValue(WidgetProperties.enabled().observe(btnSearch),
                 BeanProperties.value("enableOrDisableButton").observe(model));
 
@@ -294,15 +305,31 @@ public class JournalViewerView {
             setProgressIndicatorsVisible(true);
             model.setPageNumber(spinnerPageNumber.getSelection()).thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
-        
+
+        btnPrevPage.addListener(SWT.Selection, e -> {
+        	int prevPageNumber = spinnerPageNumber.getSelection() - 1;
+        	if(prevPageNumber >= spinnerPageNumber.getMinimum()) {
+	        	spinnerPageNumber.setSelection(prevPageNumber);
+	        	spinnerPageNumber.notifyListeners(SWT.Selection, e); 	
+        	}
+        });
+
+        btnNextPage.addListener(SWT.Selection, e -> {
+        	int nextPageNumber = spinnerPageNumber.getSelection() + 1;
+        	if(nextPageNumber <= spinnerPageNumber.getMaximum()) {
+	        	spinnerPageNumber.setSelection(nextPageNumber);
+	        	spinnerPageNumber.notifyListeners(SWT.Selection, e); 	
+        	}
+        });
+
         btnRefresh.addListener(SWT.Selection, e -> {
             resetPageNumber();
             setProgressIndicatorsVisible(true);
             model.setPageNumber(1).thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
-        
+
         btnSearch.addListener(SWT.Selection, e -> search());
-        
+
         btnClear.addListener(SWT.Selection, e -> {
             resetPageNumber();
             searchInput.clearInput();

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -306,6 +306,8 @@ public class JournalViewerView {
                 BeanProperties.value("errorMessage").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(lblResults),
         		BeanProperties.value("resultsInfo").observe(model));
+        bindingContext.bindValue(WidgetProperties.tooltipText().observe(lblResults),
+        		BeanProperties.value("resultsInfo").observe(model));
 
         bindingContext.bindValue(WidgetProperties.enabled().observe(btnSearch),
                 BeanProperties.value("enableOrDisableButton").observe(model));
@@ -354,9 +356,6 @@ public class JournalViewerView {
                 updateSortIndicator();
                 table.setRows(model.getRuns());
                 
-                lblResults.requestLayout();  // update layout to resize label upon text change
-                lblResults.setText(model.getResultsInfo());
-                lblResults.setToolTipText(model.getResultsInfo());
                 setProgressIndicatorsVisible(false);
         }));
         

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -355,7 +355,7 @@ public class JournalViewerView {
                 table.updateTableColumns();
                 updateSortIndicator();
                 table.setRows(model.getRuns());
-                
+
                 setProgressIndicatorsVisible(false);
         }));
         

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -86,6 +86,8 @@ public class JournalViewerView {
     private SearchInput searchInput;
     private Button btnSearch;
     private ProgressBar progressBar;
+    
+    private Label lblResults;
 
     private DataboundTable<JournalRow> table;
 
@@ -130,20 +132,21 @@ public class JournalViewerView {
         rlBasicControls.center = true;
         basicControls.setLayout(rlBasicControls);
 
-        Label lblPage = new Label(basicControls, SWT.NONE);
-        lblPage.setText("Page: ");
+        lblResults = new Label(basicControls, SWT.WRAP | SWT.LEFT);
+        lblResults.setText(model.getResultsInfo());
         
         btnPrevPage = new Button(basicControls, SWT.NONE);
-        btnPrevPage.setText("< Prev");
-        btnPrevPage.setToolTipText("Previous page");
+        btnPrevPage.setText(" < Newer ");
+        btnPrevPage.setToolTipText("Go to newer entries.");
         
         spinnerPageNumber = new Spinner(basicControls, SWT.BORDER);
         spinnerPageNumber.setMinimum(1);
-        spinnerPageNumber.setToolTipText("Page number");
+        spinnerPageNumber.setMaximum(1);
+        spinnerPageNumber.setToolTipText("Page number (1 is newest).");
 
         btnNextPage = new Button(basicControls, SWT.NONE);
-        btnNextPage.setText("Next >");
-        btnNextPage.setToolTipText("Next page");
+        btnNextPage.setText(" Older > ");
+        btnNextPage.setToolTipText("Go to older entries.");
         
         btnRefresh = new Button(basicControls, SWT.NONE);
         btnRefresh.setText("Refresh data");
@@ -304,6 +307,9 @@ public class JournalViewerView {
         spinnerPageNumber.addListener(SWT.Selection, e -> {
             setProgressIndicatorsVisible(true);
             model.setPageNumber(spinnerPageNumber.getSelection()).thenAccept(ignored -> setProgressIndicatorsVisible(false));
+            
+            lblResults.setText(model.getResultsInfo());
+            lblResults.requestLayout();  // update layout to resize label upon text change
         });
 
         btnPrevPage.addListener(SWT.Selection, e -> {

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -91,6 +91,8 @@ public class JournalViewerView {
     private Text textPageNumber;
     private Button btnNewerPage;
     private Button btnOlderPage;
+    private Button btnNewestPage;
+    private Button btnOldestPage;
     private SearchInput searchInput;
     private Button btnSearch;
     private ProgressBar progressBar;
@@ -142,9 +144,13 @@ public class JournalViewerView {
         lblResults.setText("placeholder");
         lblResults.setToolTipText("Currently displayed entries out of total.");
         RowData lblResultsData = new RowData();
-        lblResultsData.width = 200;
+        lblResultsData.width = 150;
     	lblResults.setLayoutData(lblResultsData);
 
+    	btnNewestPage = new Button(basicControls, SWT.NONE);
+    	btnNewestPage.setText("<<");
+        btnNewestPage.setToolTipText("Most recent entries.");
+        
         btnNewerPage = new Button(basicControls, SWT.NONE);
         btnNewerPage.setText(" < Newer ");
         btnNewerPage.setToolTipText("Go to newer entries.");
@@ -157,6 +163,10 @@ public class JournalViewerView {
         btnOlderPage = new Button(basicControls, SWT.NONE);
         btnOlderPage.setText(" Older > ");
         btnOlderPage.setToolTipText("Go to older entries.");
+        
+        btnOldestPage = new Button(basicControls, SWT.NONE);
+        btnOldestPage.setText(">>");
+        btnOldestPage.setToolTipText("Least recent entries.");
 
         btnRefresh = new Button(basicControls, SWT.NONE);
         btnRefresh.setText("Refresh data");
@@ -349,6 +359,16 @@ public class JournalViewerView {
         btnOlderPage.addListener(SWT.Selection, e -> {
         	setProgressIndicatorsVisible(true);
         	model.olderPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        });
+        
+        btnNewestPage.addListener(SWT.Selection, e -> {
+        	setProgressIndicatorsVisible(true);
+        	model.newestPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        });
+
+        btnOldestPage.addListener(SWT.Selection, e -> {
+        	setProgressIndicatorsVisible(true);
+        	model.oldestPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
 
         btnRefresh.addListener(SWT.Selection, e -> {

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -128,66 +128,66 @@ public class JournalViewerView {
         controls.setLayout(rlControls);
         controls.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
-        basicControls = new Composite(controls, SWT.NONE);
-        RowLayout rlBasicControls = new RowLayout(SWT.HORIZONTAL);
-        rlBasicControls.marginTop = 7;
-        rlBasicControls.center = true;
-        basicControls.setLayout(rlBasicControls);
-
-        lblResults = new Label(basicControls, SWT.LEFT | SWT.HORIZONTAL | SWT.BORDER);
-        lblResults.setText("placeholder");
-        lblResults.setToolTipText("Currently displayed entries out of total.");
-        RowData lblResultsData = new RowData();
-        lblResultsData.width = 150;
-    	lblResults.setLayoutData(lblResultsData);
-
-    	btnNewestPage = new Button(basicControls, SWT.NONE);
-    	btnNewestPage.setText("<<");
-        btnNewestPage.setToolTipText("Most recent entries.");
-        
-        btnNewerPage = new Button(basicControls, SWT.NONE);
-        btnNewerPage.setText(" < Newer ");
-        btnNewerPage.setToolTipText("Go to newer entries.");
-
-        textPageNumber = new Text(basicControls, SWT.BORDER);
-        RowData textPageNumberData = new RowData();
-        textPageNumberData.width = 25;
-        textPageNumber.setLayoutData(textPageNumberData);
-
-        btnOlderPage = new Button(basicControls, SWT.NONE);
-        btnOlderPage.setText(" Older > ");
-        btnOlderPage.setToolTipText("Go to older entries.");
-        
-        btnOldestPage = new Button(basicControls, SWT.NONE);
-        btnOldestPage.setText(">>");
-        btnOldestPage.setToolTipText("Least recent entries.");
-
-        btnRefresh = new Button(basicControls, SWT.NONE);
-        btnRefresh.setText("Refresh data");
-
-        searchControls = new Composite(controls, SWT.NONE);
-        RowLayout rlSearchControls = new RowLayout(SWT.HORIZONTAL);
-        rlSearchControls.center = true;
-        searchControls.setLayout(rlSearchControls);
-
-        searchInput = new SearchInput(searchControls, model);
-        RowLayout rlFilterControl = new RowLayout(SWT.HORIZONTAL);
-        searchInput.setLayout(rlFilterControl);
-
-        btnSearch = new Button(searchControls, SWT.NONE);
-        btnSearch.setLayoutData(new RowData(80, SWT.DEFAULT));
-        btnSearch.setText("Search");
-
-        btnClear = new Button(searchControls, SWT.NONE);
-        btnClear.setText("Clear");
-
-        progressBar = new ProgressBar(searchControls, SWT.INDETERMINATE);
-        progressBar.setMaximum(80);
-        progressBar.setLayoutData(new RowData(100, SWT.DEFAULT));
-
-        error = new Label(searchControls, SWT.NONE);
-        error.setForeground(parent.getDisplay().getSystemColor(SWT.COLOR_RED));
-        error.setLayoutData(new RowData(200, SWT.DEFAULT));
+	    basicControls = new Composite(controls, SWT.NONE);
+	    RowLayout rlBasicControls = new RowLayout(SWT.HORIZONTAL);
+	    rlBasicControls.marginTop = 7;
+	    rlBasicControls.center = true;
+	    basicControls.setLayout(rlBasicControls);
+	
+	    lblResults = new Label(basicControls, SWT.LEFT | SWT.HORIZONTAL | SWT.BORDER);
+	    lblResults.setText("placeholder");
+	    lblResults.setToolTipText("Currently displayed entries out of total.");
+	    RowData lblResultsData = new RowData();
+	    lblResultsData.width = 150;
+		lblResults.setLayoutData(lblResultsData);
+	
+		btnNewestPage = new Button(basicControls, SWT.NONE);
+		btnNewestPage.setText("<<");
+	    btnNewestPage.setToolTipText("Most recent entries.");
+	    
+	    btnNewerPage = new Button(basicControls, SWT.NONE);
+	    btnNewerPage.setText(" < Newer ");
+	    btnNewerPage.setToolTipText("Go to newer entries.");
+	
+	    textPageNumber = new Text(basicControls, SWT.BORDER);
+	    RowData textPageNumberData = new RowData();
+	    textPageNumberData.width = 25;
+	    textPageNumber.setLayoutData(textPageNumberData);
+	
+	    btnOlderPage = new Button(basicControls, SWT.NONE);
+	    btnOlderPage.setText(" Older > ");
+	    btnOlderPage.setToolTipText("Go to older entries.");
+	    
+	    btnOldestPage = new Button(basicControls, SWT.NONE);
+	    btnOldestPage.setText(">>");
+	    btnOldestPage.setToolTipText("Least recent entries.");
+	
+	    btnRefresh = new Button(basicControls, SWT.NONE);
+	    btnRefresh.setText("Refresh data");
+	
+	    searchControls = new Composite(controls, SWT.NONE);
+	    RowLayout rlSearchControls = new RowLayout(SWT.HORIZONTAL);
+	    rlSearchControls.center = true;
+	    searchControls.setLayout(rlSearchControls);
+	
+	    searchInput = new SearchInput(searchControls, model);
+	    RowLayout rlFilterControl = new RowLayout(SWT.HORIZONTAL);
+	    searchInput.setLayout(rlFilterControl);
+	
+	    btnSearch = new Button(searchControls, SWT.NONE);
+	    btnSearch.setLayoutData(new RowData(80, SWT.DEFAULT));
+	    btnSearch.setText("Search");
+	
+	    btnClear = new Button(searchControls, SWT.NONE);
+	    btnClear.setText("Clear");
+	
+	    progressBar = new ProgressBar(searchControls, SWT.INDETERMINATE);
+	    progressBar.setMaximum(80);
+	    progressBar.setLayoutData(new RowData(100, SWT.DEFAULT));
+	
+	    error = new Label(searchControls, SWT.NONE);
+	    error.setForeground(parent.getDisplay().getSystemColor(SWT.COLOR_RED));
+	    error.setLayoutData(new RowData(200, SWT.DEFAULT));
 
         for (final JournalField property : JournalField.values()) {
             final Button checkbox = new Button(selectedContainer, SWT.CHECK);
@@ -306,23 +306,23 @@ public class JournalViewerView {
     }
 
     private void bind() {
-        bindingContext.bindValue(WidgetProperties.text().observe(lblError),
-                BeanProperties.value("message").observe(model));
-        bindingContext.bindValue(WidgetProperties.text().observe(lblLastUpdate),
-                BeanProperties.value("lastUpdate").observe(model));
-        bindingContext.bindValue(WidgetProperties.text().observe(textPageNumber), 
-        		BeanProperties.value("pageNumber").observe(model));
-        bindingContext.bindValue(WidgetProperties.tooltipText().observe(textPageNumber), 
-        		BeanProperties.value("pageNumber").observe(model));
-        bindingContext.bindValue(WidgetProperties.text().observe(error),
-                BeanProperties.value("errorMessage").observe(model));
-        bindingContext.bindValue(WidgetProperties.text().observe(lblResults),
-        		BeanProperties.value("resultsInfo").observe(model));
-        bindingContext.bindValue(WidgetProperties.tooltipText().observe(lblResults),
-        		BeanProperties.value("resultsInfo").observe(model));
-
-        bindingContext.bindValue(WidgetProperties.enabled().observe(btnSearch),
-                BeanProperties.value("enableOrDisableButton").observe(model));
+	    bindingContext.bindValue(WidgetProperties.text().observe(lblError),
+	            BeanProperties.value("message").observe(model));
+	    bindingContext.bindValue(WidgetProperties.text().observe(lblLastUpdate),
+	            BeanProperties.value("lastUpdate").observe(model));
+	    bindingContext.bindValue(WidgetProperties.text().observe(textPageNumber), 
+	    		BeanProperties.value("pageNumber").observe(model));
+	    bindingContext.bindValue(WidgetProperties.tooltipText().observe(textPageNumber), 
+	    		BeanProperties.value("pageNumber").observe(model));
+	    bindingContext.bindValue(WidgetProperties.text().observe(error),
+	            BeanProperties.value("errorMessage").observe(model));
+	    bindingContext.bindValue(WidgetProperties.text().observe(lblResults),
+	    		BeanProperties.value("resultsInfo").observe(model));
+	    bindingContext.bindValue(WidgetProperties.tooltipText().observe(lblResults),
+	    		BeanProperties.value("resultsInfo").observe(model));
+	
+	    bindingContext.bindValue(WidgetProperties.enabled().observe(btnSearch),
+	            BeanProperties.value("enableOrDisableButton").observe(model));
 
         textPageNumber.addVerifyListener(new NumbersOnlyListener());
         

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -60,6 +60,7 @@ import uk.ac.stfc.isis.ibex.ui.tables.ColumnComparator;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundTable;
 import uk.ac.stfc.isis.ibex.ui.tables.NullComparator;
+import uk.ac.stfc.isis.ibex.validators.NumbersOnlyListener;
 
 /**
  * Journal viewer main view.
@@ -313,6 +314,8 @@ public class JournalViewerView {
 
         bindingContext.bindValue(WidgetProperties.enabled().observe(btnSearch),
                 BeanProperties.value("enableOrDisableButton").observe(model));
+
+        textPageNumber.addVerifyListener(new NumbersOnlyListener());
 
 //        textPageNumber.addListener(SWT.Selection, e -> {
 //            setProgressIndicatorsVisible(true);

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -30,10 +30,15 @@ import org.eclipse.core.databinding.observable.map.ObservableMap;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.FocusEvent;
+import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.layout.RowData;
@@ -41,9 +46,9 @@ import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.ProgressBar;
-import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.wb.swt.SWTResourceManager;
@@ -316,20 +321,34 @@ public class JournalViewerView {
                 BeanProperties.value("enableOrDisableButton").observe(model));
 
         textPageNumber.addVerifyListener(new NumbersOnlyListener());
-
-//        textPageNumber.addListener(SWT.Selection, e -> {
-//            setProgressIndicatorsVisible(true);
-//            model.setPageNumber(Integer.parseInt(textPageNumber.getText())).thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        
+        textPageNumber.addListener(SWT.Traverse, e -> {
+        	if (e.detail == SWT.TRAVERSE_RETURN) {
+        		setProgressIndicatorsVisible(true);
+        		model.setPageNumber(Integer.parseInt(textPageNumber.getText()))
+        							.thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        	}
+        	
+        });
+        
+//        textPageNumber.addListener(SWT.MouseDown, e -> {
+//        	System.out.println("Mouse down");
+//        	//textPageNumber.selectAll();
 //        });
-
+//        
+//        textPageNumber.addListener(SWT.FocusIn, e -> {
+//        	System.out.println("FOCUSED");
+//        	textPageNumber.selectAll();
+//        });
+        
         btnNewerPage.addListener(SWT.Selection, e -> {
         	setProgressIndicatorsVisible(true);
-        	model.setPageNumber(model.newerPageNumber()).thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        	model.newerPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
 
         btnOlderPage.addListener(SWT.Selection, e -> {
         	setProgressIndicatorsVisible(true);
-        	model.setPageNumber(model.olderPageNumber()).thenAccept(ignored -> setProgressIndicatorsVisible(false));
+        	model.olderPage().thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
 
         btnRefresh.addListener(SWT.Selection, e -> {

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -82,7 +82,7 @@ public class JournalViewerView {
     private static final Display DISPLAY = Display.getCurrent();
 
     private Button btnRefresh;
-    private Spinner spinnerPageNumber;
+    private Text textPageNumber;
     private Button btnNewerPage;
     private Button btnOlderPage;
     private SearchInput searchInput;
@@ -123,7 +123,6 @@ public class JournalViewerView {
         Composite controls = new Composite(parent, SWT.FILL);
         RowLayout rlControls = new RowLayout(SWT.HORIZONTAL);
         rlControls.center = true;
-        RowData data = new RowData();
         controls.setLayout(rlControls);
         controls.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
 
@@ -136,18 +135,18 @@ public class JournalViewerView {
         lblResults = new Label(basicControls, SWT.LEFT | SWT.HORIZONTAL | SWT.BORDER);
         lblResults.setText("placeholder");
         lblResults.setToolTipText("Currently displayed entries out of total.");
-    	data = new RowData();
-    	data.width = 200;
-    	lblResults.setLayoutData(data);
+        RowData lblResultsData = new RowData();
+        lblResultsData.width = 200;
+    	lblResults.setLayoutData(lblResultsData);
 
         btnNewerPage = new Button(basicControls, SWT.NONE);
         btnNewerPage.setText(" < Newer ");
         btnNewerPage.setToolTipText("Go to newer entries.");
-        
-        spinnerPageNumber = new Spinner(basicControls, SWT.BORDER);
-        spinnerPageNumber.setMinimum(1);
-        spinnerPageNumber.setMaximum(1);
-        spinnerPageNumber.setToolTipText("Page number (1 is newest).");
+
+        textPageNumber = new Text(basicControls, SWT.BORDER);
+        RowData textPageNumberData = new RowData();
+        textPageNumberData.width = 25;
+        textPageNumber.setLayoutData(textPageNumberData);
 
         btnOlderPage = new Button(basicControls, SWT.NONE);
         btnOlderPage.setText(" Older > ");
@@ -270,7 +269,7 @@ public class JournalViewerView {
         setProgressIndicatorsVisible(true);
         model.setPageNumber(1).thenAccept(ignored -> setProgressIndicatorsVisible(false));
     }
-    
+
     /**
      * Updates the sort indicator arrow to the currently sorted column
      */
@@ -293,7 +292,7 @@ public class JournalViewerView {
     }
     
     private void resetPageNumber() {
-        DISPLAY.asyncExec(() -> spinnerPageNumber.setSelection(1));
+        DISPLAY.asyncExec(() -> textPageNumber.setText("1"));
     }
 
     private void bind() {
@@ -301,9 +300,9 @@ public class JournalViewerView {
                 BeanProperties.value("message").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(lblLastUpdate),
                 BeanProperties.value("lastUpdate").observe(model));
-        bindingContext.bindValue(WidgetProperties.maximum().observe(spinnerPageNumber),
-                BeanProperties.value("pageMax").observe(model));
-        bindingContext.bindValue(WidgetProperties.spinnerSelection().observe(spinnerPageNumber), 
+        bindingContext.bindValue(WidgetProperties.text().observe(textPageNumber), 
+        		BeanProperties.value("pageNumber").observe(model));
+        bindingContext.bindValue(WidgetProperties.tooltipText().observe(textPageNumber), 
         		BeanProperties.value("pageNumber").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(error),
                 BeanProperties.value("errorMessage").observe(model));
@@ -315,17 +314,19 @@ public class JournalViewerView {
         bindingContext.bindValue(WidgetProperties.enabled().observe(btnSearch),
                 BeanProperties.value("enableOrDisableButton").observe(model));
 
-        spinnerPageNumber.addListener(SWT.Selection, e -> {
-            setProgressIndicatorsVisible(true);
-            model.setPageNumber(spinnerPageNumber.getSelection()).thenAccept(ignored -> setProgressIndicatorsVisible(false));
-        });
+//        textPageNumber.addListener(SWT.Selection, e -> {
+//            setProgressIndicatorsVisible(true);
+//            model.setPageNumber(Integer.parseInt(textPageNumber.getText())).thenAccept(ignored -> setProgressIndicatorsVisible(false));
+//        });
 
         btnNewerPage.addListener(SWT.Selection, e -> {
-        	model.newerPage();
+        	setProgressIndicatorsVisible(true);
+        	model.setPageNumber(model.newerPageNumber()).thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
 
         btnOlderPage.addListener(SWT.Selection, e -> {
-        	model.olderPage();
+        	setProgressIndicatorsVisible(true);
+        	model.setPageNumber(model.olderPageNumber()).thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
 
         btnRefresh.addListener(SWT.Selection, e -> {

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/JournalViewerView.java
@@ -45,6 +45,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.ProgressBar;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.wb.swt.SWTResourceManager;
 
 import uk.ac.stfc.isis.ibex.journal.JournalField;
@@ -82,8 +83,8 @@ public class JournalViewerView {
 
     private Button btnRefresh;
     private Spinner spinnerPageNumber;
-    private Button btnPrevPage;
-    private Button btnNextPage;
+    private Button btnNewerPage;
+    private Button btnOlderPage;
     private SearchInput searchInput;
     private Button btnSearch;
     private ProgressBar progressBar;
@@ -139,18 +140,18 @@ public class JournalViewerView {
     	data.width = 200;
     	lblResults.setLayoutData(data);
 
-        btnPrevPage = new Button(basicControls, SWT.NONE);
-        btnPrevPage.setText(" < Newer ");
-        btnPrevPage.setToolTipText("Go to newer entries.");
-
+        btnNewerPage = new Button(basicControls, SWT.NONE);
+        btnNewerPage.setText(" < Newer ");
+        btnNewerPage.setToolTipText("Go to newer entries.");
+        
         spinnerPageNumber = new Spinner(basicControls, SWT.BORDER);
         spinnerPageNumber.setMinimum(1);
         spinnerPageNumber.setMaximum(1);
         spinnerPageNumber.setToolTipText("Page number (1 is newest).");
 
-        btnNextPage = new Button(basicControls, SWT.NONE);
-        btnNextPage.setText(" Older > ");
-        btnNextPage.setToolTipText("Go to older entries.");
+        btnOlderPage = new Button(basicControls, SWT.NONE);
+        btnOlderPage.setText(" Older > ");
+        btnOlderPage.setToolTipText("Go to older entries.");
 
         btnRefresh = new Button(basicControls, SWT.NONE);
         btnRefresh.setText("Refresh data");
@@ -302,6 +303,8 @@ public class JournalViewerView {
                 BeanProperties.value("lastUpdate").observe(model));
         bindingContext.bindValue(WidgetProperties.maximum().observe(spinnerPageNumber),
                 BeanProperties.value("pageMax").observe(model));
+        bindingContext.bindValue(WidgetProperties.spinnerSelection().observe(spinnerPageNumber), 
+        		BeanProperties.value("pageNumber").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(error),
                 BeanProperties.value("errorMessage").observe(model));
         bindingContext.bindValue(WidgetProperties.text().observe(lblResults),
@@ -317,20 +320,12 @@ public class JournalViewerView {
             model.setPageNumber(spinnerPageNumber.getSelection()).thenAccept(ignored -> setProgressIndicatorsVisible(false));
         });
 
-        btnPrevPage.addListener(SWT.Selection, e -> {
-        	int prevPageNumber = spinnerPageNumber.getSelection() - 1;
-        	if(prevPageNumber >= spinnerPageNumber.getMinimum()) {
-	        	spinnerPageNumber.setSelection(prevPageNumber);
-	        	spinnerPageNumber.notifyListeners(SWT.Selection, e); 	
-        	}
+        btnNewerPage.addListener(SWT.Selection, e -> {
+        	model.newerPage();
         });
 
-        btnNextPage.addListener(SWT.Selection, e -> {
-        	int nextPageNumber = spinnerPageNumber.getSelection() + 1;
-        	if(nextPageNumber <= spinnerPageNumber.getMaximum()) {
-	        	spinnerPageNumber.setSelection(nextPageNumber);
-	        	spinnerPageNumber.notifyListeners(SWT.Selection, e);
-        	}
+        btnOlderPage.addListener(SWT.Selection, e -> {
+        	model.olderPage();
         });
 
         btnRefresh.addListener(SWT.Selection, e -> {

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -50,7 +50,7 @@ public class JournalViewModel extends ModelObject {
 	private String lastUpdate;
 	private String resultsInfo;
 	private int pageMax;
-	private int pageNumber;
+	private int pageNumber = 1;
 	private int toNumber = 0;
 	private int fromNumber = 0;
 	private static final String NO_ERROR = "";
@@ -252,7 +252,7 @@ public class JournalViewModel extends ModelObject {
 	 * @return a CompletableFuture
 	 */
 	public CompletableFuture<Void> setPageNumber(int pageNumber) {
-		return model.setPage(pageNumber);
+		return model.setPageNumber(pageNumber);
 	}
 
 	/**
@@ -262,22 +262,30 @@ public class JournalViewModel extends ModelObject {
 		return model.getPage();
 	}
 	
-	public int newerPageNumber() {
+	public CompletableFuture<Void> newerPage() {
     	int newerPageNumber = model.getPage() - 1;
-    	int returnVal = model.getPage();
+    	CompletableFuture<Void> future = new CompletableFuture<>();
+    	
     	if(newerPageNumber >= 1) {
-    		returnVal = newerPageNumber;
+    		future = setPageNumber(newerPageNumber);
+    	} else {
+    		future.complete(null);
     	}
-    	return returnVal;
+    	
+    	return future;
 	}
 	
-	public int olderPageNumber() {
+	public CompletableFuture<Void> olderPage() {
     	int olderPageNumber = model.getPage() + 1;
-    	int returnVal = model.getPage();
+    	CompletableFuture<Void> future = new CompletableFuture<>();
+    	
     	if(olderPageNumber <= model.getPageMax()) {
-        	returnVal = olderPageNumber;
+    		future = setPageNumber(olderPageNumber);
+    	} else {
+    		future.complete(null);
     	}
-    	return returnVal;
+    	
+    	return future;
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -139,7 +139,7 @@ public class JournalViewModel extends ModelObject {
 			entryFrom = entryTo = 0;
 		}
 	
-		return String.format("Entries %d-%d of %d", entryFrom, entryTo, model.getResultsNumber());
+		return String.format("%d-%d of %d", entryFrom, entryTo, model.getResultsNumber());
 	}
 	
 	private void setResultsInfo(String resultsInfo) {
@@ -254,7 +254,7 @@ public class JournalViewModel extends ModelObject {
 	public void updatePageNumber(int pageNumber) {
 		firePropertyChange("pageNumber", this.pageNumber, this.pageNumber = pageNumber);
 	}
-	
+
 	/**
 	 * @param pageNumber The number of the results page.
 	 * @return a CompletableFuture
@@ -276,6 +276,19 @@ public class JournalViewModel extends ModelObject {
 	 */
 	public int getPageNumber() {
 		return model.getPage();
+	}
+	
+	/**
+	 * Calls {@link JournalViewModel#setPageNumber(int)} to change the current page to pageNumber.
+	 * If the desired page is not available due to it being higher than the maximum page number,
+	 * change the current page to the last (max page number) instead.
+	 * @param pageNumber The number of the desired results page.
+	 * @return a CompletableFuture.
+	 */
+	public CompletableFuture<Void> goToPage(int pageNumber) {
+		CompletableFuture<Void> future = new CompletableFuture<>();
+		future = (pageNumber > getPageMax()) ? setPageNumber(getPageMax()) : setPageNumber(pageNumber);
+		return future;
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -289,6 +289,24 @@ public class JournalViewModel extends ModelObject {
 	}
 	
 	/**
+	 * Calls {@link JournalViewModel#setPageNumber(int)} to set the current page number to minimum.
+	 * @return a CompletableFuture.
+	 */
+	public CompletableFuture<Void> newestPage() {
+    	int newestPageNumber = 1;
+    	return setPageNumber(newestPageNumber);
+	}
+	
+	/**
+	 * Calls {@link JournalViewModel#setPageNumber(int)} to set the current page number to maximum.
+	 * @return a CompletableFuture.
+	 */
+	public CompletableFuture<Void> oldestPage() {
+    	int oldestPageNumber = model.getPageMax();
+    	return setPageNumber(oldestPageNumber);
+	}
+	
+	/**
 	 * @param max The maximum number of pages supported by the journal view.
 	 */
 	public void setPageMax(int max) {

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -260,10 +260,11 @@ public class JournalViewModel extends ModelObject {
 	 * @return a CompletableFuture
 	 */
 	public CompletableFuture<Void> setPageNumber(int pageNumber) {
-		CompletableFuture<Void> future = new CompletableFuture<>();
+		CompletableFuture<Void> future;
 		if (pageNumber >= 1 && pageNumber <= model.getPageMax()) {
 			future = model.setPageNumber(pageNumber);
 		} else {
+		    future = new CompletableFuture<Void>();
 			future.complete(null);
 			setMessage(String.format("Page [%d] is out of bounds", pageNumber));
 		}
@@ -286,9 +287,7 @@ public class JournalViewModel extends ModelObject {
 	 * @return a CompletableFuture.
 	 */
 	public CompletableFuture<Void> goToPage(int pageNumber) {
-		CompletableFuture<Void> future = new CompletableFuture<>();
-		future = (pageNumber > getPageMax()) ? setPageNumber(getPageMax()) : setPageNumber(pageNumber);
-		return future;
+		return (pageNumber > getPageMax()) ? setPageNumber(getPageMax()) : setPageNumber(pageNumber);
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -108,6 +108,13 @@ public class JournalViewModel extends ModelObject {
 		firePropertyChange("lastUpdate", this.lastUpdate, this.lastUpdate = lastUpdate);
 	}
 	
+	/**
+	 * @return String containing the number of total results and currently displayed entries.
+	 */
+	public String getResultsInfo() {
+		return model.getResultsInfo();
+	}
+	
 	private void setResultsInfo(String resultsInfo) {
 		firePropertyChange("resultsInfo", this.resultsInfo, this.resultsInfo = resultsInfo);
 	}
@@ -248,13 +255,6 @@ public class JournalViewModel extends ModelObject {
 	 */
 	public int getResultsNumber() {
 		return model.getResultsNumber();
-	}
-	
-	/**
-	 * @return String containing the number of total results and currently displayed entries.
-	 */
-	public String getResultsInfo() {
-		return model.getResultsInfo();
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -110,14 +110,14 @@ public class JournalViewModel extends ModelObject {
 	private void setLastUpdate(String lastUpdate) {
 		firePropertyChange("lastUpdate", this.lastUpdate, this.lastUpdate = lastUpdate);
 	}
-	
+
 	/**
 	 * @return The current number of result entries.
 	 */
 	public int getResultsNumber() {
 		return model.getResultsNumber();
 	}
-	
+
     /**
      * Returns the number of total current results and the currently displayed results depending on page and page size.
      * @return The number of total results and currently displayed entries.
@@ -262,18 +262,22 @@ public class JournalViewModel extends ModelObject {
 		return model.getPage();
 	}
 	
-	public void newerPage() {
+	public int newerPageNumber() {
     	int newerPageNumber = model.getPage() - 1;
+    	int returnVal = model.getPage();
     	if(newerPageNumber >= 1) {
-        	setPageNumber(newerPageNumber);
+    		returnVal = newerPageNumber;
     	}
+    	return returnVal;
 	}
 	
-	public void olderPage() {
+	public int olderPageNumber() {
     	int olderPageNumber = model.getPage() + 1;
+    	int returnVal = model.getPage();
     	if(olderPageNumber <= model.getPageMax()) {
-        	setPageNumber(olderPageNumber);
+        	returnVal = olderPageNumber;
     	}
+    	return returnVal;
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -252,7 +252,15 @@ public class JournalViewModel extends ModelObject {
 	 * @return a CompletableFuture
 	 */
 	public CompletableFuture<Void> setPageNumber(int pageNumber) {
-		return model.setPageNumber(pageNumber);
+		CompletableFuture<Void> future = new CompletableFuture<>();
+		if (pageNumber >= 1 && pageNumber <= model.getPageMax()) {
+			future = model.setPageNumber(pageNumber);
+		} else {
+			future.complete(null);
+		}
+		setMessage(String.format("Page [%d] is out of bounds", pageNumber));
+		
+		return future;
 	}
 
 	/**
@@ -262,30 +270,22 @@ public class JournalViewModel extends ModelObject {
 		return model.getPage();
 	}
 	
+	/**
+	 * Calls {@link JournalViewModel#setPageNumber(int)} to lower the current page number by 1.
+	 * @return a CompletableFuture.
+	 */
 	public CompletableFuture<Void> newerPage() {
     	int newerPageNumber = model.getPage() - 1;
-    	CompletableFuture<Void> future = new CompletableFuture<>();
-    	
-    	if(newerPageNumber >= 1) {
-    		future = setPageNumber(newerPageNumber);
-    	} else {
-    		future.complete(null);
-    	}
-    	
-    	return future;
+    	return setPageNumber(newerPageNumber);
 	}
 	
+	/**
+	 * Calls {@link JournalViewModel#setPageNumber(int)} to increase the current page number by 1.
+	 * @return a CompletableFuture.
+	 */
 	public CompletableFuture<Void> olderPage() {
     	int olderPageNumber = model.getPage() + 1;
-    	CompletableFuture<Void> future = new CompletableFuture<>();
-    	
-    	if(olderPageNumber <= model.getPageMax()) {
-    		future = setPageNumber(olderPageNumber);
-    	} else {
-    		future.complete(null);
-    	}
-    	
-    	return future;
+    	return setPageNumber(olderPageNumber);
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -48,6 +48,7 @@ public class JournalViewModel extends ModelObject {
 	private String message;
 	private List<JournalRow> runs;
 	private String lastUpdate;
+	private String resultsInfo;
 	private int toNumber = 0;
 	private int fromNumber = 0;
 	private static final String NO_ERROR = "";
@@ -82,6 +83,7 @@ public class JournalViewModel extends ModelObject {
 		setMessage(model.getMessage());
 		setRuns(model.getRuns());
 		setPageNumberMax(model.getPageMax());
+		setResultsInfo(model.getResultsInfo());
 	}
 
 	/**
@@ -104,6 +106,10 @@ public class JournalViewModel extends ModelObject {
 
 	private void setLastUpdate(String lastUpdate) {
 		firePropertyChange("lastUpdate", this.lastUpdate, this.lastUpdate = lastUpdate);
+	}
+	
+	private void setResultsInfo(String resultsInfo) {
+		firePropertyChange("resultsInfo", this.resultsInfo, this.resultsInfo = resultsInfo);
 	}
 
 	/**
@@ -245,7 +251,7 @@ public class JournalViewModel extends ModelObject {
 	}
 	
 	/**
-	 * @return The number of total results and currently displayed entries.
+	 * @return String containing the number of total results and currently displayed entries.
 	 */
 	public String getResultsInfo() {
 		return model.getResultsInfo();

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -49,6 +49,7 @@ public class JournalViewModel extends ModelObject {
 	private List<JournalRow> runs;
 	private String lastUpdate;
 	private String resultsInfo;
+	private int pageNumberMax;
 	private int toNumber = 0;
 	private int fromNumber = 0;
 	private static final String NO_ERROR = "";
@@ -240,7 +241,7 @@ public class JournalViewModel extends ModelObject {
 	 * @param max The maximum number of pages supported by the journal view.
 	 */
 	public void setPageNumberMax(int max) {
-		firePropertyChange("pageNumberMax", 0, model.getPageMax());
+		firePropertyChange("pageNumberMax", this.pageNumberMax, this.pageNumberMax = max);
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -236,6 +236,20 @@ public class JournalViewModel extends ModelObject {
 	public int getPageNumberMax() {
 		return model.getPageMax();
 	}
+	
+	/**
+	 * @return The current number of result entries.
+	 */
+	public int getResultsNumber() {
+		return model.getResultsNumber();
+	}
+	
+	/**
+	 * @return The number of total results and currently displayed entries.
+	 */
+	public String getResultsInfo() {
+		return model.getResultsInfo();
+	}
 
 	/**
 	 * @return the searchableFields

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -50,6 +50,7 @@ public class JournalViewModel extends ModelObject {
 	private String lastUpdate;
 	private String resultsInfo;
 	private int pageMax;
+	private int pageNumber;
 	private int toNumber = 0;
 	private int fromNumber = 0;
 	private static final String NO_ERROR = "";
@@ -84,6 +85,7 @@ public class JournalViewModel extends ModelObject {
 		setMessage(model.getMessage());
 		setRuns(model.getRuns());
 		setPageMax(model.getPageMax());
+		updatePageNumber(model.getPage());
 		setResultsInfo(getResultsInfo());
 	}
 
@@ -241,6 +243,10 @@ public class JournalViewModel extends ModelObject {
 		return date.after(today);
 	}
 
+	public void updatePageNumber(int pageNumber) {
+		firePropertyChange("pageNumber", this.pageNumber, this.pageNumber = pageNumber);
+	}
+	
 	/**
 	 * @param pageNumber The number of the results page.
 	 * @return a CompletableFuture
@@ -255,7 +261,21 @@ public class JournalViewModel extends ModelObject {
 	public int getPageNumber() {
 		return model.getPage();
 	}
-
+	
+	public void newerPage() {
+    	int newerPageNumber = model.getPage() - 1;
+    	if(newerPageNumber >= 1) {
+        	setPageNumber(newerPageNumber);
+    	}
+	}
+	
+	public void olderPage() {
+    	int olderPageNumber = model.getPage() + 1;
+    	if(olderPageNumber <= model.getPageMax()) {
+        	setPageNumber(olderPageNumber);
+    	}
+	}
+	
 	/**
 	 * @param max The maximum number of pages supported by the journal view.
 	 */

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -49,7 +49,7 @@ public class JournalViewModel extends ModelObject {
 	private List<JournalRow> runs;
 	private String lastUpdate;
 	private String resultsInfo;
-	private int pageNumberMax;
+	private int pageMax;
 	private int toNumber = 0;
 	private int fromNumber = 0;
 	private static final String NO_ERROR = "";
@@ -83,8 +83,8 @@ public class JournalViewModel extends ModelObject {
 		setLastUpdate("Last successful update: " + dateToString(model.getLastUpdate()));
 		setMessage(model.getMessage());
 		setRuns(model.getRuns());
-		setPageNumberMax(model.getPageMax());
-		setResultsInfo(model.getResultsInfo());
+		setPageMax(model.getPageMax());
+		setResultsInfo(getResultsInfo());
 	}
 
 	/**
@@ -110,11 +110,30 @@ public class JournalViewModel extends ModelObject {
 	}
 	
 	/**
-	 * @return String containing the number of total results and currently displayed entries.
+	 * @return The current number of result entries.
 	 */
-	public String getResultsInfo() {
-		return model.getResultsInfo();
+	public int getResultsNumber() {
+		return model.getResultsNumber();
 	}
+	
+    /**
+     * Returns the number of total current results and the currently displayed results depending on page and page size.
+     * @return The number of total results and currently displayed entries.
+     */
+    public String getResultsInfo() {
+    	int entryFrom;
+    	int entryTo;
+
+    	if (model.getResultsNumber() != 0 && model.getPageSize() != 0) {
+	    	entryFrom = (model.getPage() - 1) * model.getPageSize() + 1;
+	    	entryTo = entryFrom + model.getPageSize() - 1;
+	    	if (entryTo > model.getResultsNumber()) { entryTo = model.getResultsNumber(); }
+    	} else {
+    		entryFrom = entryTo = 0;
+    	}
+
+    	return String.format("Entries %d-%d of %d", entryFrom, entryTo, model.getResultsNumber());
+    }
 	
 	private void setResultsInfo(String resultsInfo) {
 		firePropertyChange("resultsInfo", this.resultsInfo, this.resultsInfo = resultsInfo);
@@ -240,22 +259,15 @@ public class JournalViewModel extends ModelObject {
 	/**
 	 * @param max The maximum number of pages supported by the journal view.
 	 */
-	public void setPageNumberMax(int max) {
-		firePropertyChange("pageNumberMax", this.pageNumberMax, this.pageNumberMax = max);
+	public void setPageMax(int max) {
+		firePropertyChange("pageMax", this.pageMax, this.pageMax = max);
 	}
 
 	/**
 	 * @return The maximum number of pages supported by the journal view.
 	 */
-	public int getPageNumberMax() {
+	public int getPageMax() {
 		return model.getPageMax();
-	}
-	
-	/**
-	 * @return The current number of result entries.
-	 */
-	public int getResultsNumber() {
-		return model.getResultsNumber();
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.journalviewer/src/uk/ac/stfc/isis/ibex/ui/journalviewer/models/JournalViewModel.java
@@ -117,25 +117,25 @@ public class JournalViewModel extends ModelObject {
 	public int getResultsNumber() {
 		return model.getResultsNumber();
 	}
-
-    /**
-     * Returns the number of total current results and the currently displayed results depending on page and page size.
-     * @return The number of total results and currently displayed entries.
-     */
-    public String getResultsInfo() {
-    	int entryFrom;
-    	int entryTo;
-
-    	if (model.getResultsNumber() != 0 && model.getPageSize() != 0) {
+	
+	/**
+	 * Returns the number of total current results and the currently displayed results depending on page and page size.
+	 * @return The number of total results and currently displayed entries.
+	 */
+	public String getResultsInfo() {
+		int entryFrom;
+		int entryTo;
+	
+		if (model.getResultsNumber() != 0 && model.getPageSize() != 0) {
 	    	entryFrom = (model.getPage() - 1) * model.getPageSize() + 1;
 	    	entryTo = entryFrom + model.getPageSize() - 1;
 	    	if (entryTo > model.getResultsNumber()) { entryTo = model.getResultsNumber(); }
-    	} else {
-    		entryFrom = entryTo = 0;
-    	}
-
-    	return String.format("Entries %d-%d of %d", entryFrom, entryTo, model.getResultsNumber());
-    }
+		} else {
+			entryFrom = entryTo = 0;
+		}
+	
+		return String.format("Entries %d-%d of %d", entryFrom, entryTo, model.getResultsNumber());
+	}
 	
 	private void setResultsInfo(String resultsInfo) {
 		firePropertyChange("resultsInfo", this.resultsInfo, this.resultsInfo = resultsInfo);

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/NumbersOnlyListener.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/NumbersOnlyListener.java
@@ -1,0 +1,50 @@
+ /*
+ * This file is part of the ISIS IBEX application.
+ * Copyright (C) 2012-2017 Science & Technology Facilities Council.
+ * All rights reserved.
+ *
+ * This program is distributed in the hope that it will be useful.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v1.0 which accompanies this distribution.
+ * EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
+ * AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
+ * OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+ *
+ * You should have received a copy of the Eclipse Public License v1.0
+ * along with this program; if not, you can obtain a copy from
+ * https://www.eclipse.org/org/documents/epl-v10.php or 
+ * http://opensource.org/licenses/eclipse-1.0.php
+ */
+
+package uk.ac.stfc.isis.ibex.validators;
+
+import java.util.regex.Pattern;
+
+import org.eclipse.swt.events.VerifyEvent;
+import org.eclipse.swt.events.VerifyListener;
+import org.eclipse.swt.widgets.Text;
+
+/**
+ * SWT verifier that checks whether text input contains only numeric characters.
+ */
+public class NumbersOnlyListener implements VerifyListener {
+
+    final Pattern numbersOnly = Pattern.compile("\\d*");
+	
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void verifyText(VerifyEvent e) {
+        String oldString = ((Text) e.getSource()).getText();
+        String newString = oldString.substring(0, e.start) + e.text + oldString.substring(e.end);
+
+
+        if (newString != null && numbersOnly.matcher(newString).matches()) {
+        	e.doit = true;
+        } else {
+        	e.doit = false;
+        }
+    }
+    
+}


### PR DESCRIPTION
### Description of work

1. **Replaced the old spinner with new UI elements for page control:**
   - Text label to show currently displayed entries out of total `e.g. Entries 16-30 out of 50`. 
      Search filters are taken into consideration when displaying the total results.
   - Buttons to navigate through the pages: `First, Previous, Next, Last`. Buttons will be greyed out when not relevant or pressing them would cause an out of bounds error (e.g. Next button on the last page).
   - Text field displaying the current page; user can type in a page number to navigate there.
      Field input is verified via listener to be numbers only. If desired page number is out of bounds due to it being too high, page will be set to last (page max). If desired page is out of bounds due to other reasons, users will be informed by message.
2. **Various adjustments and some bugfixes:**
   - Replaced the runs/results count prepared statement method `constructCountFieldsSQLQuery` in `JournalModel` with the new `constructCountQuery` in `JournalSearch`. This was in order to get the correct number of available results, as before it would not care about the search filters, which was also resulting in an incorrect maximum page numbers. That has been now fixed.
   - All `JournalModel` fields are now changed with `firePropertyChange` in order to be updated on time, as before they wouldn't trigger the listener in `JournalViewModel` which caused them to be updated late (one step behind).
   - Fixed `maxPage` and `pageNumber` (current page) not being updated upon instrument switch.
   - Other small adjustments, such as member name changes to conform with the others (`e.g. pageNumberMax to pageMax as the method was getPageMax and not getPageNumberMax`) and method improvements (`e.g. calcTotalPages returning 0 for pageMax which was causing the issue above`).

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4479

### Acceptance criteria

Acceptance criteria:

1. The page number spinner is replaced with something more intuitive.
2. Functionality is equivalent to the spinner.

### Unit tests

Added unit tests for:
- `JournalModel.calcTotalPages()` in `base/uk.ac.stfc.isis.ibex.journal.tests/src/uk/ac/stfc/isis/ibex/journal/tests/JournalCalcTotalPagesTest.java`

- `JournalViewModel.getResultsInfo()` in `base/uk.ac.stfc.isis.ibex.ui.journalviewer.tests/src/uk/ac/stfc/isis/ibex/ui/journalviewer/tests/JournalViewModelTest.java`

### System tests

N/A

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

