### PR TITLE
Ticket 5708: Set the selection of cell editors after focus leaves editor

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -698,18 +698,20 @@ public class ScriptGeneratorViewModel extends ModelObject {
             }
             });
 
-        column.setEditingSupport(new StringEditingSupport<ScriptGeneratorAction>(viewTable.viewer(), ScriptGeneratorAction.class) {
-
-        @Override
-        protected String valueFromRow(ScriptGeneratorAction row) {
-            return row.getActionParameterValue(actionParameter);
-        }
-
-        @Override
-        protected void setValueForRow(ScriptGeneratorAction row, String value) {
-            row.setActionParameterValue(actionParameter, value);
-        }
-        });    
+        var editingSupport = new StringEditingSupport<ScriptGeneratorAction>(viewTable.viewer(), ScriptGeneratorAction.class) {          
+            @Override
+            protected String valueFromRow(ScriptGeneratorAction row) {
+                return row.getActionParameterValue(actionParameter);
+            }
+    
+            @Override
+            protected void setValueForRow(ScriptGeneratorAction row, String value) {
+                row.setActionParameterValue(actionParameter, value);
+            }
+        };
+        viewTable.addEditingSupport(editingSupport);
+        column.setEditingSupport(editingSupport);
+        
     }
     // Add validity notifier column
     TableViewerColumn validityColumn = viewTable.createColumn("Validity", 


### PR DESCRIPTION
### Description of work

A hot fix that will reset the selection of a cell if it loses focus. Note that further docs and a better solution will be provided to call the ticket complete.

### Ticket

See https://github.com/ISISComputingGroup/IBEX/issues/5708

### Acceptance criteria

Fixes original issue and causes no new side effects

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

