### PR TITLE
Remove height2 for vertical mode. Fix PVs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/POLREF/sample_stack.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/POLREF/sample_stack.opi
@@ -220,7 +220,7 @@
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PARAM_NAME>Height</PARAM_NAME>
-        <PARAM_PV>SAMPHEIGHT</PARAM_PV>
+        <PARAM_PV>SAMPOFFSET</PARAM_PV>
       </macros>
       <name>Linking Container</name>
       <opi_file>../param_move.opi</opi_file>
@@ -262,7 +262,7 @@
       <macros>
         <include_parent_macros>true</include_parent_macros>
         <PARAM_NAME>Height2</PARAM_NAME>
-        <PARAM_PV>SAMPOFFSET</PARAM_PV>
+        <PARAM_PV>SAMPHEIGHT</PARAM_PV>
       </macros>
       <name>Linking Container</name>
       <opi_file>../param_move.opi</opi_file>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/POLREF_VERT/sample_stack.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/POLREF_VERT/sample_stack.opi
@@ -261,8 +261,8 @@
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
-        <PARAM_NAME>HEIGHT2_OF</PARAM_NAME>
-        <PARAM_PV>HEIGHT2_OF</PARAM_PV>
+        <PARAM_NAME>Trans</PARAM_NAME>
+        <PARAM_PV>SAMPTRANS</PARAM_PV>
       </macros>
       <name>Linking Container</name>
       <opi_file>../param_move.opi</opi_file>
@@ -281,48 +281,6 @@
       <wuid>2150758c:16990a9ebac:-73e7</wuid>
       <x>0</x>
       <y>92</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-      </font>
-      <foreground_color>
-        <color red="192" green="192" blue="192" />
-      </foreground_color>
-      <group_name></group_name>
-      <height>25</height>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-        <PARAM_NAME>Trans</PARAM_NAME>
-        <PARAM_PV>SAMPTRANS</PARAM_PV>
-      </macros>
-      <name>Linking Container</name>
-      <opi_file>../param_move.opi</opi_file>
-      <resize_behaviour>1</resize_behaviour>
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts />
-      <tooltip></tooltip>
-      <visible>true</visible>
-      <widget_type>Linking Container</widget_type>
-      <width>441</width>
-      <wuid>26a128d5:1730f1e20ee:-69e3</wuid>
-      <x>0</x>
-      <y>117</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">


### PR DESCRIPTION
### Description of work

Minor changes for POLREF front panel OPI: 
- made PVs for height / height2 the right way around
- removed height2 for vertical mode

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5459

### Acceptance criteria

OPI is correct

### Unit tests

/
### System tests

/

### Documentation

https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Reflectomtery-IOC-POLREF#sample-stack

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

