### PR TITLE
Filtering configs should be done on name, not description

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/ConfigInfo.java
@@ -165,11 +165,11 @@ public class ConfigInfo {
      * 
      * @param infos
      *            The list of ConfigInfos
-     * @return The sorted map of configuration/component descriptions without the current one
+     * @return The sorted map of configuration/component name to descriptions without the current one
      */
     public static SortedMap<String, String> namesAndDescriptionsWithoutCurrent(Collection<ConfigInfo> infos) {
         SortedMap<String, String> filteredNamesAndDescriptions = namesAndDescriptions(infos);
-        filteredNamesAndDescriptions.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().description());
+        filteredNamesAndDescriptions.remove(Configurations.getInstance().display().displayCurrentConfig().getValue().name());
         return filteredNamesAndDescriptions;
     }
     
@@ -178,7 +178,7 @@ public class ConfigInfo {
      * 
      * @param infos
      *            The list of ConfigInfos
-     * @return The sorted map of configuration/component descriptions without the current one
+     * @return The sorted map of configuration/component name to description
      */
     public static SortedMap<String, String> namesAndDescriptions(Collection<ConfigInfo> infos) {
     	if (infos == null || infos.isEmpty()) {


### PR DESCRIPTION
### Description of work

When filtering configs we should do it on the name not description, this was happening to work in some cases as people are lazy and set the description equal to the name. This was caught be a squish test.

To test:
* On master create a config that has the same name and description and switch to it
* Confirm it doesn't appear in the delete configuration dialog
* Change the description to not be the same as the name
* Confirm it does appear in the delete configuration dialog
* Switch to this branch and confirm it no longer appears in the dialog in either case

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

