### PR TITLE
Selectively hide polarity SP

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/danfysik_calibrated.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/danfysik_calibrated.opi
@@ -475,7 +475,7 @@ $(pv_value)</tooltip>
       </macros>
       <name>Grouping Container</name>
       <rules>
-        <rule name="Visibile when bipolar" prop_id="visible" out_exp="false">
+        <rule name="Visible when bipolar" prop_id="visible" out_exp="false">
           <exp bool_exp="pvStr0!=&quot;BIPOLAR&quot;">
             <value>false</value>
           </exp>
@@ -617,7 +617,14 @@ $(pv_value)</tooltip>
         <name>ChoiceBtn</name>
         <pv_name>$(PV_ROOT)POL:SP</pv_name>
         <pv_value />
-        <rules />
+        <rules>
+          <rule name="Visibility" prop_id="visible" out_exp="false">
+            <exp bool_exp="pv0">
+              <value>false</value>
+            </exp>
+            <pv trig="true">$(PV_ROOT)POL:HIDE</pv>
+          </rule>
+        </rules>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/danfysik_uncalibrated.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/danfysik_uncalibrated.opi
@@ -299,7 +299,7 @@ $(pv_value)</tooltip>
       </macros>
       <name>Grouping Container</name>
       <rules>
-        <rule name="Visibile when bipolar" prop_id="visible" out_exp="false">
+        <rule name="Visible when bipolar" prop_id="visible" out_exp="false">
           <exp bool_exp="pvStr0!=&quot;BIPOLAR&quot;">
             <value>false</value>
           </exp>
@@ -441,7 +441,14 @@ $(pv_value)</tooltip>
         <name>ChoiceBtn</name>
         <pv_name>$(PV_ROOT)POL:SP</pv_name>
         <pv_value />
-        <rules />
+        <rules>
+          <rule name="Visibility" prop_id="visible" out_exp="false">
+            <exp bool_exp="pv0">
+              <value>false</value>
+            </exp>
+            <pv trig="true">$(PV_ROOT)POL:HIDE</pv>
+          </rule>
+        </rules>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>


### PR DESCRIPTION
### Description of work

Show polarity setpoint only when IOC is explicitly set to do so.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5296

### Acceptance criteria

- Polarity setpoint is hidden for standard DFKPS
- Polarity setpoint is shown for RIKEN DFKPS

### Unit tests

/

### System tests

/

### Documentation

/

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

