### PR TITLE
Fix typo in Kepco OPI

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/kepco.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/kepco.opi
@@ -1164,7 +1164,7 @@ $(pv_value)</tooltip>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
-    <name>Contol</name>
+    <name>Control</name>
     <rules />
     <scale_options>
       <width_scalable>true</width_scalable>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/kepco.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/kepco.opi
@@ -1164,7 +1164,7 @@ $(pv_value)</tooltip>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
-    <name>Control</name>
+    <name>Communications</name>
     <rules />
     <scale_options>
       <width_scalable>true</width_scalable>


### PR DESCRIPTION
### Description of work

Fixes "contol" to "communications" in Kepco OPI, found during ISISComputingGroup/IBEX#5851 

### Ticket

Relates to ISISComputingGroup/IBEX#5851

### Acceptance criteria

Typo is fixed

### Unit tests

N/A

### System tests

N/A

### Documentation

N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

