### PR TITLE
fix checkstyle warnings

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryActivationParametersTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryActivationParametersTargetView.java
@@ -24,25 +24,29 @@ package uk.ac.stfc.isis.ibex.ui.reflectometry;
 
 
 /**
- * A standalone view for the Reflectometry Activation Parameters OPI
+ * A standalone view for the Reflectometry Activation Parameters OPI.
  */
 public class ReflectometryActivationParametersTargetView extends ReflectometryOpiTargetView {
-    /**
-     * Class ID.
-     */
-    public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryFrontPanelTargetView";
+	/**
+	 * Class ID.
+	 */
+	public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryFrontPanelTargetView";
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiName() {
-    	return "reflectometry/tab_activation_params.opi";
-    }
+	/**
+	 * File name of the reflectometry OPI.
+	 * 
+	 * @return the OPI file name
+	 */
+	protected String getOpiName() {
+		return "reflectometry/tab_activation_params.opi";
+	}
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiTitle() {
-    	return "Activation Parameters";
-    }
+	/**
+	 * The title of the OPI view.
+	 * 
+	 * @return the OPI title
+	 */
+	protected String getOpiTitle() {
+		return "Activation Parameters";
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryCollimationParametersTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryCollimationParametersTargetView.java
@@ -23,25 +23,29 @@
 package uk.ac.stfc.isis.ibex.ui.reflectometry;
 
 /**
- * A standalone view for the Reflectometry Collimation Plane Parameters OPI
+ * A standalone view for the Reflectometry Collimation Plane Parameters OPI.
  */
 public class ReflectometryCollimationParametersTargetView extends ReflectometryOpiTargetView {
-    /**
-     * Class ID.
-     */
-    public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryCollimationParametersTargetView";
+	/**
+	 * Class ID.
+	 */
+	public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryCollimationParametersTargetView";
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiName() {
-    	return "reflectometry/tab_collimation_params.opi";
-    }
+	/**
+	 * File name of the reflectometry OPI.
+	 * 
+	 * @return the OPI file name
+	 */
+	protected String getOpiName() {
+		return "reflectometry/tab_collimation_params.opi";
+	}
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiTitle() {
-    	return "Collimation Plane Parameters";
-    }
+	/**
+	 * The title of the OPI view.
+	 * 
+	 * @return the OPI title
+	 */
+	protected String getOpiTitle() {
+		return "Collimation Plane Parameters";
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryConstantsTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryConstantsTargetView.java
@@ -23,7 +23,7 @@
 package uk.ac.stfc.isis.ibex.ui.reflectometry;
 
 /**
- * A standalone view for the Reflectometry Constants OPI
+ * A standalone view for the Reflectometry Constants OPI.
  */
 public class ReflectometryConstantsTargetView extends ReflectometryOpiTargetView {
     /**
@@ -33,13 +33,17 @@ public class ReflectometryConstantsTargetView extends ReflectometryOpiTargetView
 
     /**
      * File name of the reflectometry OPI.
+     * 
+     * @return the OPI file name
      */
     protected String getOpiName() {
     	return "reflectometry/tab_constants.opi";
     }
 
     /**
-     * File name of the reflectometry OPI.
+     * The title of the OPI view.
+     * 
+     * @return the OPI title
      */
     protected String getOpiTitle() {
     	return "Constants";

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryCorrectionsTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryCorrectionsTargetView.java
@@ -23,25 +23,30 @@
 package uk.ac.stfc.isis.ibex.ui.reflectometry;
 
 /**
- * A standalone view for the Reflectometry Corrections OPI
+ * A standalone view for the Reflectometry Corrections OPI.
  */
 public class ReflectometryCorrectionsTargetView extends ReflectometryOpiTargetView {
-    /**
-     * Class ID.
-     */
-    public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryCorrectionsTargetView";
+	/**
+	 * Class ID.
+	 */
+	public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryCorrectionsTargetView";
+
 
     /**
      * File name of the reflectometry OPI.
+     * 
+     * @return the OPI file name
      */
-    protected String getOpiName() {
-    	return "reflectometry/tab_corrections.opi";
-    }
+	protected String getOpiName() {
+		return "reflectometry/tab_corrections.opi";
+	}
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiTitle() {
-    	return "Driver Corrections";
-    }
+	/**
+	 * The title of the OPI view.
+	 * 
+	 * @return the OPI title
+	 */
+	protected String getOpiTitle() {
+		return "Driver Corrections";
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryErrorLogTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryErrorLogTargetView.java
@@ -23,25 +23,29 @@
 package uk.ac.stfc.isis.ibex.ui.reflectometry;
 
 /**
- * A standalone view for the Reflectometry Error Log OPI
+ * A standalone view for the Reflectometry Error Log OPI.
  */
 public class ReflectometryErrorLogTargetView extends ReflectometryOpiTargetView {
-    /**
-     * Class ID.
-     */
-    public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryErrorLogTargetView";
+	/**
+	 * Class ID.
+	 */
+	public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryErrorLogTargetView";
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiName() {
-    	return "reflectometry/tab_error_log.opi";
-    }
+	/**
+	 * File name of the reflectometry OPI.
+	 * 
+	 * @return the OPI file name
+	 */
+	protected String getOpiName() {
+		return "reflectometry/tab_error_log.opi";
+	}
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiTitle() {
-    	return "Error Log";
-    }
+	/**
+	 * The title of the OPI view.
+	 * 
+	 * @return the OPI title
+	 */
+	protected String getOpiTitle() {
+		return "Error Log";
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryFrontPanelTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryFrontPanelTargetView.java
@@ -23,25 +23,29 @@
 package uk.ac.stfc.isis.ibex.ui.reflectometry;
 
 /**
- * A standalone view for the Reflectometry Front Panel OPI
+ * A standalone view for the Reflectometry Front Panel OPI.
  */
 public class ReflectometryFrontPanelTargetView extends ReflectometryOpiTargetView {
-    /**
-     * Class ID.
-     */
-    public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryFrontPanelTargetView";
+	/**
+	 * Class ID.
+	 */
+	public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryFrontPanelTargetView";
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiName() {
-    	return "reflectometry/tab_front_panel.opi";
-    }
+	/**
+	 * File name of the reflectometry OPI.
+	 * 
+	 * @return the OPI file name
+	 */
+	protected String getOpiName() {
+		return "reflectometry/tab_front_panel.opi";
+	}
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiTitle() {
-    	return "Front Panel";
-    }
+	/**
+	 * The title of the OPI view.
+	 * 
+	 * @return the OPI title
+	 */
+	protected String getOpiTitle() {
+		return "Front Panel";
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryOpiTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryOpiTargetView.java
@@ -33,32 +33,36 @@ import uk.ac.stfc.isis.ibex.opis.Opi;
 import uk.ac.stfc.isis.ibex.ui.targets.OpiTargetView;
 
 /**
- * The ReflectometryOpiTargetView shows a stand-alone OPI for the reflectometry front panel.
+ * Shows a stand-alone view for a reflectometry OPI.
  */
 public abstract class ReflectometryOpiTargetView extends OpiTargetView {
-    /**
-     * Class ID.
-     */
-    public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryOpiTargetView";
+	/**
+	 * Class ID.
+	 */
+	public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryOpiTargetView";
 
     /**
      * File name of the reflectometry OPI.
+     * 
+     * @return the OPI file name
      */
-    protected abstract String getOpiName();
+	protected abstract String getOpiName();
 
     /**
-     * File name of the reflectometry OPI.
+     * The title of the OPI view.
+     * 
+     * @return the OPI title
      */
-    protected abstract String getOpiTitle();
+	protected abstract String getOpiTitle();
 
-    /**
-     * {@inheritDoc}
-     */
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	protected Path opi() throws OPIViewCreationException {
 		return Opi.getDefault().opiProvider().pathFromName(getOpiName());
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -76,11 +80,11 @@ public abstract class ReflectometryOpiTargetView extends OpiTargetView {
 	 * {@inheritDoc}
 	 */
 	@Override
-    public MacrosInput macros() {
-    	MacrosInput macros = emptyMacrosInput();
-    	macros.put("NAME", getOpiTitle());
-    	macros.put("P", Instrument.getInstance().currentInstrument().pvPrefix());
-    	return macros;
-    }
+	public MacrosInput macros() {
+		MacrosInput macros = emptyMacrosInput();
+		macros.put("NAME", getOpiTitle());
+		macros.put("P", Instrument.getInstance().currentInstrument().pvPrefix());
+		return macros;
+	}
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryOtherParametersTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryOtherParametersTargetView.java
@@ -23,7 +23,7 @@
 package uk.ac.stfc.isis.ibex.ui.reflectometry;
 
 /**
- * A standalone view for the Reflectometry Other Parameters OPI
+ * A standalone view for the Reflectometry Other Parameters OPI.
  */
 public class ReflectometryOtherParametersTargetView extends ReflectometryOpiTargetView {
     /**
@@ -33,13 +33,17 @@ public class ReflectometryOtherParametersTargetView extends ReflectometryOpiTarg
 
     /**
      * File name of the reflectometry OPI.
+     * 
+     * @return the OPI file name
      */
     protected String getOpiName() {
     	return "reflectometry/tab_other_params.opi";
     }
 
     /**
-     * File name of the reflectometry OPI.
+     * The title of the OPI view.
+     * 
+     * @return the OPI title
      */
     protected String getOpiTitle() {
     	return "Other Parameters";

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryRedefineMotorsTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometryRedefineMotorsTargetView.java
@@ -23,25 +23,29 @@
 package uk.ac.stfc.isis.ibex.ui.reflectometry;
 
 /**
- * A standalone view for the Reflectometry Redefine Motors Panel OPI
+ * A standalone view for the Reflectometry Redefine Motors Panel OPI.
  */
 public class ReflectometryRedefineMotorsTargetView extends ReflectometryOpiTargetView {
-    /**
-     * Class ID.
-     */
-    public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryRedefineMotorsTargetView";
+	/**
+	 * Class ID.
+	 */
+	public static final String ID = "uk.ac.stfc.isis.ibex.ui.ReflectometryRedefineMotorsTargetView";
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiName() {
-    	return "reflectometry/tab_redefine.opi";
-    }
+	/**
+	 * File name of the reflectometry OPI.
+	 * 
+	 * @return the OPI file name
+	 */
+	protected String getOpiName() {
+		return "reflectometry/tab_redefine.opi";
+	}
 
-    /**
-     * File name of the reflectometry OPI.
-     */
-    protected String getOpiTitle() {
-    	return "Redefine Motors";
-    }
+	/**
+	 * The title of the OPI view.
+	 * 
+	 * @return the OPI title
+	 */
+	protected String getOpiTitle() {
+		return "Redefine Motors";
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometrySlitParametersTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/src/uk/ac/stfc/isis/ibex/ui/reflectometry/ReflectometrySlitParametersTargetView.java
@@ -23,7 +23,7 @@
 package uk.ac.stfc.isis.ibex.ui.reflectometry;
 
 /**
- * A standalone view for the Reflectometry Slit Parameters OPI
+ * A standalone view for the Reflectometry Slit Parameters OPI.
  */
 public class ReflectometrySlitParametersTargetView extends ReflectometryOpiTargetView {
     /**
@@ -33,13 +33,17 @@ public class ReflectometrySlitParametersTargetView extends ReflectometryOpiTarge
 
     /**
      * File name of the reflectometry OPI.
+     * 
+     * @return the OPI file name
      */
     protected String getOpiName() {
     	return "reflectometry/tab_slit_params.opi";
     }
 
     /**
-     * File name of the reflectometry OPI.
+     * The title of the OPI view.
+     * 
+     * @return the OPI title
      */
     protected String getOpiTitle() {
     	return "Slit Parameters";


### PR DESCRIPTION
Updated docstrings in reflectometry OPI views to fix checkstyle warnings. (ignore whitespace changes for easier comparison)