### PR TITLE
Ticket 5995: Allow opening device screens on non-running instrument

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.devicescreens/src/uk/ac/stfc/isis/ibex/devicescreens/DeviceScreensModel.java
+++ b/base/uk.ac.stfc.isis.ibex.devicescreens/src/uk/ac/stfc/isis/ibex/devicescreens/DeviceScreensModel.java
@@ -67,6 +67,7 @@ public class DeviceScreensModel extends ModelObject {
             Writable<DeviceScreensDescription> writableDeviceScreenDescriptions) {
 
         localDevices = new DeviceScreensDescription();
+        setDeviceScreensDescription(localDevices);
 
         this.writableDeviceScreenDescriptions = new SameTypeWriter<DeviceScreensDescription>() {
             @Override


### PR DESCRIPTION
### Description of work

Explicitly sets the devicescreens to a sensible default. Previously we were relying on getting a disconnected event from the PV to initialise it but we were trying to get the value before we got this event.

### Ticket

See https://github.com/ISISComputingGroup/IBEX/issues/5995

### To Test
* Start the GUI up pointing to a disconnected instrument
* Edit the device screens and confirm that the dialog now opens
* Confirm devicescreen behaviour unchanged when pointing to a connected instrument


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

