### PR TITLE
Ticket 4334: Removed arbitrary limit on description length

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/summary/SummaryPanel.java
@@ -105,7 +105,6 @@ public class SummaryPanel extends Composite {
 
         txtDescription = new Text(cmpSummary, SWT.BORDER);
         txtDescription.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-        txtDescription.setTextLimit(39);
 
         lblSynoptic = new Label(cmpSummary, SWT.NONE);
         lblSynoptic.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/4334

To Test:
* Edit a configuration to add a very long description
* Save the configuration
* Confirm this long description appears in the load description selection dialog (you may have to resize the window to see it all)
* 
---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

