### PR TITLE
Fix failing test

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/TestableObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/TestableObservable.java
@@ -1,0 +1,15 @@
+package uk.ac.stfc.isis.ibex.synoptic.tests.internal;
+
+import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
+
+/**
+ * Observable to be used for testing, allows access to setValue, setError and setConnectionChanged methods.
+ * 
+ * This is final, so no mocking this, or using it outside testing!
+ */
+final class TestableObservable<T> extends ClosableObservable<T> {
+	@Override
+	public void setValue(T value) {
+		super.setValue(value);
+	}
+}

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/VariablesTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/VariablesTest.java
@@ -219,18 +219,27 @@ public class VariablesTest {
 
     @Test
     public void
-            GIVEN_new_variables_WHEN_getting_defaultReaderRemote_THEN_returns_default_observable_from_specified_pv() {
+            GIVEN_new_variables_WHEN_getting_defaultReaderRemote_THEN_returns_subscriber_to_value_and_units() {
         // Arrange
         String address = "Test";
-        when(closingObservableFactory.getSwitchableObservable(any(DefaultChannel.class), eq(address)))
-                .thenReturn(mockSwitchableObservable);
+        var testableObservableValue = new TestableObservable<String>();
+        var mockValue = new SwitchableObservable<>(testableObservableValue);
+        when(closingObservableFactory.getSwitchableObservable(any(DefaultChannelWithoutUnits.class), eq(address)))
+                .thenReturn(mockValue);
+        var testableObservableUnit = new TestableObservable<String>();
+        var mockUnits = new SwitchableObservable<>(testableObservableUnit);
+        when(closingObservableFactory.getSwitchableObservable(any(StringChannel.class), eq(address + ".EGU")))
+        		.thenReturn(mockUnits);
         variables = createVariables();
 
         // Act
         ForwardingObservable<String> result = variables.defaultReaderRemote(address);
         
-        // Assert
-        assertSame(mockSwitchableObservable, result);
+        //Assert
+        assertNull(result.getValue());
+        testableObservableValue.setValue("Value");
+        testableObservableUnit.setValue("Units");
+        assertEquals(result.getValue(), "Value Units");
         assertNotEquals(defaultSwitchableObservable, result);
     }
 


### PR DESCRIPTION
### Description of work

As a result of https://github.com/ISISComputingGroup/IBEX/issues/4019 or https://github.com/ISISComputingGroup/ibex_gui/pull/1230/files changed the defaultReaderRemote for the synoptic Variables class to an observable that concatenates values and units. The GUI pipeline was failing because the test for that method had not been updated to reflect the new behaviour. This PR also updates the test.

### Ticket

*Link to Ticket*

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

