### PR TITLE
fixing insert action copy previous row behaviour 

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -104,14 +104,19 @@ public class ActionsTable extends ModelObject {
 		var parametersMap = new HashMap<JavaActionParameter, String>();
 		// Make a parameter/string pair for each parameter in the action
 		for (JavaActionParameter actionParameter: this.actionParameters) {
-			if (actionParameter.getCopyPreviousRow() && this.actions.size() > 0) {
-				ScriptGeneratorAction rowToCopy = getRowToCopy(insertionLocation);
-				parametersMap.put(actionParameter, rowToCopy.getActionParameterValue(actionParameter));
-			} else { 
-				parametersMap.put(actionParameter, actionParameter.getDefaultValue());
-			}
+			createDefaultActionParameter(insertionLocation, parametersMap, actionParameter);
 		}
 		return createAction(parametersMap);
+	}
+
+	private void createDefaultActionParameter(Optional<Integer> insertionLocation,
+			HashMap<JavaActionParameter, String> parametersMap, JavaActionParameter actionParameter) {
+		if (actionParameter.getCopyPreviousRow() && this.actions.size() > 0) {
+			ScriptGeneratorAction rowToCopy = getRowToCopy(insertionLocation);
+			parametersMap.put(actionParameter, rowToCopy.getActionParameterValue(actionParameter));
+		} else { 
+			parametersMap.put(actionParameter, actionParameter.getDefaultValue());
+		}
 	}
 
 	private ScriptGeneratorAction getRowToCopy(Optional<Integer> insertionLocation) {

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -97,11 +97,22 @@ public class ActionsTable extends ModelObject {
 	}
 	
 	private ScriptGeneratorAction createDefaultAction() {
+		return createDefaultAction(null);
+	}
+	
+	private ScriptGeneratorAction createDefaultAction(Integer insertionLocation) {
 		var parametersMap = new HashMap<JavaActionParameter, String>();
 		// Make a parameter/string pair for each parameter in the action
 		for (JavaActionParameter actionParameter: this.actionParameters) {
 			if (actionParameter.getCopyPreviousRow() && this.actions.size() > 0) {
-				ScriptGeneratorAction lastRow = this.actions.get(this.actions.size() - 1);
+				int positionOfRowToCopy;
+				if (insertionLocation != null ) {
+					positionOfRowToCopy = (insertionLocation - 1);
+				} else {
+					// Copy the last row's value as we are adding to the end
+					positionOfRowToCopy = (this.actions.size() - 1);
+				}
+				ScriptGeneratorAction lastRow = this.actions.get(positionOfRowToCopy);
 				parametersMap.put(actionParameter, lastRow.getActionParameterValue(actionParameter));
 			} else { 
 				parametersMap.put(actionParameter, actionParameter.getDefaultValue());
@@ -136,7 +147,7 @@ public class ActionsTable extends ModelObject {
 	 * @param insertionLocation The index to add the specified 
 	 */
 	public void insertEmptyAction(Integer insertionLocation) {
-		var newAction = createDefaultAction();
+		var newAction = createDefaultAction(insertionLocation);
 		var correctedInsertionLocation = coerceActionIndexIntoRange(insertionLocation);
 		final List<ScriptGeneratorAction> newList = new ArrayList<ScriptGeneratorAction>(actions);
 		newList.add(correctedInsertionLocation, newAction);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -97,17 +97,17 @@ public class ActionsTable extends ModelObject {
 	}
 	
 	private ScriptGeneratorAction createDefaultAction() {
-		return createDefaultAction(null);
+		return createDefaultAction(Optional.empty());
 	}
 	
-	private ScriptGeneratorAction createDefaultAction(Integer insertionLocation) {
+	private ScriptGeneratorAction createDefaultAction(Optional<Integer> insertionLocation) {
 		var parametersMap = new HashMap<JavaActionParameter, String>();
 		// Make a parameter/string pair for each parameter in the action
 		for (JavaActionParameter actionParameter: this.actionParameters) {
 			if (actionParameter.getCopyPreviousRow() && this.actions.size() > 0) {
 				int positionOfRowToCopy;
-				if (insertionLocation != null ) {
-					positionOfRowToCopy = (insertionLocation - 1);
+				if (insertionLocation.isPresent()) {
+					positionOfRowToCopy = (insertionLocation.get() - 1);
 				} else {
 					// Copy the last row's value as we are adding to the end
 					positionOfRowToCopy = (this.actions.size() - 1);
@@ -147,7 +147,7 @@ public class ActionsTable extends ModelObject {
 	 * @param insertionLocation The index to add the specified 
 	 */
 	public void insertEmptyAction(Integer insertionLocation) {
-		var newAction = createDefaultAction(insertionLocation);
+		var newAction = createDefaultAction(Optional.of(insertionLocation));
 		var correctedInsertionLocation = coerceActionIndexIntoRange(insertionLocation);
 		final List<ScriptGeneratorAction> newList = new ArrayList<ScriptGeneratorAction>(actions);
 		newList.add(correctedInsertionLocation, newAction);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -105,20 +105,25 @@ public class ActionsTable extends ModelObject {
 		// Make a parameter/string pair for each parameter in the action
 		for (JavaActionParameter actionParameter: this.actionParameters) {
 			if (actionParameter.getCopyPreviousRow() && this.actions.size() > 0) {
-				int positionOfRowToCopy;
-				if (insertionLocation.isPresent()) {
-					positionOfRowToCopy = (insertionLocation.get() - 1);
-				} else {
-					// Copy the last row's value as we are adding to the end
-					positionOfRowToCopy = (this.actions.size() - 1);
-				}
-				ScriptGeneratorAction lastRow = this.actions.get(positionOfRowToCopy);
-				parametersMap.put(actionParameter, lastRow.getActionParameterValue(actionParameter));
+				ScriptGeneratorAction rowToCopy = getRowToCopy(insertionLocation);
+				parametersMap.put(actionParameter, rowToCopy.getActionParameterValue(actionParameter));
 			} else { 
 				parametersMap.put(actionParameter, actionParameter.getDefaultValue());
 			}
 		}
 		return createAction(parametersMap);
+	}
+
+	private ScriptGeneratorAction getRowToCopy(Optional<Integer> insertionLocation) {
+		int positionOfRowToCopy;
+		if (insertionLocation.isPresent()) {
+			positionOfRowToCopy = (insertionLocation.get() - 1);
+		} else {
+			// Copy the last row's value as we are adding to the end
+			positionOfRowToCopy = (this.actions.size() - 1);
+		}
+		ScriptGeneratorAction lastRow = this.actions.get(positionOfRowToCopy);
+		return lastRow;
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -96,10 +96,22 @@ public class ActionsTable extends ModelObject {
 		return newAction;
 	}
 	
+	/**
+	 * Create the default action for the last row in the table.
+	 * 
+	 * @return The default action for the bottom row of the table.
+	 */
 	private ScriptGeneratorAction createDefaultAction() {
 		return createDefaultAction(Optional.empty());
 	}
 	
+	/**
+	 * Create an action with default values for it's given location.
+	 * It may copy some values from the row directly above it.
+	 * 
+	 * @param insertionLocation The row we are creating the action for.
+	 * @return The default action for the given row.
+	 */
 	private ScriptGeneratorAction createDefaultAction(Optional<Integer> insertionLocation) {
 		var parametersMap = new HashMap<JavaActionParameter, String>();
 		// Make a parameter/string pair for each parameter in the action
@@ -109,6 +121,14 @@ public class ActionsTable extends ModelObject {
 		return createAction(parametersMap);
 	}
 
+	/**
+	 * Get the default value for the action parameter given the insertionLocation (may copy value from previous row).
+	 * Add that default value to the parametersMap.
+	 * 
+	 * @param insertionLocation The row in the table we are inserting the action containing the parametersMap in.
+	 * @param parametersMap A map of action parameter to string that is used to create an action.
+	 * @param actionParameter The key of the parametersMap we are setting the value for.
+	 */
 	private void createDefaultActionParameter(Optional<Integer> insertionLocation,
 			HashMap<JavaActionParameter, String> parametersMap, JavaActionParameter actionParameter) {
 		if (actionParameter.getCopyPreviousRow() && this.actions.size() > 0) {
@@ -119,6 +139,13 @@ public class ActionsTable extends ModelObject {
 		}
 	}
 
+	/**
+	 * If the insertionLocation is present get the row action directly 
+	 * above the insertionLocation, else get the last action in the table.
+	 * 
+	 * @param insertionLocation The location we are getting the row to copy for.
+	 * @return A script generator action.
+	 */
 	private ScriptGeneratorAction getRowToCopy(Optional<Integer> insertionLocation) {
 		int positionOfRowToCopy;
 		if (insertionLocation.isPresent()) {


### PR DESCRIPTION
### Description of work

Adds an `insertionLocation` parameter to `CreateDefaultAction()` which is set to `null` if a user clicks `Add Action to end` or set to the insertion location if a user clicks `Insert Action below`. In `createDefaultAction()` the previous row's value (or last row's value in the case of adding an action to the end) is copied and applied to the new action.  

### Ticket

ISISComputingGroup/IBEX#6017

### Acceptance criteria

See Ticket

### Unit tests

None modified

### System tests

Squish test added

### Documentation

None, docs already exist for copyPreviousRow behaviour and this is a bug fix

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

