### PR TITLE
Added tooltips for auto-start/auto-restart/sim. level

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/EditableIocsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/EditableIocsTable.java
@@ -166,6 +166,11 @@ public class EditableIocsTable extends DataboundTable<EditableIoc> {
                     }
                 });
         simLevel.setEditingSupport(new SimLevelEditingSupport(viewer()));
+        setColumnToolTipText(simLevel,
+        		"By default, the simulation level file is set to NONE, meaning that the IOC will not run in simulation mode.\n"
+        		+ "Under normal circumstances, you should not change the default setting.\n"
+        		+ "Simulation mode is used for running the IOC without the actual physical device."
+        );
     }
 
     /**
@@ -173,6 +178,14 @@ public class EditableIocsTable extends DataboundTable<EditableIoc> {
      */
 	private void autostart() {
         autoStart = createColumn("Auto-start?", 1, false, autoStartLabelProvider);
+        setColumnToolTipText(autoStart, 
+        		"If set, the IOC will be started/restarted whenever the configuration is changed.\n"
+        		+ "If not set then if the IOC is not running it will remained stopped after config change,\n" 
+        		+ "and if it is running it will remain running throughout the config change.\n"
+        		+ "\n" 
+        		+ "Warning: if not set and the IOC is running, any changes you make (e.g. a macro change)\n" 
+        		+ "will not be set on the IOC until you restart it manually."
+        );
 	}
 
     /**
@@ -180,6 +193,10 @@ public class EditableIocsTable extends DataboundTable<EditableIoc> {
      */
 	private void restart() {
         autoRestart = createColumn("Auto-restart?", 1, false, autoRestartLabelProvider);
+        setColumnToolTipText(autoRestart, 
+        		"If set, the IOC will be automatically restarted if it is terminated unexpectedly.\n"
+        		+ "If the IOC is stopped from the client or writing to the appropriate PV then it will not be restarted."
+        );
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/dialog/EditPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/dialog/EditPanel.java
@@ -137,7 +137,7 @@ public class EditPanel extends Composite {
         autoRestart.setText("Auto-Restart");
         autoRestart.setToolTipText(
         		"If set, the IOC will be automatically restarted if it is terminated unexpectedly.\n"
-        		+ "If the IOC is stopped from the client or writing to the appropriate PV then it will not be restarted."
+        		+ "If the IOC is stopped from the client then it will not be restarted."
         );
 
         

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/dialog/EditPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/dialog/EditPanel.java
@@ -106,6 +106,11 @@ public class EditPanel extends Composite {
         // General IOC Settings
         Label lblSimLevel = new Label(cmpIocDetails, SWT.NONE);
         lblSimLevel.setText("Sim. Level");
+        lblSimLevel.setToolTipText(
+        		"By default, the simulation level file is set to NONE, meaning that the IOC will not run in simulation mode.\n"
+        		+ "Under normal circumstances, you should not change the default setting.\n"
+        		+ "Simulation mode is used for running the IOC without the actual physical device."
+        );
         lblSimLevel.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false));
 
         simLevel = new ComboViewer(cmpIocDetails, SWT.READ_ONLY);
@@ -118,10 +123,23 @@ public class EditPanel extends Composite {
         autoStart = new Button(cmpIocDetails, SWT.CHECK);
         autoStart.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false));
         autoStart.setText("Auto-Start");
+        autoStart.setToolTipText(
+        		"If set, the IOC will be started/restarted whenever the configuration is changed.\n"
+        		+ "If not set then if the IOC is not running it will remained stopped after config change,\n"
+        		+ "and if it is running it will remain running throughout the config change.\n"
+        		+ "\n"
+        		+ "Warning: if not set and the IOC is running, any changes you make (e.g. a macro change)\n"
+        		+ "will not be set on the IOC until you restart it manually."
+        );
 
         autoRestart = new Button(cmpIocDetails, SWT.CHECK);
         autoRestart.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false));
         autoRestart.setText("Auto-Restart");
+        autoRestart.setToolTipText(
+        		"If set, the IOC will be automatically restarted if it is terminated unexpectedly.\n"
+        		+ "If the IOC is stopped from the client or writing to the appropriate PV then it will not be restarted."
+        );
+
         
         if (ALLOW_REMOTE_PV_PREFIX_CHANGE) {
 	        remotePvPrefixLbl = new Label(cmpIocDetails, SWT.NONE);

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
@@ -445,6 +445,17 @@ public abstract class DataboundTable<TRow> extends Composite {
 	tableColumn.setLabelProvider(cellProvider);
 	return tableColumn;
     }
+    
+    /**
+     * Sets the tooltip text of an existing column.
+     *
+     * @param column the column
+     * @param tooltip the tooltip text
+     */
+    public void setColumnToolTipText(TableViewerColumn column, String tooltip) {
+    	TableColumn col = column.getColumn();
+    	col.setToolTipText(tooltip);
+    }
 
     /**
      * Observe property.


### PR DESCRIPTION
### Description of work

Added tooltips for the auto-start/auto-restart/sim. level labels in Add IOC and column headers in the config table.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2046

### Acceptance criteria

As a user, I would like tooltips for the auto-start and auto-restart properties of IOCs to tell me what they do.

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

N/A

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

