### PR TITLE
Changed script generator parameter files from .json to .sgp

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorJsonFileHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorJsonFileHandler.java
@@ -44,7 +44,7 @@ public class ScriptGeneratorJsonFileHandler {
 	private static final Logger LOG = IsisLog.getLogger(ScriptGeneratorSingleton.class);
 	private Gson gson = new GsonBuilder().setPrettyPrinting().create();
 	/**
-	 * Save Parameters to a JSON file.
+	 * Save Parameters to a JSON file (with script generator parameters file extension).
 	 * @param scriptGenContent content to generate data file with
 	 * @param scriptDefPath path of script definition used to create data file
 	 * @param absoluteFilePath absolute file path to save data file
@@ -78,7 +78,7 @@ public class ScriptGeneratorJsonFileHandler {
 	}
 
 	/**
-	 * Load parameter values from a file only if the currently loaded script definition is the same as script definition in JSON file.
+	 * Load parameter values from a file only if the currently loaded script definition is the same as script definition in file (JSON/SGP - Script Generator Parameters).
 	 * @param filePath path of file to load parameter values from
 	 * @param scriptDefinitionPath file path to current script definition
 	 * @param currentActionsParams the list of actions in the current script definition

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -61,11 +61,16 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	/**
 	 * JSON file extension.
 	 */
+	@SuppressWarnings("unused")
 	private static final String JSON_EXT = ".json";
 	/**
 	 * Python file extension.
 	 */
 	public static final String PYTHON_EXT = ".py";
+	/**
+	 * Script generator parameters file extension.
+	 */
+	public static final String SCRIPT_GEN_PARAMS_EXT = ".sgp";
 	
 	/**
 	 * The preferences supplier to get the area to generate scripts from.
@@ -736,9 +741,9 @@ public class ScriptGeneratorSingleton extends ModelObject {
 				.orElseThrow(() -> new NoScriptDefinitionSelectedException("No Configuration Selected"));
 		
 		try {
-			if (!filePath.endsWith(JSON_EXT)) {
-				//Strip out other any pre-existing file extension and add JSON extension
-				filePath = filePath.substring(0, filePath.lastIndexOf('.')) + JSON_EXT;
+			if (!filePath.endsWith(SCRIPT_GEN_PARAMS_EXT)) {
+				//Strip out other any pre-existing file extension and add the SGP (script generator parameters) file extension
+				filePath = filePath.substring(0, filePath.lastIndexOf('.')) + SCRIPT_GEN_PARAMS_EXT;
 			}
 			scriptGenFileHandler.saveParameters(scriptGeneratorTable.getActions(), getScriptDefinitionPath(scriptDefinition), filePath);
 		} catch (InterruptedException | ExecutionException e) {

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -949,13 +949,15 @@ public class ScriptGeneratorViewModel extends ModelObject {
     private Optional<String> openFileDialog(int action) {
     FileDialog dialog = new FileDialog(Display.getDefault().getActiveShell(), action);
     dialog.setFilterPath("C:/scripts");
-    dialog.setFilterExtensions(new String[] {"*.json"});
     dialog.setOverwrite(true);
     if (action == SWT.SAVE) {
         dialog.setText("Save as");
+        dialog.setFilterExtensions(new String[] {"*.sgp"});
 
     } else {
         dialog.setText("Load");
+        // Keep JSON extension when loading (for older param. files)
+        dialog.setFilterExtensions(new String[] {"*.sgp", "*.json"});
     }
     return Optional.ofNullable(dialog.open());
     }


### PR DESCRIPTION
### Description of work

Changed the extension in which script generator parameters files are saved from `.json` to `.sgp` (script generator parameters). 
Changed the extension filters in param. save/load dialogs to `.sgp` for saving and `.sgp`/`.json` for loading (to be compatible with param. files created before the change).

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5371

### Acceptance criteria

1. Saving a parameters file in the script generator results in a file with a more meaningful extension
2. Loading parameters still works correctly with this new extension

### Unit tests

N/A

### System tests

N/A

### Documentation
https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/The-IBEX-Script-Generator#saving-the-parameter-values-and-loading-back-up

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

