### PR TITLE
Improve PV search speed/responsiveness when adding to block

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/pvs/PVSelectorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/pvs/PVSelectorPanel.java
@@ -19,9 +19,12 @@
 
 package uk.ac.stfc.isis.ibex.ui.configserver.editing.pvs;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
+import javax.swing.Timer;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
@@ -37,6 +40,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
@@ -147,7 +151,17 @@ public class PVSelectorPanel extends Composite {
 			}
 		});
 		
-		pvAddress.addModifyListener(e -> blockPVTable.setSearch(pvAddress.getText()));
+		int pvSearchDelay = 1000; //milliseconds
+		ActionListener pvSearchTaskPerformer = new ActionListener() {
+			public void actionPerformed(ActionEvent evt) {
+				Display.getDefault().asyncExec(() -> blockPVTable.setSearch(pvAddress.getText()));
+		    	  
+			}
+		};
+		Timer pvSearch = new Timer(pvSearchDelay, pvSearchTaskPerformer);
+		pvSearch.setRepeats(false); // Set timer to go off only once
+		
+		pvAddress.addModifyListener(e -> pvSearch.restart());
 	}
 	
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/pvs/PVSelectorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/pvs/PVSelectorPanel.java
@@ -155,9 +155,9 @@ public class PVSelectorPanel extends Composite {
 		ActionListener pvSearchTaskPerformer = new ActionListener() {
 			public void actionPerformed(ActionEvent evt) {
 				Display.getDefault().asyncExec(() -> blockPVTable.setSearch(pvAddress.getText()));
-		    	  
 			}
 		};
+		
 		Timer pvSearch = new Timer(pvSearchDelay, pvSearchTaskPerformer);
 		pvSearch.setRepeats(false); // Set timer to go off only once
 		


### PR DESCRIPTION
### Description of work

Improve PV search speed when adding to block by using a timer to wait for user input to finish before starting the search.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5892

### Acceptance criteria

- Search is made a bit quicker by using a timer or similar method
- If the search text has not changed the function should not perform a search

### Unit tests

N/A

### System tests

N/A

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

