### PR TITLE
Ticket 6233: Use RAW requests on the log plotter data

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/META-INF/MANIFEST.MF
@@ -23,7 +23,8 @@ Require-Bundle: org.eclipse.ui,
  org.hamcrest.generator;bundle-version="1.3.0",
  org.hamcrest.integration;bundle-version="1.3.0",
  org.hamcrest.library;bundle-version="1.3.0",
- org.hamcrest.text;bundle-version="1.1.0"
+ org.hamcrest.text;bundle-version="1.1.0",
+ org.csstudio.csdata;bundle-version="3.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.ui.logplotter

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterHistoryPresenter.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/LogPlotterHistoryPresenter.java
@@ -34,6 +34,7 @@ import org.csstudio.trends.databrowser2.model.AxisConfig;
 import org.csstudio.trends.databrowser2.model.Model;
 import org.csstudio.trends.databrowser2.model.ModelListenerAdapter;
 import org.csstudio.trends.databrowser2.model.PVItem;
+import org.csstudio.trends.databrowser2.model.RequestType;
 import org.csstudio.trends.databrowser2.preferences.Preferences;
 import org.csstudio.ui.util.EmptyEditorInput;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -128,6 +129,7 @@ public class LogPlotterHistoryPresenter implements PVHistoryPresenter {
             final PVItem item = new PVItem(pvAddress, period);
             item.setDisplayName(displayName);
             item.useDefaultArchiveDataSources();
+            item.setRequestType(RequestType.RAW);
 
             AxisConfig axis;
             if (axisName.isPresent()) {

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
@@ -18,6 +18,8 @@
 
 package uk.ac.stfc.isis.ibex.ui.logplotter;
 
+import org.csstudio.trends.databrowser2.model.PVItem;
+import org.csstudio.trends.databrowser2.model.RequestType;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.ui.IPerspectiveRegistry;
@@ -44,6 +46,7 @@ public class OpenLogPlotterPopup extends org.csstudio.trends.databrowser2.OpenDa
 			super.execute(event);
 			// We can't get the editor from the parent so turn off save changes dialog for all editors
 			LogPlotterHistoryPresenter.getCurrentDataBrowsers().forEach(db -> db.getModel().setSaveChanges(false));
+			LogPlotterHistoryPresenter.getCurrentDataBrowsers().forEach(db -> db.getModel().getItems().forEach(item -> ((PVItem)item).setRequestType(RequestType.RAW)));
 			return null;
 		} catch (ExecutionException | RuntimeException e) {
 			IsisLog.getLogger(getClass()).error(e.getMessage(), e);

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
@@ -1,69 +1,154 @@
-/*
-* This file is part of the ISIS IBEX application.
-* Copyright (C) 2012-2015 Science & Technology Facilities Council.
-* All rights reserved.
-*
-* This program is distributed in the hope that it will be useful.
-* This program and the accompanying materials are made available under the
-* terms of the Eclipse Public License v1.0 which accompanies this distribution.
-* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM 
-* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES 
-* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
-*
-* You should have received a copy of the Eclipse Public License v1.0
-* along with this program; if not, you can obtain a copy from
-* https://www.eclipse.org/org/documents/epl-v10.php or 
-* http://opensource.org/licenses/eclipse-1.0.php
-*/
-
+/*******************************************************************************
+ * Copyright (c) 2010 Oak Ridge National Laboratory.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ ******************************************************************************/
 package uk.ac.stfc.isis.ibex.ui.logplotter;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+import org.csstudio.csdata.ProcessVariable;
+import org.csstudio.csdata.TimestampedPV;
+import org.csstudio.trends.databrowser2.editor.DataBrowserEditor;
+import org.csstudio.trends.databrowser2.model.ArchiveDataSource;
+import org.csstudio.trends.databrowser2.model.ChannelInfo;
+import org.csstudio.trends.databrowser2.model.Model;
 import org.csstudio.trends.databrowser2.model.PVItem;
 import org.csstudio.trends.databrowser2.model.RequestType;
+import org.csstudio.trends.databrowser2.preferences.Preferences;
+import org.csstudio.ui.util.AdapterUtil;
+import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IPerspectiveRegistry;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.handlers.HandlerUtil;
 
-import uk.ac.stfc.isis.ibex.logger.IsisLog;
 
-/**
- * This class is needed to display OPI PVs in the databrowser.
+/** Command handler for opening Data Browser on the current selection. 
+ *  Copied almost exactly from CS-Studio code but modified for IBEX.
+ *  Linked from popup menu that is sensitive to {@link ProcessVariable}
  */
-public class OpenLogPlotterPopup extends org.csstudio.trends.databrowser2.OpenDataBrowserPopup {
-	
-	private static final String LOG_PLOTTER_PERSPECTIVE_ID = "uk.ac.stfc.isis.ibex.client.e4.product.perspective.logplotter";
+public class OpenLogPlotterPopup extends AbstractHandler {
 
-	/**
-	 * Override CSStudio command to switch to log plotter perspective first, before adding items to databrowser.
-	 */
-	@Override
-    public Object execute(final ExecutionEvent event) {       
-		try {
-			switchToLogPlotter();
-			super.execute(event);
-			// We can't get the editor from the parent so turn off save changes dialog for all editors
-			LogPlotterHistoryPresenter.getCurrentDataBrowsers().forEach(db -> db.getModel().setSaveChanges(false));
-			LogPlotterHistoryPresenter.getCurrentDataBrowsers().forEach(db -> db.getModel().getItems().forEach(item -> ((PVItem)item).setRequestType(RequestType.RAW)));
-			return null;
-		} catch (ExecutionException | RuntimeException e) {
-			IsisLog.getLogger(getClass()).error(e.getMessage(), e);
-			return null;
-		}
+    final double period = Preferences.getScanPeriod();
+    private static final String LOG_PLOTTER_PERSPECTIVE_ID = "uk.ac.stfc.isis.ibex.client.e4.product.perspective.logplotter";
+
+    /** {@inheritDoc} */
+    @Override
+    public Object execute(final ExecutionEvent event) throws ExecutionException {
+        // Get selection first because the ApplicationContext might change.
+        ISelection selection = HandlerUtil.getActiveMenuSelection(event);
+        if (selection == null) {
+            // This works for double-clicks.
+            selection = HandlerUtil.getCurrentSelection(event);
+        }
+
+        switchToLogPlotter();
+
+        // Create new editor
+        final DataBrowserEditor editor = DataBrowserEditor.createInstance();
+        if (editor == null) {
+            return null;
+        }
+        
+        // Add received items
+        final Model model = editor.getModel();
+        model.setSaveChanges(false);
+        try {
+            if (selection instanceof IStructuredSelection
+                && ((IStructuredSelection) selection).getFirstElement() instanceof ChannelInfo) {   
+                // Received items are from search dialog
+                final Object[] channels = ((IStructuredSelection) selection).toArray();
+                for (Object channel : channels) {
+                    final ChannelInfo info = (ChannelInfo) channel;
+                    add(model, info.getProcessVariable(), info.getArchiveDataSource());
+                }
+            } else {
+                // Add received PVs with default archive data sources
+                final List<TimestampedPV> timestampedPVs = Arrays
+                        .asList(AdapterUtil.convert(selection,
+                                TimestampedPV.class));
+                if (!timestampedPVs.isEmpty()) {
+                    // Add received items, tracking their start..end time
+                    long start_ms = Long.MAX_VALUE,  end_ms = 0;
+                    for (TimestampedPV timestampedPV : timestampedPVs) {
+                        final long time = timestampedPV.getTime();
+                        if (time < start_ms) {
+                            start_ms = time;
+                        }
+                        if (time > end_ms) {
+                            end_ms = time;
+                        }
+                        final PVItem item = new PVItem(timestampedPV.getName().trim(), period);
+                        item.setAxis(model.addAxis());
+                        item.useDefaultArchiveDataSources();
+                        model.addItem(item);
+                    }
+
+                    final Instant start = Instant.ofEpochMilli(start_ms).minus(Duration.ofMinutes(30));
+                    final Instant end = Instant.ofEpochMilli(end_ms).plus(Duration.ofMinutes(30));
+                    model.enableScrolling(false);
+                    model.setTimerange(start, end);
+                } else {
+                    final ProcessVariable[] pvs = AdapterUtil.convert(
+                            selection, ProcessVariable.class);
+                    for (ProcessVariable pv : pvs) {
+                        add(model, pv, null);
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            MessageDialog.openError(editor.getSite().getShell(),
+                    "Error", ex.getMessage());
+        }
+        return null;
     }
-	
-	/**
-	 * This is a bit of a hack to switch perspectives in a way that is compatible with both E4 and the E3 compatibility layer.
-	 * 
-	 * Can't use our normal perspective provider as that requires dependency injection, which we can't use with E3-style extension
-	 * points. Can't move away from E3 extension points as this is what the CSStudio view uses.
-	 */
-	private static void switchToLogPlotter() {
-		final IWorkbench workbench = PlatformUI.getWorkbench();
+
+    /** Add item
+     *  @param model Model to which to add the item
+     *  @param pv PV to add
+     *  @param archive Archive to use or <code>null</code>
+     *  @throws Exception on error
+     */
+    private void add(final Model model, final ProcessVariable pv,
+            final ArchiveDataSource archive) throws Exception {
+        String pvName = pv.getName();
+        if (!pvName.contains(".")) {
+            pvName += ".VAL";
+        }
+        final PVItem item = new PVItem(pvName, period);
+        if (archive == null) {
+            item.useDefaultArchiveDataSources();            
+        } else {
+            item.addArchiveDataSource(archive);
+        }
+        item.setRequestType(RequestType.RAW);
+        // Add item to new axis
+        item.setAxis(model.addAxis());
+        model.addItem(item);
+    }
+    
+    /**
+     * This is a bit of a hack to switch perspectives in a way that is compatible with both E4 and the E3 compatibility layer.
+     * 
+     * Can't use our normal perspective provider as that requires dependency injection, which we can't use with E3-style extension
+     * points. Can't move away from E3 extension points as this is what the CSStudio view uses.
+     */
+    private static void switchToLogPlotter() {
+        final IWorkbench workbench = PlatformUI.getWorkbench();
         final IPerspectiveRegistry registry = workbench.getPerspectiveRegistry();
         final IWorkbenchPage page = workbench.getActiveWorkbenchWindow().getActivePage();
         page.setPerspective(registry.findPerspectiveWithId(LOG_PLOTTER_PERSPECTIVE_ID));
-	}
+    }
 }


### PR DESCRIPTION
### Description of work

When sufficiently zoomed out the databrowser averages data to save memory. Additionally, when it has no data it will assume the data stays constant, in the example linked in the ticket it averaged the data just before getting no data for a long period of time and so it assumed this average was the value for that time. This changes any added PVs to `RAW` mode, stopping the averaging

As the user zooms in this averaging should correct itself but it didn't seem to be doing this very well, I'm not sure why.

### Ticket

See https://github.com/ISISComputingGroup/IBEX/issues/6233
Also https://github.com/ISISComputingGroup/IBEX/issues/2177

### System tests

I can't think of an easy way to test this

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?
- [x] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

