### PR TITLE
Disable controls on DISP

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/action_bar.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/action_bar.opi
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
-  <actions hook="false" hook_all="false" />
+  <actions hook="false" hook_all="false"/>
   <auto_scale_widgets>
     <auto_scale_widgets>false</auto_scale_widgets>
     <min_width>-1</min_width>
@@ -8,20 +8,20 @@
   </auto_scale_widgets>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
-    <color red="240" green="240" blue="240" />
+    <color red="240" green="240" blue="240"/>
   </background_color>
   <boy_version>5.1.0</boy_version>
   <foreground_color>
-    <color red="192" green="192" blue="192" />
+    <color red="192" green="192" blue="192"/>
   </foreground_color>
   <grid_space>6</grid_space>
   <height>54</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <name></name>
-  <rules />
-  <scripts />
+  <name/>
+  <rules/>
+  <scripts/>
   <show_close_button>true</show_close_button>
   <show_edit_range>true</show_edit_range>
   <show_grid>true</show_grid>
@@ -33,12 +33,12 @@
   <x>0</x>
   <y>0</y>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </background_color>
     <border_color>
-      <color red="0" green="128" blue="255" />
+      <color red="0" green="128" blue="255"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -48,7 +48,7 @@
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
     </foreground_color>
     <height>54</height>
     <lock_children>false</lock_children>
@@ -56,15 +56,15 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <name>Grouping Container</name>
-    <rules />
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <show_scrollbar>true</show_scrollbar>
-    <tooltip></tooltip>
+    <tooltip/>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
@@ -73,17 +73,17 @@
     <x>0</x>
     <y>0</y>
     <widget typeId="org.csstudio.opibuilder.widgets.checkbox" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <alarm_pulsing>false</alarm_pulsing>
       <auto_size>false</auto_size>
       <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <bit>0</bit>
       <border_alarm_sensitive>true</border_alarm_sensitive>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -93,22 +93,22 @@
       </font>
       <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
       <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
       </foreground_color>
       <height>20</height>
-      <label></label>
+      <label/>
       <name>Check Box</name>
       <pv_name>$(PV_ROOT)BL:INIT_ON_MOVE</pv_name>
-      <pv_value />
-      <rules />
+      <pv_value/>
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <selected_color>
-        <color red="77" green="77" blue="77" />
+        <color red="77" green="77" blue="77"/>
       </selected_color>
       <tooltip>$(pv_name)
 $(pv_value)</tooltip>
@@ -120,13 +120,13 @@ $(pv_value)</tooltip>
       <y>16</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <auto_size>false</auto_size>
       <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color name="ISIS_Motor_Error" red="255" green="0" blue="0" />
+        <color name="ISIS_Motor_Error" red="255" green="0" blue="0"/>
       </border_color>
       <border_style>1</border_style>
       <border_width>3</border_width>
@@ -135,7 +135,7 @@ $(pv_value)</tooltip>
         <opifont.name fontName="Segoe UI" height="12" style="1" pixels="false">ISIS_Header3_NEW</opifont.name>
       </font>
       <foreground_color>
-        <color name="Major" red="255" green="0" blue="0" />
+        <color name="Major" red="255" green="0" blue="0"/>
       </foreground_color>
       <height>52</height>
       <horizontal_alignment>1</horizontal_alignment>
@@ -153,11 +153,11 @@ $(pv_value)</tooltip>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>false</show_scrollbar>
-      <text>Bump Strip Hit. Motion Control Disabled. Reset Motion Control in &#xD;
+      <text>Bump Strip Hit. Motion Control Disabled. Reset Motion Control in &#13;
 Block House. PRESS MOVE BEFORE PROCEEDING</text>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>false</transparent>
       <vertical_alignment>1</vertical_alignment>
       <visible>false</visible>
@@ -174,13 +174,13 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
           <pv_name>$(pv_name)</pv_name>
           <value>1</value>
           <timeout>10</timeout>
-          <confirm_message></confirm_message>
+          <confirm_message/>
           <description>Trigger a move on the whole beamline</description>
         </action>
       </actions>
       <border_alarm_sensitive>false</border_alarm_sensitive>
       <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
+        <color name="ISIS_Border" red="0" green="0" blue="0"/>
       </border_color>
       <border_style>2</border_style>
       <border_width>1</border_width>
@@ -190,14 +190,14 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
       </font>
       <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
       <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
       </foreground_color>
       <height>52</height>
-      <image></image>
+      <image/>
       <name>Button_1</name>
       <push_action_index>0</push_action_index>
       <pv_name>$(PV_ROOT)BL:MOVE</pv_name>
-      <pv_value />
+      <pv_value/>
       <rules>
         <rule name="hide_when_tripped" prop_id="visible" out_exp="false">
           <exp bool_exp="pv0==0">
@@ -211,7 +211,7 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <style>1</style>
       <text>Move All</text>
       <toggle_button>false</toggle_button>
@@ -232,18 +232,18 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
         <pv_name>$(pv_name)</pv_name>
         <value>1</value>
         <timeout>10</timeout>
-        <confirm_message></confirm_message>
-        <description></description>
+        <confirm_message/>
+        <description/>
       </action>
     </actions>
     <alarm_pulsing>false</alarm_pulsing>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color name="ISIS_DAE_Button_End" red="255" green="0" blue="0" />
+      <color name="ISIS_DAE_Button_End" red="255" green="0" blue="0"/>
     </background_color>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
     </border_color>
     <border_style>14</border_style>
     <border_width>3</border_width>
@@ -253,21 +253,21 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </foreground_color>
     <height>52</height>
-    <image></image>
+    <image/>
     <name>Action Button</name>
     <push_action_index>0</push_action_index>
     <pv_name>$(P)CS:MOT:STOP:ALL</pv_name>
-    <pv_value />
-    <rules />
+    <pv_value/>
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <style>0</style>
     <text>STOP ALL MOTION</text>
     <toggle_button>false</toggle_button>
@@ -282,22 +282,22 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
     <y>1</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <alarm_pulsing>false</alarm_pulsing>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </background_color>
     <bit>-1</bit>
     <border_alarm_sensitive>true</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Check_Border" red="0" green="128" blue="255" />
+      <color name="ISIS_Check_Border" red="0" green="128" blue="255"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
     <bulb_border>3</bulb_border>
     <bulb_border_color>
-      <color red="150" green="150" blue="150" />
+      <color red="150" green="150" blue="150"/>
     </bulb_border_color>
     <data_type>0</data_type>
     <effect_3d>false</effect_3d>
@@ -307,25 +307,25 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Textbox_Background" red="255" green="255" blue="255" />
+      <color name="ISIS_Textbox_Background" red="255" green="255" blue="255"/>
     </foreground_color>
     <height>49</height>
     <name>Autotune_LED</name>
     <off_color>
-      <color name="ISIS_Green_LED_Off" red="0" green="102" blue="0" />
+      <color name="ISIS_Green_LED_Off" red="0" green="102" blue="0"/>
     </off_color>
     <off_label>Not In Motion</off_label>
     <on_color>
-      <color name="ISIS_Green_LED_On" red="0" green="255" blue="0" />
+      <color name="ISIS_Green_LED_On" red="0" green="255" blue="0"/>
     </on_color>
     <on_label>In Motion</on_label>
     <pv_name>$(P)CS:MOT:MOVING</pv_name>
-    <pv_value />
+    <pv_value/>
     <rules>
       <rule name="TextColour" prop_id="foreground_color" out_exp="false">
         <exp bool_exp="pv0==1">
           <value>
-            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
           </value>
         </exp>
         <pv trig="true">$(P)CS:MOT:MOVING</pv>
@@ -336,7 +336,7 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>true</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <show_boolean_label>true</show_boolean_label>
     <square_led>true</square_led>
     <tooltip>$(pv_name)
@@ -350,13 +350,13 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
     <y>3</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <auto_size>false</auto_size>
     <background_color>
-      <color red="255" green="255" blue="255" />
+      <color red="255" green="255" blue="255"/>
     </background_color>
     <border_color>
-      <color red="0" green="128" blue="255" />
+      <color red="0" green="128" blue="255"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -365,21 +365,21 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <foreground_color>
-      <color red="0" green="0" blue="0" />
+      <color red="0" green="0" blue="0"/>
     </foreground_color>
     <height>34</height>
     <horizontal_alignment>0</horizontal_alignment>
     <name>Label</name>
-    <rules />
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <show_scrollbar>false</show_scrollbar>
     <text>Apply mode inits on move</text>
-    <tooltip></tooltip>
+    <tooltip/>
     <transparent>true</transparent>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
@@ -389,5 +389,45 @@ Block House. PRESS MOVE BEFORE PROCEEDING</text>
     <wuid>-66b2d298:176527e9421:-72d9</wuid>
     <x>672</x>
     <y>11</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+    <actions hook="false" hook_all="false"/>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+    </foreground_color>
+    <height>1</height>
+    <image/>
+    <name>Dummy</name>
+    <push_action_index>0</push_action_index>
+    <pv_name/>
+    <pv_value/>
+    <rules/>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts/>
+    <style>1</style>
+    <text/>
+    <toggle_button>false</toggle_button>
+    <tooltip/>
+    <visible>true</visible>
+    <widget_type>Action Button</widget_type>
+    <width>1</width>
+    <wuid>-648922a4:1624e4fa0bd:-7f69</wuid>
+    <x>0</x>
+    <y>0</y>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/correction.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/correction.opi
@@ -10,7 +10,7 @@
   <background_color>
     <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
-  <boy_version>5.1.0.201707071649</boy_version>
+  <boy_version>5.1.0</boy_version>
   <foreground_color>
     <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
@@ -72,7 +72,7 @@
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
     <scripts />
-    <show_units>true</show_units>
+    <show_units>false</show_units>
     <text>######</text>
     <tooltip>$(pv_name)
 $(pv_value)</tooltip>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/full_opi.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/full_opi.opi
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
-  <actions hook="false" hook_all="false" />
+  <actions hook="false" hook_all="false"/>
   <auto_scale_widgets>
     <auto_scale_widgets>false</auto_scale_widgets>
     <min_width>-1</min_width>
@@ -8,11 +8,11 @@
   </auto_scale_widgets>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
-    <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
   </background_color>
   <boy_version>5.1.0</boy_version>
   <foreground_color>
-    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
   </foreground_color>
   <grid_space>6</grid_space>
   <height>660</height>
@@ -21,8 +21,8 @@
     <PV_ROOT>$(P)REFL_01:</PV_ROOT>
   </macros>
   <name>$(NAME)</name>
-  <rules />
-  <scripts />
+  <rules/>
+  <scripts/>
   <show_close_button>true</show_close_button>
   <show_edit_range>true</show_edit_range>
   <show_grid>true</show_grid>
@@ -34,10 +34,10 @@
   <x>-1</x>
   <y>-1</y>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -47,25 +47,25 @@
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </foreground_color>
     <height>1</height>
-    <image></image>
+    <image/>
     <name>Dummy</name>
     <push_action_index>0</push_action_index>
-    <pv_name></pv_name>
-    <pv_value />
-    <rules />
+    <pv_name/>
+    <pv_value/>
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <style>1</style>
-    <text></text>
+    <text/>
     <toggle_button>false</toggle_button>
-    <tooltip></tooltip>
+    <tooltip/>
     <visible>true</visible>
     <widget_type>Action Button</widget_type>
     <width>1</width>
@@ -74,19 +74,19 @@
     <y>0</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.tab" version="1.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <active_tab>0</active_tab>
     <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </background_color>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
     <enabled>true</enabled>
     <foreground_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </foreground_color>
     <height>660</height>
     <horizontal_tabs>true</horizontal_tabs>
@@ -108,117 +108,117 @@
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <tab_0_background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_0_background_color>
     <tab_0_enabled>true</tab_0_enabled>
     <tab_0_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_0_font>
     <tab_0_foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </tab_0_foreground_color>
-    <tab_0_icon_path></tab_0_icon_path>
+    <tab_0_icon_path/>
     <tab_0_title>Front Panel</tab_0_title>
     <tab_1_background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_1_background_color>
     <tab_1_enabled>true</tab_1_enabled>
     <tab_1_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_1_font>
     <tab_1_foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </tab_1_foreground_color>
-    <tab_1_icon_path></tab_1_icon_path>
+    <tab_1_icon_path/>
     <tab_1_title>Collimation Plane Parameters</tab_1_title>
     <tab_2_background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_2_background_color>
     <tab_2_enabled>true</tab_2_enabled>
     <tab_2_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_2_font>
     <tab_2_foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </tab_2_foreground_color>
-    <tab_2_icon_path></tab_2_icon_path>
+    <tab_2_icon_path/>
     <tab_2_title>Activation Parameters</tab_2_title>
     <tab_3_background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_3_background_color>
     <tab_3_enabled>true</tab_3_enabled>
     <tab_3_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_3_font>
     <tab_3_foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </tab_3_foreground_color>
-    <tab_3_icon_path></tab_3_icon_path>
+    <tab_3_icon_path/>
     <tab_3_title>Slit Parameters</tab_3_title>
     <tab_4_background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_4_background_color>
     <tab_4_enabled>true</tab_4_enabled>
     <tab_4_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_4_font>
     <tab_4_foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </tab_4_foreground_color>
-    <tab_4_icon_path></tab_4_icon_path>
+    <tab_4_icon_path/>
     <tab_4_title>Other Parameters</tab_4_title>
     <tab_5_background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_5_background_color>
     <tab_5_enabled>true</tab_5_enabled>
     <tab_5_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_5_font>
     <tab_5_foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </tab_5_foreground_color>
-    <tab_5_icon_path></tab_5_icon_path>
+    <tab_5_icon_path/>
     <tab_5_title>Driver Corrections</tab_5_title>
     <tab_6_background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_6_background_color>
     <tab_6_enabled>true</tab_6_enabled>
     <tab_6_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_6_font>
     <tab_6_foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </tab_6_foreground_color>
-    <tab_6_icon_path></tab_6_icon_path>
+    <tab_6_icon_path/>
     <tab_6_title>Constants</tab_6_title>
     <tab_7_background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_7_background_color>
     <tab_7_enabled>true</tab_7_enabled>
     <tab_7_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_7_font>
     <tab_7_foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </tab_7_foreground_color>
-    <tab_7_icon_path></tab_7_icon_path>
+    <tab_7_icon_path/>
     <tab_7_title>Error Log</tab_7_title>
     <tab_8_background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_8_background_color>
     <tab_8_enabled>true</tab_8_enabled>
     <tab_8_font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_TabTitle_NEW</opifont.name>
     </tab_8_font>
     <tab_8_foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </tab_8_foreground_color>
-    <tab_8_icon_path></tab_8_icon_path>
+    <tab_8_icon_path/>
     <tab_8_title>Redefine Motors</tab_8_title>
     <tab_count>9</tab_count>
-    <tooltip></tooltip>
+    <tooltip/>
     <visible>true</visible>
     <widget_type>Tabbed Container</widget_type>
     <width>1054</width>
@@ -226,12 +226,12 @@
     <x>0</x>
     <y>0</y>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+        <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color name="ISIS_Check_Border" red="0" green="128" blue="255" />
+        <color name="ISIS_Check_Border" red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -241,7 +241,7 @@
         <opifont.name fontName="Arial" height="9" style="0" pixels="false">ISIS_Label_Small</opifont.name>
       </font>
       <foreground_color>
-        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
       </foreground_color>
       <height>631</height>
       <lock_children>false</lock_children>
@@ -249,15 +249,15 @@
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Front Panel</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>true</show_scrollbar>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>true</transparent>
       <visible>true</visible>
       <widget_type>Grouping Container</widget_type>
@@ -266,12 +266,12 @@
       <x>1</x>
       <y>1</y>
       <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-        <actions hook="false" hook_all="false" />
+        <actions hook="false" hook_all="false"/>
         <background_color>
-          <color red="240" green="240" blue="240" />
+          <color red="240" green="240" blue="240"/>
         </background_color>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="128" blue="255"/>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
@@ -280,9 +280,9 @@
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
         </font>
         <foreground_color>
-          <color red="192" green="192" blue="192" />
+          <color red="192" green="192" blue="192"/>
         </foreground_color>
-        <group_name></group_name>
+        <group_name/>
         <height>631</height>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -290,14 +290,14 @@
         <name>Linking Container</name>
         <opi_file>tab_front_panel.opi</opi_file>
         <resize_behaviour>1</resize_behaviour>
-        <rules />
+        <rules/>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
-        <scripts />
-        <tooltip></tooltip>
+        <scripts/>
+        <tooltip/>
         <visible>true</visible>
         <widget_type>Linking Container</widget_type>
         <width>1051</width>
@@ -307,12 +307,12 @@
       </widget>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -322,7 +322,7 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
       <height>631</height>
       <lock_children>false</lock_children>
@@ -330,15 +330,15 @@
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Collimation Plane Parameters</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>true</show_scrollbar>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>true</transparent>
       <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
@@ -347,12 +347,12 @@
       <x>1</x>
       <y>1</y>
       <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-        <actions hook="false" hook_all="false" />
+        <actions hook="false" hook_all="false"/>
         <background_color>
-          <color red="240" green="240" blue="240" />
+          <color red="240" green="240" blue="240"/>
         </background_color>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="128" blue="255"/>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
@@ -361,9 +361,9 @@
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
         </font>
         <foreground_color>
-          <color red="192" green="192" blue="192" />
+          <color red="192" green="192" blue="192"/>
         </foreground_color>
-        <group_name></group_name>
+        <group_name/>
         <height>631</height>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -371,14 +371,14 @@
         <name>Linking Container_1</name>
         <opi_file>tab_collimation_params.opi</opi_file>
         <resize_behaviour>1</resize_behaviour>
-        <rules />
+        <rules/>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
-        <scripts />
-        <tooltip></tooltip>
+        <scripts/>
+        <tooltip/>
         <visible>true</visible>
         <widget_type>Linking Container</widget_type>
         <width>1051</width>
@@ -388,12 +388,12 @@
       </widget>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -403,7 +403,7 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
       <height>631</height>
       <lock_children>false</lock_children>
@@ -411,15 +411,15 @@
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Activation Parameters</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>true</show_scrollbar>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>true</transparent>
       <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
@@ -428,12 +428,12 @@
       <x>1</x>
       <y>1</y>
       <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-        <actions hook="false" hook_all="false" />
+        <actions hook="false" hook_all="false"/>
         <background_color>
-          <color red="240" green="240" blue="240" />
+          <color red="240" green="240" blue="240"/>
         </background_color>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="128" blue="255"/>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
@@ -442,9 +442,9 @@
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
         </font>
         <foreground_color>
-          <color red="192" green="192" blue="192" />
+          <color red="192" green="192" blue="192"/>
         </foreground_color>
-        <group_name></group_name>
+        <group_name/>
         <height>631</height>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -452,14 +452,14 @@
         <name>Linking Container</name>
         <opi_file>tab_activation_params.opi</opi_file>
         <resize_behaviour>1</resize_behaviour>
-        <rules />
+        <rules/>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
-        <scripts />
-        <tooltip></tooltip>
+        <scripts/>
+        <tooltip/>
         <visible>true</visible>
         <widget_type>Linking Container</widget_type>
         <width>1051</width>
@@ -469,12 +469,12 @@
       </widget>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -484,7 +484,7 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
       <height>631</height>
       <lock_children>false</lock_children>
@@ -492,15 +492,15 @@
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Slit Parameters</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>true</show_scrollbar>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>true</transparent>
       <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
@@ -509,12 +509,12 @@
       <x>1</x>
       <y>1</y>
       <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-        <actions hook="false" hook_all="false" />
+        <actions hook="false" hook_all="false"/>
         <background_color>
-          <color red="240" green="240" blue="240" />
+          <color red="240" green="240" blue="240"/>
         </background_color>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="128" blue="255"/>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
@@ -523,9 +523,9 @@
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
         </font>
         <foreground_color>
-          <color red="192" green="192" blue="192" />
+          <color red="192" green="192" blue="192"/>
         </foreground_color>
-        <group_name></group_name>
+        <group_name/>
         <height>631</height>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -533,14 +533,14 @@
         <name>Linking Container_1</name>
         <opi_file>tab_slit_params.opi</opi_file>
         <resize_behaviour>1</resize_behaviour>
-        <rules />
+        <rules/>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
-        <scripts />
-        <tooltip></tooltip>
+        <scripts/>
+        <tooltip/>
         <visible>true</visible>
         <widget_type>Linking Container</widget_type>
         <width>1051</width>
@@ -550,12 +550,12 @@
       </widget>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -565,7 +565,7 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
       <height>631</height>
       <lock_children>false</lock_children>
@@ -573,15 +573,15 @@
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Other Parameters</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>true</show_scrollbar>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>true</transparent>
       <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
@@ -590,12 +590,12 @@
       <x>1</x>
       <y>1</y>
       <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-        <actions hook="false" hook_all="false" />
+        <actions hook="false" hook_all="false"/>
         <background_color>
-          <color red="240" green="240" blue="240" />
+          <color red="240" green="240" blue="240"/>
         </background_color>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="128" blue="255"/>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
@@ -604,9 +604,9 @@
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
         </font>
         <foreground_color>
-          <color red="192" green="192" blue="192" />
+          <color red="192" green="192" blue="192"/>
         </foreground_color>
-        <group_name></group_name>
+        <group_name/>
         <height>631</height>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -614,14 +614,14 @@
         <name>Linking Container_1</name>
         <opi_file>tab_other_params.opi</opi_file>
         <resize_behaviour>1</resize_behaviour>
-        <rules />
+        <rules/>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
-        <scripts />
-        <tooltip></tooltip>
+        <scripts/>
+        <tooltip/>
         <visible>true</visible>
         <widget_type>Linking Container</widget_type>
         <width>1051</width>
@@ -631,12 +631,12 @@
       </widget>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -646,7 +646,7 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
       <height>631</height>
       <lock_children>false</lock_children>
@@ -654,15 +654,15 @@
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Driver Corrections</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>true</show_scrollbar>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>true</transparent>
       <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
@@ -671,12 +671,12 @@
       <x>1</x>
       <y>1</y>
       <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-        <actions hook="false" hook_all="false" />
+        <actions hook="false" hook_all="false"/>
         <background_color>
-          <color red="240" green="240" blue="240" />
+          <color red="240" green="240" blue="240"/>
         </background_color>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="128" blue="255"/>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
@@ -685,9 +685,9 @@
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
         </font>
         <foreground_color>
-          <color red="192" green="192" blue="192" />
+          <color red="192" green="192" blue="192"/>
         </foreground_color>
-        <group_name></group_name>
+        <group_name/>
         <height>631</height>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -695,14 +695,14 @@
         <name>Linking Container</name>
         <opi_file>tab_corrections.opi</opi_file>
         <resize_behaviour>1</resize_behaviour>
-        <rules />
+        <rules/>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
-        <scripts />
-        <tooltip></tooltip>
+        <scripts/>
+        <tooltip/>
         <visible>true</visible>
         <widget_type>Linking Container</widget_type>
         <width>1051</width>
@@ -712,12 +712,12 @@
       </widget>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -727,7 +727,7 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
       <height>631</height>
       <lock_children>false</lock_children>
@@ -735,15 +735,15 @@
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Constants</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>true</show_scrollbar>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>true</transparent>
       <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
@@ -752,12 +752,12 @@
       <x>1</x>
       <y>1</y>
       <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-        <actions hook="false" hook_all="false" />
+        <actions hook="false" hook_all="false"/>
         <background_color>
-          <color red="240" green="240" blue="240" />
+          <color red="240" green="240" blue="240"/>
         </background_color>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="128" blue="255"/>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
@@ -766,9 +766,9 @@
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
         </font>
         <foreground_color>
-          <color red="192" green="192" blue="192" />
+          <color red="192" green="192" blue="192"/>
         </foreground_color>
-        <group_name></group_name>
+        <group_name/>
         <height>631</height>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -776,14 +776,14 @@
         <name>Linking Container</name>
         <opi_file>tab_constants.opi</opi_file>
         <resize_behaviour>1</resize_behaviour>
-        <rules />
+        <rules/>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
-        <scripts />
-        <tooltip></tooltip>
+        <scripts/>
+        <tooltip/>
         <visible>true</visible>
         <widget_type>Linking Container</widget_type>
         <width>1051</width>
@@ -793,12 +793,12 @@
       </widget>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -808,7 +808,7 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
       <height>631</height>
       <lock_children>false</lock_children>
@@ -816,15 +816,15 @@
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Error Log</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>true</show_scrollbar>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>true</transparent>
       <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
@@ -833,12 +833,12 @@
       <x>1</x>
       <y>1</y>
       <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-        <actions hook="false" hook_all="false" />
+        <actions hook="false" hook_all="false"/>
         <background_color>
-          <color red="240" green="240" blue="240" />
+          <color red="240" green="240" blue="240"/>
         </background_color>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="128" blue="255"/>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
@@ -847,9 +847,9 @@
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
         </font>
         <foreground_color>
-          <color red="192" green="192" blue="192" />
+          <color red="192" green="192" blue="192"/>
         </foreground_color>
-        <group_name></group_name>
+        <group_name/>
         <height>631</height>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -857,14 +857,14 @@
         <name>Linking Container</name>
         <opi_file>tab_error_log.opi</opi_file>
         <resize_behaviour>1</resize_behaviour>
-        <rules />
+        <rules/>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
-        <scripts />
-        <tooltip></tooltip>
+        <scripts/>
+        <tooltip/>
         <visible>true</visible>
         <widget_type>Linking Container</widget_type>
         <width>1051</width>
@@ -874,12 +874,12 @@
       </widget>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -889,7 +889,7 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
       <height>631</height>
       <lock_children>false</lock_children>
@@ -897,15 +897,15 @@
         <include_parent_macros>true</include_parent_macros>
       </macros>
       <name>Redefine Motors</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>true</show_scrollbar>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>true</transparent>
       <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
@@ -914,12 +914,12 @@
       <x>1</x>
       <y>1</y>
       <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-        <actions hook="false" hook_all="false" />
+        <actions hook="false" hook_all="false"/>
         <background_color>
-          <color red="240" green="240" blue="240" />
+          <color red="240" green="240" blue="240"/>
         </background_color>
         <border_color>
-          <color red="0" green="128" blue="255" />
+          <color red="0" green="128" blue="255"/>
         </border_color>
         <border_style>0</border_style>
         <border_width>1</border_width>
@@ -928,9 +928,9 @@
           <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
         </font>
         <foreground_color>
-          <color red="192" green="192" blue="192" />
+          <color red="192" green="192" blue="192"/>
         </foreground_color>
-        <group_name></group_name>
+        <group_name/>
         <height>631</height>
         <macros>
           <include_parent_macros>true</include_parent_macros>
@@ -938,14 +938,14 @@
         <name>Linking Container</name>
         <opi_file>tab_redefine.opi</opi_file>
         <resize_behaviour>1</resize_behaviour>
-        <rules />
+        <rules/>
         <scale_options>
           <width_scalable>true</width_scalable>
           <height_scalable>true</height_scalable>
           <keep_wh_ratio>false</keep_wh_ratio>
         </scale_options>
-        <scripts />
-        <tooltip></tooltip>
+        <scripts/>
+        <tooltip/>
         <visible>true</visible>
         <widget_type>Linking Container</widget_type>
         <width>1051</width>
@@ -954,5 +954,45 @@
         <y>0</y>
       </widget>
     </widget>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+    <actions hook="false" hook_all="false"/>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+    </foreground_color>
+    <height>1</height>
+    <image/>
+    <name>Dummy</name>
+    <push_action_index>0</push_action_index>
+    <pv_name/>
+    <pv_value/>
+    <rules/>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts/>
+    <style>1</style>
+    <text/>
+    <toggle_button>false</toggle_button>
+    <tooltip/>
+    <visible>true</visible>
+    <widget_type>Action Button</widget_type>
+    <width>1</width>
+    <wuid>-648922a4:1624e4fa0bd:-7f69</wuid>
+    <x>0</x>
+    <y>0</y>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_align.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_align.opi
@@ -178,7 +178,7 @@ $(pv_value)</tooltip>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
       <scripts />
-      <show_units>true</show_units>
+      <show_units>false</show_units>
       <text>######</text>
       <tooltip>Readback $(pv_name)&#xD;
 $(pv_value)  (current position)</tooltip>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_list.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_list.opi
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
-  <actions hook="false" hook_all="false" />
+  <actions hook="false" hook_all="false"/>
   <auto_scale_widgets>
     <auto_scale_widgets>false</auto_scale_widgets>
     <min_width>-1</min_width>
@@ -8,20 +8,20 @@
   </auto_scale_widgets>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
-    <color red="240" green="240" blue="240" />
+    <color red="240" green="240" blue="240"/>
   </background_color>
   <boy_version>5.1.0</boy_version>
   <foreground_color>
-    <color red="192" green="192" blue="192" />
+    <color red="192" green="192" blue="192"/>
   </foreground_color>
   <grid_space>6</grid_space>
   <height>600</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
   </macros>
-  <name></name>
-  <rules />
-  <scripts />
+  <name/>
+  <rules/>
+  <scripts/>
   <show_close_button>true</show_close_button>
   <show_edit_range>true</show_edit_range>
   <show_grid>true</show_grid>
@@ -33,12 +33,12 @@
   <x>-1</x>
   <y>-1</y>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </background_color>
     <border_color>
-      <color red="0" green="128" blue="255" />
+      <color red="0" green="128" blue="255"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -48,7 +48,7 @@
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
     </foreground_color>
     <height>560</height>
     <lock_children>false</lock_children>
@@ -56,15 +56,15 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <name>params_col_1</name>
-    <rules />
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <show_scrollbar>true</show_scrollbar>
-    <tooltip></tooltip>
+    <tooltip/>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
@@ -73,12 +73,12 @@
     <x>0</x>
     <y>0</y>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -87,9 +87,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>17</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -97,14 +97,14 @@
       <name>col_1_labels</name>
       <opi_file>set_point_column_labels.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>201</width>
@@ -113,12 +113,12 @@
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -127,9 +127,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -137,14 +137,14 @@
       <name>$(GROUP_KEY)_1</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -153,12 +153,12 @@
       <y>19</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -167,9 +167,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -177,14 +177,14 @@
       <name>$(GROUP_KEY)_2</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -193,12 +193,12 @@
       <y>54</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -207,9 +207,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -217,14 +217,14 @@
       <name>$(GROUP_KEY)_3</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -233,12 +233,12 @@
       <y>89</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -247,9 +247,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -257,14 +257,14 @@
       <name>$(GROUP_KEY)_4</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -273,12 +273,12 @@
       <y>124</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -287,9 +287,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -297,14 +297,14 @@
       <name>$(GROUP_KEY)_5</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -313,12 +313,12 @@
       <y>159</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -327,9 +327,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -337,14 +337,14 @@
       <name>$(GROUP_KEY)_6</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -353,12 +353,12 @@
       <y>194</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -367,9 +367,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -377,14 +377,14 @@
       <name>$(GROUP_KEY)_7</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -393,12 +393,12 @@
       <y>229</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -407,9 +407,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -417,14 +417,14 @@
       <name>$(GROUP_KEY)_8</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -433,12 +433,12 @@
       <y>264</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -447,9 +447,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -457,14 +457,14 @@
       <name>$(GROUP_KEY)_9</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -473,12 +473,12 @@
       <y>299</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -487,9 +487,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -497,14 +497,14 @@
       <name>$(GROUP_KEY)_10</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -513,12 +513,12 @@
       <y>334</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -527,9 +527,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -537,14 +537,14 @@
       <name>$(GROUP_KEY)_11</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -553,12 +553,12 @@
       <y>369</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -567,9 +567,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -577,14 +577,14 @@
       <name>$(GROUP_KEY)_12</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -593,12 +593,12 @@
       <y>404</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -607,9 +607,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -617,14 +617,14 @@
       <name>$(GROUP_KEY)_13</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -633,12 +633,12 @@
       <y>439</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -647,9 +647,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -657,14 +657,14 @@
       <name>$(GROUP_KEY)_14</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -673,12 +673,12 @@
       <y>474</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -687,9 +687,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -697,14 +697,14 @@
       <name>$(GROUP_KEY)_15</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -714,12 +714,12 @@
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <background_color>
-      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </background_color>
     <border_color>
-      <color red="0" green="128" blue="255" />
+      <color red="0" green="128" blue="255"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -729,7 +729,7 @@
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <foreground_color>
-      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
     </foreground_color>
     <height>560</height>
     <lock_children>false</lock_children>
@@ -737,15 +737,15 @@
       <include_parent_macros>true</include_parent_macros>
     </macros>
     <name>params_col_2</name>
-    <rules />
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <show_scrollbar>true</show_scrollbar>
-    <tooltip></tooltip>
+    <tooltip/>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
@@ -754,12 +754,12 @@
     <x>525</x>
     <y>0</y>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -768,9 +768,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -778,14 +778,14 @@
       <name>$(GROUP_KEY)_28</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -794,12 +794,12 @@
       <y>439</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -808,9 +808,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -818,14 +818,14 @@
       <name>$(GROUP_KEY)_27</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -834,12 +834,12 @@
       <y>404</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -848,9 +848,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -858,14 +858,14 @@
       <name>$(GROUP_KEY)_26</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -874,12 +874,12 @@
       <y>369</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -888,9 +888,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -898,14 +898,14 @@
       <name>$(GROUP_KEY)_25</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -914,12 +914,12 @@
       <y>334</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -928,9 +928,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -938,14 +938,14 @@
       <name>$(GROUP_KEY)_24</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -954,12 +954,12 @@
       <y>299</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -968,9 +968,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -978,14 +978,14 @@
       <name>$(GROUP_KEY)_23</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -994,12 +994,12 @@
       <y>264</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1008,9 +1008,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1018,14 +1018,14 @@
       <name>$(GROUP_KEY)_22</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -1034,12 +1034,12 @@
       <y>229</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1048,9 +1048,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1058,14 +1058,14 @@
       <name>$(GROUP_KEY)_21</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -1074,12 +1074,12 @@
       <y>194</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1088,9 +1088,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1098,14 +1098,14 @@
       <name>$(GROUP_KEY)_20</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -1114,12 +1114,12 @@
       <y>159</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1128,9 +1128,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1138,14 +1138,14 @@
       <name>$(GROUP_KEY)_19</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -1154,12 +1154,12 @@
       <y>124</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1168,9 +1168,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1178,14 +1178,14 @@
       <name>$(GROUP_KEY)_18</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -1194,12 +1194,12 @@
       <y>89</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1208,9 +1208,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1218,14 +1218,14 @@
       <name>$(GROUP_KEY)_17</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -1234,12 +1234,12 @@
       <y>54</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1248,9 +1248,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1258,14 +1258,14 @@
       <name>$(GROUP_KEY)_16</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -1274,12 +1274,12 @@
       <y>19</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1288,9 +1288,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>17</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1298,14 +1298,14 @@
       <name>col_2_labels</name>
       <opi_file>set_point_column_labels.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>201</width>
@@ -1314,12 +1314,12 @@
       <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1328,9 +1328,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1338,14 +1338,14 @@
       <name>$(GROUP_KEY)_29</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -1354,12 +1354,12 @@
       <y>474</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -1368,9 +1368,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>25</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1378,14 +1378,14 @@
       <name>$(GROUP_KEY)_30</name>
       <opi_file>param_move.opi</opi_file>
       <resize_behaviour>3</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>false</visible>
       <widget_type>Linking Container</widget_type>
       <width>505</width>
@@ -1395,10 +1395,10 @@
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -1408,25 +1408,25 @@
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </foreground_color>
     <height>1</height>
-    <image></image>
+    <image/>
     <name>Dummy</name>
     <push_action_index>0</push_action_index>
-    <pv_name></pv_name>
-    <pv_value />
-    <rules />
+    <pv_name/>
+    <pv_value/>
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <style>1</style>
-    <text></text>
+    <text/>
     <toggle_button>false</toggle_button>
-    <tooltip></tooltip>
+    <tooltip/>
     <visible>true</visible>
     <widget_type>Action Button</widget_type>
     <width>1</width>
@@ -1435,7 +1435,7 @@
     <y>0</y>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.polyline" version="1.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <alarm_pulsing>false</alarm_pulsing>
     <alpha>255</alpha>
     <anti_alias>true</anti_alias>
@@ -1443,11 +1443,11 @@
     <arrows>0</arrows>
     <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
     <background_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
     </background_color>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -1459,7 +1459,7 @@
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color red="255" green="0" blue="0" />
+      <color red="255" green="0" blue="0"/>
     </foreground_color>
     <height>500</height>
     <horizontal_fill>true</horizontal_fill>
@@ -1467,19 +1467,19 @@
     <line_width>1</line_width>
     <name>Polyline</name>
     <points>
-      <point x="525" y="529" />
-      <point x="525" y="30" />
+      <point x="525" y="529"/>
+      <point x="525" y="30"/>
     </points>
-    <pv_name></pv_name>
-    <pv_value />
+    <pv_name/>
+    <pv_value/>
     <rotation_angle>0.0</rotation_angle>
-    <rules />
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>true</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <tooltip>$(pv_name)
 $(pv_value)</tooltip>
     <transparent>false</transparent>
@@ -1489,5 +1489,45 @@ $(pv_value)</tooltip>
     <wuid>38ac9ff8:1774a068546:-6eb2</wuid>
     <x>525</x>
     <y>30</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+    <actions hook="false" hook_all="false"/>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+    </foreground_color>
+    <height>1</height>
+    <image/>
+    <name>Dummy</name>
+    <push_action_index>0</push_action_index>
+    <pv_name/>
+    <pv_value/>
+    <rules/>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts/>
+    <style>1</style>
+    <text/>
+    <toggle_button>false</toggle_button>
+    <tooltip/>
+    <visible>true</visible>
+    <widget_type>Action Button</widget_type>
+    <width>1</width>
+    <wuid>-648922a4:1624e4fa0bd:-7f69</wuid>
+    <x>0</x>
+    <y>0</y>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
@@ -115,7 +115,7 @@
       <pv_name>$(PV_ROOT)$(PREFIXED_PV):ACTION</pv_name>
       <pv_value />
       <rules>
-        <rule name="Enabled" prop_id="enabled" out_exp="false">
+        <rule name="visible" prop_id="visible" out_exp="false">
           <exp bool_exp="pv0==1">
             <value>false</value>
           </exp>
@@ -177,7 +177,7 @@
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
       <scripts />
-      <show_units>true</show_units>
+      <show_units>false</show_units>
       <text>######</text>
       <tooltip>Parameter set point readback $(pv_name)&#xD;
 $(pv_value)</tooltip>
@@ -321,7 +321,7 @@ $(pv_value)</tooltip>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
       <scripts />
-      <show_units>true</show_units>
+      <show_units>false</show_units>
       <text>######</text>
       <tooltip>Readback $(pv_name)&#xD;
 $(pv_value)  (current position)</tooltip>
@@ -449,6 +449,53 @@ $(pv_value)</tooltip>
       <width>18</width>
       <wuid>-13168dce:16b323bd04e:-727f</wuid>
       <x>0</x>
+      <y>0</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color red="255" green="255" blue="255" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+      <name>Out_label</name>
+      <rules>
+        <rule name="Visible" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):ACTION.DISP</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <text>Out</text>
+      <tooltip>Cannot move axis - component is set to be parked out of beam</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Label</widget_type>
+      <width>56</width>
+      <wrap_words>false</wrap_words>
+      <wuid>3f33d901:177f440403d:-7ee0</wuid>
+      <x>380</x>
       <y>0</y>
     </widget>
   </widget>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
@@ -114,7 +114,14 @@
       <push_action_index>0</push_action_index>
       <pv_name>$(PV_ROOT)$(PREFIXED_PV):ACTION</pv_name>
       <pv_value />
-      <rules />
+      <rules>
+        <rule name="Enabled" prop_id="enabled" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
+        </rule>
+      </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
@@ -233,6 +240,18 @@ $(pv_value)</tooltip>
             </value>
           </exp>
           <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):CHANGED</pv>
+        </rule>
+        <rule name="Enabled" prop_id="enabled" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
+        </rule>
+        <rule name="Enabledbg" prop_id="transparent" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
         </rule>
       </rules>
       <scale_options>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
@@ -119,7 +119,7 @@
           <exp bool_exp="pv0==1">
             <value>false</value>
           </exp>
-          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):ACTION.DISP</pv>
         </rule>
       </rules>
       <scale_options>
@@ -245,13 +245,13 @@ $(pv_value)</tooltip>
           <exp bool_exp="pv0==1">
             <value>false</value>
           </exp>
-          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
         </rule>
         <rule name="Enabledbg" prop_id="transparent" out_exp="false">
           <exp bool_exp="pv0==1">
             <value>true</value>
           </exp>
-          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
         </rule>
       </rules>
       <scale_options>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_highlighted.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_highlighted.opi
@@ -122,7 +122,7 @@
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
       <scripts />
-      <show_units>true</show_units>
+      <show_units>false</show_units>
       <text>######</text>
       <tooltip>Parameter set point readback $(pv_name)&#xD;
 $(pv_value)</tooltip>
@@ -266,7 +266,7 @@ $(pv_value)</tooltip>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
       <scripts />
-      <show_units>true</show_units>
+      <show_units>false</show_units>
       <text>######</text>
       <tooltip>Readback $(pv_name)&#xD;
 $(pv_value)  (current position)</tooltip>
@@ -427,7 +427,7 @@ $(pv_value)</tooltip>
       <pv_name>$(PV_ROOT)$(PREFIXED_PV):ACTION</pv_name>
       <pv_value />
       <rules>
-        <rule name="Enabled" prop_id="enabled" out_exp="false">
+        <rule name="Visible" prop_id="visible" out_exp="false">
           <exp bool_exp="pv0==1">
             <value>false</value>
           </exp>
@@ -450,6 +450,53 @@ $(pv_value)</tooltip>
       <wuid>-744b7940:165a9b5d31a:-7a6a</wuid>
       <x>380</x>
       <y>1</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color red="255" green="255" blue="255" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+      <name>Out_label</name>
+      <rules>
+        <rule name="Visible" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):ACTION.DISP</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <text>Out</text>
+      <tooltip>Cannot move axis - component is set to be parked out of beam</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Label</widget_type>
+      <width>56</width>
+      <wrap_words>false</wrap_words>
+      <wuid>3f33d901:177f440403d:-7ed8</wuid>
+      <x>380</x>
+      <y>2</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_highlighted.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_highlighted.opi
@@ -186,6 +186,18 @@ $(pv_value)</tooltip>
           </exp>
           <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):CHANGED</pv>
         </rule>
+        <rule name="Enabled" prop_id="enabled" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
+        </rule>
+        <rule name="Enabledbg" prop_id="transparent" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
+        </rule>
       </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -414,7 +426,14 @@ $(pv_value)</tooltip>
       <push_action_index>0</push_action_index>
       <pv_name>$(PV_ROOT)$(PREFIXED_PV):ACTION</pv_name>
       <pv_value />
-      <rules />
+      <rules>
+        <rule name="Enabled" prop_id="enabled" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):ACTION.DISP</pv>
+        </rule>
+      </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_with_cv.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_with_cv.opi
@@ -114,7 +114,14 @@
       <push_action_index>0</push_action_index>
       <pv_name>$(PV_ROOT)$(PREFIXED_PV):ACTION</pv_name>
       <pv_value />
-      <rules />
+      <rules>
+        <rule name="Enabled" prop_id="enabled" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
+        </rule>
+      </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
@@ -233,6 +240,12 @@ $(pv_value)</tooltip>
             </value>
           </exp>
           <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):CHANGED</pv>
+        </rule>
+        <rule name="Enabled" prop_id="enabled" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
         </rule>
       </rules>
       <scale_options>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_with_cv.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_with_cv.opi
@@ -119,7 +119,7 @@
           <exp bool_exp="pv0==1">
             <value>false</value>
           </exp>
-          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):ACTION.DISP</pv>
         </rule>
       </rules>
       <scale_options>
@@ -245,7 +245,13 @@ $(pv_value)</tooltip>
           <exp bool_exp="pv0==1">
             <value>false</value>
           </exp>
-          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV).DISP</pv>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
+        </rule>
+        <rule name="Enabledbg" prop_id="transparent" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
         </rule>
       </rules>
       <scale_options>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_with_cv.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_with_cv.opi
@@ -115,7 +115,7 @@
       <pv_name>$(PV_ROOT)$(PREFIXED_PV):ACTION</pv_name>
       <pv_value />
       <rules>
-        <rule name="Enabled" prop_id="enabled" out_exp="false">
+        <rule name="Visible" prop_id="visible" out_exp="false">
           <exp bool_exp="pv0==1">
             <value>false</value>
           </exp>
@@ -177,7 +177,7 @@
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
       <scripts />
-      <show_units>true</show_units>
+      <show_units>false</show_units>
       <text>######</text>
       <tooltip>Parameter set point readback $(pv_name)&#xD;
 $(pv_value)</tooltip>
@@ -321,7 +321,7 @@ $(pv_value)</tooltip>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
       <scripts />
-      <show_units>true</show_units>
+      <show_units>false</show_units>
       <text>######</text>
       <tooltip>Readback $(pv_name)&#xD;
 $(pv_value)  (current position)</tooltip>
@@ -510,6 +510,53 @@ $(pv_value)</tooltip>
       <wuid>38ac9ff8:1774a068546:-715b</wuid>
       <x>444</x>
       <y>1</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color red="255" green="255" blue="255" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+      <name>Out_label</name>
+      <rules>
+        <rule name="Visible" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):ACTION.DISP</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <text>Out</text>
+      <tooltip>Cannot move axis - component is set to be parked out of beam</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Label</widget_type>
+      <width>56</width>
+      <wrap_words>false</wrap_words>
+      <wuid>3f33d901:177f440403d:-7ed3</wuid>
+      <x>380</x>
+      <y>0</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/tab_constants.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/tab_constants.opi
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
-  <actions hook="false" hook_all="false" />
+  <actions hook="false" hook_all="false"/>
   <auto_scale_widgets>
     <auto_scale_widgets>false</auto_scale_widgets>
     <min_width>-1</min_width>
@@ -8,11 +8,11 @@
   </auto_scale_widgets>
   <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
   <background_color>
-    <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
   </background_color>
   <boy_version>5.1.0</boy_version>
   <foreground_color>
-    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192"/>
   </foreground_color>
   <grid_space>6</grid_space>
   <height>630</height>
@@ -21,8 +21,8 @@
     <PV_ROOT>$(P)REFL_01:</PV_ROOT>
   </macros>
   <name>$(NAME)</name>
-  <rules />
-  <scripts />
+  <rules/>
+  <scripts/>
   <show_close_button>true</show_close_button>
   <show_edit_range>true</show_edit_range>
   <show_grid>true</show_grid>
@@ -34,12 +34,12 @@
   <x>-1</x>
   <y>-1</y>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <background_color>
-      <color red="240" green="240" blue="240" />
+      <color red="240" green="240" blue="240"/>
     </background_color>
     <border_color>
-      <color red="0" green="128" blue="255" />
+      <color red="0" green="128" blue="255"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -49,7 +49,7 @@
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <foreground_color>
-      <color red="192" green="192" blue="192" />
+      <color red="192" green="192" blue="192"/>
     </foreground_color>
     <height>630</height>
     <lock_children>false</lock_children>
@@ -61,7 +61,7 @@
       <MAX_NUMBER>32</MAX_NUMBER>
     </macros>
     <name>Front Panel</name>
-    <rules />
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
@@ -73,7 +73,7 @@
       </path>
     </scripts>
     <show_scrollbar>true</show_scrollbar>
-    <tooltip></tooltip>
+    <tooltip/>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
@@ -82,12 +82,12 @@
     <x>0</x>
     <y>0</y>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -96,9 +96,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>55</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -106,14 +106,14 @@
       <name>Action Bar</name>
       <opi_file>action_bar.opi</opi_file>
       <resize_behaviour>1</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>1050</width>
@@ -122,12 +122,12 @@
       <y>570</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -136,9 +136,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -146,14 +146,14 @@
       <name>Value_1</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -162,13 +162,13 @@
       <y>42</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <auto_size>false</auto_size>
       <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
+        <color name="ISIS_Border" red="0" green="0" blue="0"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -178,21 +178,21 @@
                       </opifont.name>
       </font>
       <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
       </foreground_color>
       <height>20</height>
       <horizontal_alignment>2</horizontal_alignment>
       <name>Label_9</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>false</show_scrollbar>
       <text>Name:</text>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>false</transparent>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
@@ -204,13 +204,13 @@
       <y>12</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <auto_size>false</auto_size>
       <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
+        <color name="ISIS_Border" red="0" green="0" blue="0"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -220,21 +220,21 @@
                       </opifont.name>
       </font>
       <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
       </foreground_color>
       <height>20</height>
       <horizontal_alignment>0</horizontal_alignment>
       <name>Label_1</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>false</show_scrollbar>
       <text>Value</text>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>false</transparent>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
@@ -246,13 +246,13 @@
       <y>12</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <auto_size>false</auto_size>
       <background_color>
-        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
+        <color name="ISIS_Border" red="0" green="0" blue="0"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>1</border_width>
@@ -262,21 +262,21 @@
                       </opifont.name>
       </font>
       <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
       </foreground_color>
       <height>20</height>
       <horizontal_alignment>0</horizontal_alignment>
       <name>Label_2</name>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
+      <scripts/>
       <show_scrollbar>false</show_scrollbar>
       <text>Description</text>
-      <tooltip></tooltip>
+      <tooltip/>
       <transparent>false</transparent>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
@@ -288,12 +288,12 @@
       <y>12</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -302,9 +302,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -312,14 +312,14 @@
       <name>Value_2</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -328,12 +328,12 @@
       <y>72</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -342,9 +342,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -352,14 +352,14 @@
       <name>Value_3</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -368,12 +368,12 @@
       <y>102</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -382,9 +382,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -392,14 +392,14 @@
       <name>Value_4</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -408,12 +408,12 @@
       <y>132</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -422,9 +422,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -432,14 +432,14 @@
       <name>Value_5</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -448,12 +448,12 @@
       <y>162</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -462,9 +462,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -472,14 +472,14 @@
       <name>Value_6</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -488,12 +488,12 @@
       <y>192</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -502,9 +502,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -512,14 +512,14 @@
       <name>Value_7</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -528,12 +528,12 @@
       <y>222</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -542,9 +542,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -552,14 +552,14 @@
       <name>Value_8</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -568,12 +568,12 @@
       <y>252</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -582,9 +582,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -592,14 +592,14 @@
       <name>Value_9</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -608,12 +608,12 @@
       <y>282</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -622,9 +622,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -632,14 +632,14 @@
       <name>Value_10</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -648,12 +648,12 @@
       <y>312</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -662,9 +662,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -672,14 +672,14 @@
       <name>Value_11</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -688,12 +688,12 @@
       <y>342</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -702,9 +702,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -712,14 +712,14 @@
       <name>Value_12</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -728,12 +728,12 @@
       <y>372</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -742,9 +742,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -752,14 +752,14 @@
       <name>Value_13</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -768,12 +768,12 @@
       <y>402</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -782,9 +782,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -792,14 +792,14 @@
       <name>Value_14</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -808,12 +808,12 @@
       <y>432</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -822,9 +822,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -832,14 +832,14 @@
       <name>Value_15</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -848,12 +848,12 @@
       <y>462</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -862,9 +862,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -872,14 +872,14 @@
       <name>Value_16</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -888,12 +888,12 @@
       <y>492</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -902,9 +902,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -912,14 +912,14 @@
       <name>Value_17</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -928,12 +928,12 @@
       <y>42</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -942,9 +942,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -952,14 +952,14 @@
       <name>Value_18</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -968,12 +968,12 @@
       <y>72</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -982,9 +982,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -992,14 +992,14 @@
       <name>Value_19</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1008,12 +1008,12 @@
       <y>102</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1022,9 +1022,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1032,14 +1032,14 @@
       <name>Value_20</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1048,12 +1048,12 @@
       <y>132</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1062,9 +1062,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1072,14 +1072,14 @@
       <name>Value_21</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1088,12 +1088,12 @@
       <y>162</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1102,9 +1102,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1112,14 +1112,14 @@
       <name>Value_22</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1128,12 +1128,12 @@
       <y>192</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1142,9 +1142,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1152,14 +1152,14 @@
       <name>Value_23</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1168,12 +1168,12 @@
       <y>222</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1182,9 +1182,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1192,14 +1192,14 @@
       <name>Value_24</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1208,12 +1208,12 @@
       <y>252</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1222,9 +1222,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1232,14 +1232,14 @@
       <name>Value_25</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1248,12 +1248,12 @@
       <y>282</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1262,9 +1262,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1272,14 +1272,14 @@
       <name>Value_26</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1288,12 +1288,12 @@
       <y>312</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1302,9 +1302,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1312,14 +1312,14 @@
       <name>Value_27</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1328,12 +1328,12 @@
       <y>342</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1342,9 +1342,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1352,14 +1352,14 @@
       <name>Value_28</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1368,12 +1368,12 @@
       <y>372</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1382,9 +1382,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1392,14 +1392,14 @@
       <name>Value_29</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1408,12 +1408,12 @@
       <y>402</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1422,9 +1422,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1432,14 +1432,14 @@
       <name>Value_30</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1448,12 +1448,12 @@
       <y>432</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1462,9 +1462,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1472,14 +1472,14 @@
       <name>Value_31</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1488,12 +1488,12 @@
       <y>462</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
+      <actions hook="false" hook_all="false"/>
       <background_color>
-        <color red="240" green="240" blue="240" />
+        <color red="240" green="240" blue="240"/>
       </background_color>
       <border_color>
-        <color red="0" green="128" blue="255" />
+        <color red="0" green="128" blue="255"/>
       </border_color>
       <border_style>0</border_style>
       <border_width>0</border_width>
@@ -1502,9 +1502,9 @@
         <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
       </font>
       <foreground_color>
-        <color red="192" green="192" blue="192" />
+        <color red="192" green="192" blue="192"/>
       </foreground_color>
-      <group_name></group_name>
+      <group_name/>
       <height>31</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -1512,14 +1512,14 @@
       <name>Value_32</name>
       <opi_file>value.opi</opi_file>
       <resize_behaviour>2</resize_behaviour>
-      <rules />
+      <rules/>
       <scale_options>
         <width_scalable>false</width_scalable>
         <height_scalable>false</height_scalable>
         <keep_wh_ratio>false</keep_wh_ratio>
       </scale_options>
-      <scripts />
-      <tooltip></tooltip>
+      <scripts/>
+      <tooltip/>
       <visible>true</visible>
       <widget_type>Linking Container</widget_type>
       <width>475</width>
@@ -1529,10 +1529,10 @@
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-    <actions hook="false" hook_all="false" />
+    <actions hook="false" hook_all="false"/>
     <border_alarm_sensitive>false</border_alarm_sensitive>
     <border_color>
-      <color name="ISIS_Border" red="0" green="0" blue="0" />
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -1542,25 +1542,25 @@
     </font>
     <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
     <foreground_color>
-      <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
     </foreground_color>
     <height>1</height>
-    <image></image>
+    <image/>
     <name>Dummy</name>
     <push_action_index>0</push_action_index>
-    <pv_name></pv_name>
-    <pv_value />
-    <rules />
+    <pv_name/>
+    <pv_value/>
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <style>1</style>
-    <text></text>
+    <text/>
     <toggle_button>false</toggle_button>
-    <tooltip></tooltip>
+    <tooltip/>
     <visible>true</visible>
     <widget_type>Action Button</widget_type>
     <width>1</width>
@@ -1578,10 +1578,10 @@
     <align_to_nearest_second>false</align_to_nearest_second>
     <auto_size>true</auto_size>
     <background_color>
-      <color red="240" green="240" blue="240" />
+      <color red="240" green="240" blue="240"/>
     </background_color>
     <border_color>
-      <color red="0" green="128" blue="255" />
+      <color red="0" green="128" blue="255"/>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
@@ -1597,7 +1597,7 @@
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
     <foreground_color>
-      <color red="192" green="192" blue="192" />
+      <color red="192" green="192" blue="192"/>
     </foreground_color>
     <height>24</height>
     <image_file>../icons_for_opis/help_icon_24.png</image_file>
@@ -1613,15 +1613,15 @@
         <col>1.0</col>
       </row>
     </permutation_matrix>
-    <rules />
+    <rules/>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts />
+    <scripts/>
     <stretch_to_fit>false</stretch_to_fit>
-    <tooltip></tooltip>
+    <tooltip/>
     <transparency>false</transparency>
     <visible>true</visible>
     <widget_type>Image</widget_type>
@@ -1629,5 +1629,45 @@
     <wuid>-1e199f55:177432fd9ca:-70c6</wuid>
     <x>1023</x>
     <y>3</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+    <actions hook="false" hook_all="false"/>
+    <border_alarm_sensitive>false</border_alarm_sensitive>
+    <border_color>
+      <color name="ISIS_Border" red="0" green="0" blue="0"/>
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+    </font>
+    <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+    <foreground_color>
+      <color name="ISIS_Standard_Text" red="0" green="0" blue="0"/>
+    </foreground_color>
+    <height>1</height>
+    <image/>
+    <name>Dummy</name>
+    <push_action_index>0</push_action_index>
+    <pv_name/>
+    <pv_value/>
+    <rules/>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts/>
+    <style>1</style>
+    <text/>
+    <toggle_button>false</toggle_button>
+    <tooltip/>
+    <visible>true</visible>
+    <widget_type>Action Button</widget_type>
+    <width>1</width>
+    <wuid>-648922a4:1624e4fa0bd:-7f69</wuid>
+    <x>0</x>
+    <y>0</y>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/value.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/value.opi
@@ -72,7 +72,7 @@
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
     <scripts />
-    <show_units>true</show_units>
+    <show_units>false</show_units>
     <text>######</text>
     <tooltip>$(pv_name)&#xD;
 $(pv_value)</tooltip>


### PR DESCRIPTION
### Description of work

Changed reflectometry OPI to disable controls reflecting the state of DISP fields on parameters indiciating whether writing to PV is allowed or not.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5900

### Acceptance criteria

If `.DISP` on a reflectometry parameter is 1:
- Setpoint field is greyed out
- Setpoint field is disabled
- Move button is disabled

### Unit tests

OPI only

### System tests

/

### Documentation

https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Reflectometry-View#parameter-states

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

