### PR TITLE
Added currently active consoles count when multiple consoles

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/plugin.xml
@@ -61,9 +61,17 @@
             class="uk.ac.stfc.isis.ibex.ui.scripting.ConsoleLengthMonitor"
             id="uk.ac.stfc.isis.ibex.ui.scripting.clearConsole">
       </dynamic>
- 		
+      </menuContribution>
+      
+      <menuContribution
+            locationURI="toolbar:org.eclipse.ui.console.ConsoleView?before=launchGroup">
+        	  <dynamic
+            class="uk.ac.stfc.isis.ibex.ui.scripting.ConsolesCountMonitor"
+            id="uk.ac.stfc.isis.ibex.ui.scripting.ConsolesNumberMonitor.label">
+      </dynamic>
       </menuContribution>
     </extension>
+    
     <extension
           point="org.eclipse.ui.console.consoleFactories">
        <consoleFactory

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/ConsolesCountMonitor.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/ConsolesCountMonitor.java
@@ -1,0 +1,58 @@
+package uk.ac.stfc.isis.ibex.ui.scripting;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.ui.console.ConsolePlugin;
+import org.eclipse.ui.menus.WorkbenchWindowControlContribution;
+
+/**
+ * Handler for label which shows the number of active consoles.
+ */
+@SuppressWarnings("checkstyle:magicnumber")
+public class ConsolesCountMonitor extends WorkbenchWindowControlContribution {
+
+	private static final String FORMAT = "Active consoles: %d";
+	private static final int MAX_LENGTH = String.format(FORMAT, 100).length();
+	private static final String TOOLTIP_TEXT = "The number of currently active consoles";
+
+	private Label label;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Control createControl(Composite parent) {
+		label = new Label(parent, SWT.NONE);
+		label.setToolTipText(TOOLTIP_TEXT);
+		label.setText("Active consoles: NaN");
+		updateLabelText();
+
+		// Subscribe to the numbers of active consoles changing
+		Consoles.getDefault().addConsoleCountListener(this::updateLabelText);
+
+		// When this widget gets disposed, remove the listener
+		label.addDisposeListener(e_ignored -> Consoles.getDefault().removeConsoleCountListener(this::updateLabelText));
+
+		return label;
+	}
+
+	private void updateLabelText() {
+		long consolesNumber;
+		try {
+			consolesNumber = ConsolePlugin.getDefault().getConsoleManager().getConsoles().length;
+		} catch (RuntimeException e) {
+			consolesNumber = 0;
+		}
+				
+		final String text = StringUtils.rightPad(String.format(FORMAT, consolesNumber), MAX_LENGTH);
+		Display.getDefault().asyncExec(() -> label.setText(text));
+		
+		// Display count only if there are multiple active consoles
+		boolean visible = !(consolesNumber == 0 || consolesNumber == 1);
+		Display.getDefault().asyncExec(() -> label.setVisible(visible));
+	}
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/GeniePythonConsoleFactory.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/GeniePythonConsoleFactory.java
@@ -79,6 +79,7 @@ public class GeniePythonConsoleFactory extends PydevConsoleFactory {
 			// I'm not sure we can get at it.
 			if (event.getJob().getName() == "Create Interactive Console") {
 				Consoles.getDefault().installOutputLengthLimitsOnAllConsoles();
+				Consoles.getDefault().installConsoleCountListener();
 			}
 		}
 	};


### PR DESCRIPTION
### Description of work

Added a label in the GUI scripting toolbar to display the number of currently active consoles when there is more than one.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5597

### Acceptance criteria

There is an obvious indication in the GUI scripting toolbar of how many consoles are open

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

https://github.com/ISISComputingGroup/System_Tests_UI_E4/pull/86

### Documentation
N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

