### PR TITLE
Hide controls when sp mirrors rbv and show message

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move.opi
@@ -253,6 +253,12 @@ $(pv_value)</tooltip>
           </exp>
           <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
         </rule>
+        <rule name="Visible" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
+        </rule>
       </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -474,10 +480,11 @@ $(pv_value)</tooltip>
       <name>Out_label</name>
       <rules>
         <rule name="Visible" prop_id="visible" out_exp="false">
-          <exp bool_exp="pv0==1">
+          <exp bool_exp="pv0==1 &amp;&amp; pv1==0">
             <value>true</value>
           </exp>
           <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):ACTION.DISP</pv>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
         </rule>
       </rules>
       <scale_options>
@@ -496,6 +503,53 @@ $(pv_value)</tooltip>
       <wrap_words>false</wrap_words>
       <wuid>3f33d901:177f440403d:-7ee0</wuid>
       <x>380</x>
+      <y>0</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color red="255" green="255" blue="255" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+      <name>Mirror_RBV</name>
+      <rules>
+        <rule name="Visible" prop_id="visible" out_exp="true">
+          <exp bool_exp="pv0!=0">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <text>Mirrors RBV</text>
+      <tooltip>Set point will take the value of the read back on move</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Label</widget_type>
+      <width>75</width>
+      <wrap_words>false</wrap_words>
+      <wuid>37c8ecf8:1782120bf3e:-7ef1</wuid>
+      <x>295</x>
       <y>0</y>
     </widget>
   </widget>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_highlighted.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_highlighted.opi
@@ -198,6 +198,12 @@ $(pv_value)</tooltip>
           </exp>
           <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
         </rule>
+        <rule name="Visible" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
+        </rule>
       </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -474,10 +480,11 @@ $(pv_value)</tooltip>
       <name>Out_label</name>
       <rules>
         <rule name="Visible" prop_id="visible" out_exp="false">
-          <exp bool_exp="pv0==1">
+          <exp bool_exp="pv0==1 &amp;&amp; pv1==0">
             <value>true</value>
           </exp>
           <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):ACTION.DISP</pv>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
         </rule>
       </rules>
       <scale_options>
@@ -496,6 +503,53 @@ $(pv_value)</tooltip>
       <wrap_words>false</wrap_words>
       <wuid>3f33d901:177f440403d:-7ed8</wuid>
       <x>380</x>
+      <y>2</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color red="255" green="255" blue="255" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+      <name>Mirror_RBV</name>
+      <rules>
+        <rule name="Visible" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <text>Mirrors RBV</text>
+      <tooltip>Set point will take the value of the read back on move</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Label</widget_type>
+      <width>75</width>
+      <wrap_words>false</wrap_words>
+      <wuid>37c8ecf8:1782120bf3e:-7eb7</wuid>
+      <x>295</x>
       <y>2</y>
     </widget>
   </widget>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_with_cv.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/param_move_with_cv.opi
@@ -253,6 +253,12 @@ $(pv_value)</tooltip>
           </exp>
           <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
         </rule>
+        <rule name="Visible" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
+        </rule>
       </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
@@ -534,10 +540,11 @@ $(pv_value)</tooltip>
       <name>Out_label</name>
       <rules>
         <rule name="Visible" prop_id="visible" out_exp="false">
-          <exp bool_exp="pv0==1">
+          <exp bool_exp="pv0==1 &amp;&amp; pv1==0">
             <value>true</value>
           </exp>
           <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):ACTION.DISP</pv>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
         </rule>
       </rules>
       <scale_options>
@@ -556,6 +563,53 @@ $(pv_value)</tooltip>
       <wrap_words>false</wrap_words>
       <wuid>3f33d901:177f440403d:-7ed3</wuid>
       <x>380</x>
+      <y>0</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color red="255" green="255" blue="255" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>1</horizontal_alignment>
+      <name>Mirror_RBV</name>
+      <rules>
+        <rule name="Visible" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0==1">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(PREFIXED_PV):SP_NO_ACTION.DISP</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <text>Mirrors RBV</text>
+      <tooltip>Set point will take the value of the read back on move</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Label</widget_type>
+      <width>75</width>
+      <wrap_words>false</wrap_words>
+      <wuid>37c8ecf8:1782120bf3e:-7ec7</wuid>
+      <x>295</x>
       <y>0</y>
     </widget>
   </widget>


### PR DESCRIPTION
### Description of work

Display parameters when the sp mirrors rbv.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6273

### Acceptance criteria

For float value with and without characteristic value and emphasis:


1. rbv mirrors sp No, in beam Yes - show SP and move
2. rbv mirrors sp No, in beam No - show SP and no move button and out label
3. rbv mirrors sp Yes, in beam Yes - hide SP and move button show Mirrors RBV in place of SP 
4. rbv mirrors sp Yes, in beam No - hide SP and move button show Mirrors RBV in place of SP no out label

### Unit tests

N/A opi change

### System tests

N/A opi change

### Documentation

see ticket.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

