### PR TITLE
Add message if nicos version does not match expected version

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/ReceiveBannerMessage.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/ReceiveBannerMessage.java
@@ -20,6 +20,8 @@ package uk.ac.stfc.isis.ibex.nicos.messages;
 
 import java.util.Map;
 
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+
 /**
  * A Banner Message that has been received from NICOS. This message should be
  * the first sent and details various things about the instance of NICOS that we
@@ -40,20 +42,32 @@ public class ReceiveBannerMessage {
     private String custom_version;
 
     private static final String VALID_SERIALISER = "json";
-    private static final Integer VALID_VERSION = 15;
+    private static final Integer VALID_VERSION = 21;
 
     /**
      * @return True if the server is using the correct serializer.
      */
     public boolean serializerValid() {
-        return serializer.equals(VALID_SERIALISER);
+        var valid = serializer.equals(VALID_SERIALISER);
+        
+        if (!valid) {
+        	IsisLog.getLogger(getClass()).warn(String.format("NICOS connected to server with unexpected serialiser. Server=%s, expected=%s", serializer, VALID_SERIALISER));
+        }
+        
+        return valid;
     }
     
     /**
      * @return True if the server is using the correct protocol.
      */
     public boolean protocolValid() {
-        return protocol_version == VALID_VERSION;
+        var valid = protocol_version == VALID_VERSION;
+        
+        if (!valid) {
+        	IsisLog.getLogger(getClass()).warn(String.format("NICOS connected to server with unexpected NICOS protocol version. Server version=%d, expected=%d", protocol_version, VALID_VERSION));
+        }
+        
+        return valid;
     }
 
 }


### PR DESCRIPTION
### Description of work

Log if NICOS disconnects due to a version mismatch, rather than failing silently.

### Ticket

https://github.com/IsisComputingGroup/ibex/issues/6296

### Acceptance criteria

Message is logged if connecting to a server with mismatched nicos version

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

