### PR TITLE
Fixed open OPI script to pass through PV prefix

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/stage/openOPI.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/stage/openOPI.py
@@ -2,7 +2,13 @@ from org.csstudio.opibuilder.scriptUtil import PVUtil, ScriptUtil, DataUtil
 
 macroInput = DataUtil.createMacrosInput(True);
 axis_name_pv = widget.getPV()
-macroInput.put("MM", PVUtil.getString(axis_name_pv));		
-macroInput.put("P", "");
+motor = PVUtil.getString(axis_name_pv)
+
+#Get the pv_prefix by splitting on the 2nd colon
+second_colon = motor.find(":", motor.find(":") + 1)
+pv_prefix, motor_pv = motor[:second_colon + 1], motor[second_colon + 1:]
+
+macroInput.put("MM", motor_pv);
+macroInput.put("P", pv_prefix);
 	
 ScriptUtil.openOPI(widget, "../Motor/mymotor.opi", 0, macroInput);


### PR DESCRIPTION
### Description of work

Fixes bug where the view motors button on the motion set points opi was opening an OPI with disconnected PVs.

To test:
* On master point a GUI at LOQ and open A2 on the synoptic
* Click `view motors` on the OPI (you may need to right click on it and select actions->Execute script)
* Confirm the motor details button is shown as disconnected
* Checkout this branch and confirm that the above no longer shows disconnected

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

