### PR TITLE
Correct motion setpoints PVs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/stage/motion_setpoint.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/stage/motion_setpoint.opi
@@ -296,7 +296,7 @@ $(pv_value)</tooltip>
         <color name="ISIS_Green_LED_Off" red="0" green="102" blue="0" />
       </on_color>
       <on_label>Stationary</on_label>
-      <pv_name>$(P)$(MOTION_SET_POINT):STATIONARY</pv_name>
+      <pv_name>$(P)$(MOTION_SET_POINT):STATIONARY0</pv_name>
       <pv_value />
       <rules />
       <scale_options>
@@ -732,7 +732,7 @@ $(pv_value)</tooltip>
           <color name="ISIS_Green_LED_Off" red="0" green="102" blue="0" />
         </on_color>
         <on_label>Stationary</on_label>
-        <pv_name>$(P)$(MOTION_SET_POINT):STATIONARY2</pv_name>
+        <pv_name>$(P)$(MOTION_SET_POINT):STATIONARY1</pv_name>
         <pv_value />
         <rules />
         <scale_options>


### PR DESCRIPTION
The motion setpoints OPI stationary LEDs were pointing to the incorrect PVs showing a little pink box rather than the LED. This prompted a support call from nimrod.

### Description of work

*Add your own description here*

### Ticket

*Link to Ticket*

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

