### PR TITLE
Ticket 5616 added global parameters script generator

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ActionsTableTest.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ActionsTableTest.java
@@ -6,8 +6,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.awt.Container;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -211,12 +213,15 @@ public class ActionsTableTest {
 	}
 	
 	@Test
-	public void test_GIVEN_validity_errors_WHEN_first_error_THEN_error_is_for_globals() {
+	public void test_GIVEN_validity_errors_WHEN_first_map_THEN_error_is_for_globals() {
 		// Arrange
 		addEmptyActions(2);
-		HashMap<Integer, String> validityErrors = new HashMap<Integer, String>();
-		validityErrors.put(0, "invalid 0");
-		
+		Map<Integer, String> validityErrorsGlobal = new HashMap<Integer, String>();
+		Map<Integer, String> validityErrorsParam = Collections.<Integer, String>emptyMap();
+		validityErrorsGlobal.put(0, "invalid 0");
+		List<Map> validityErrors = new ArrayList<Map>();
+		validityErrors.add(validityErrorsGlobal);
+		validityErrors.add(validityErrorsParam);
 		// Act
 		table.setValidityErrors(validityErrors);
 		ArrayList<String> actualValidityErrors = table.getInvalidityErrorLines();

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ActionsTableTest.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ActionsTableTest.java
@@ -204,40 +204,61 @@ public class ActionsTableTest {
 		ArrayList<String> actualValidityErrors = table.getInvalidityErrorLines();
 		
 		// Assert
-		String[] arrayExpectedValidityErrors = {"Row: 2, Reason: ", "invalid 1", "Row: 4, Reason: ", "invalid 2"};
+		String[] arrayExpectedValidityErrors = {"Action Errors:", "Row: 2, Reason: ", "invalid 1", "Row: 4, Reason: ", "invalid 2"};
 		List<String> expectedValidityErrors = Arrays.asList(arrayExpectedValidityErrors);
 		assertThat("We expect validity errors to match those set into actions",
 				expectedValidityErrors, equalTo(actualValidityErrors));
 	}
 	
 	@Test
+	public void test_GIVEN_validity_errors_WHEN_first_error_THEN_error_is_for_globals() {
+		// Arrange
+		addEmptyActions(2);
+		HashMap<Integer, String> validityErrors = new HashMap<Integer, String>();
+		validityErrors.put(0, "invalid 0");
+		
+		// Act
+		table.setValidityErrors(validityErrors);
+		ArrayList<String> actualValidityErrors = table.getInvalidityErrorLines();
+		
+		// Assert
+				String[] arrayExpectedValidityErrors = {"Global Parameter Errors: \ninvalid 0"};
+				List<String> expectedValidityErrors = Arrays.asList(arrayExpectedValidityErrors);
+				assertThat("We expect validity errors to match those set into actions",
+						expectedValidityErrors, equalTo(actualValidityErrors));
+	}
+	
+	@Test
 	public void test_WHEN_setting_actions_as_invalid_THEN_correct_actions_are_invalid() {
 		// Arrange
-		addEmptyActions(4);
+		addEmptyActions(5);
 		HashMap<Integer, String> validityErrors = new HashMap<Integer, String>();
-		validityErrors.put(0, "invalid 1");
-		validityErrors.put(3, "invalid 2");
-		validityErrors.put(2, "invalid 3");
+		validityErrors.put(0, "invalid 0");
+		validityErrors.put(1, "invalid 1");
+		validityErrors.put(4, "invalid 2");
+		validityErrors.put(3, "invalid 3");
 		
 		// Act
 		table.setValidityErrors(validityErrors);
 		
 		// Assert
-		assertThat("We set 0 to invalid so should not be valid", 
+		assertThat("We set 0 to invalid, so global parameter error should be set",
+				table.getGlobalValidityErrors(), equalTo("invalid 0"));
+		assertThat("We set 1 to invalid so should not be valid", 
 				table.getActions().get(0).isValid(), is(false));
-		assertThat("We set 0 to invalid so should give same invalidity error string",
+		assertThat("We set 1 to invalid so should give same invalidity error string",
 				table.getActions().get(0).getInvalidityReason().get(), equalTo("invalid 1"));
-		assertThat("We did not set 1 to invalid so should be valid",
+		assertThat("We did not set 2 to invalid so should be valid",
 				table.getActions().get(1).isValid(), is(true));
-		assertThat("As 1 is valid should return null",
+		assertThat("As 2 is valid should return null",
 				table.getActions().get(1).getInvalidityReason(), is(Optional.empty()));
-		assertThat("We set 2 to invalid so should not be valid",
-				table.getActions().get(2).isValid(), is(false));
-		assertThat("We set 2 to invalid so should give same invalidity error string",
-				table.getActions().get(2).getInvalidityReason().get(), equalTo("invalid 3"));
 		assertThat("We set 3 to invalid so should not be valid",
-				table.getActions().get(3).isValid(), is(false));
+				table.getActions().get(2).isValid(), is(false));
 		assertThat("We set 3 to invalid so should give same invalidity error string",
+				table.getActions().get(2).getInvalidityReason().get(), equalTo("invalid 3"));
+		assertThat("We set 4 to invalid so should not be valid",
+				table.getActions().get(3).isValid(), is(false));
+		assertThat("We set 4 to invalid so should give same invalidity error string",
 				table.getActions().get(3).getInvalidityReason().get(), equalTo("invalid 2"));
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ActionsTableTest.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ActionsTableTest.java
@@ -219,7 +219,7 @@ public class ActionsTableTest {
 		Map<Integer, String> validityErrorsGlobal = new HashMap<Integer, String>();
 		Map<Integer, String> validityErrorsParam = Collections.<Integer, String>emptyMap();
 		validityErrorsGlobal.put(0, "invalid 0");
-		List<Map> validityErrors = new ArrayList<Map>();
+		List<Map<Integer, String>> validityErrors = new ArrayList<Map<Integer, String>>();
 		validityErrors.add(validityErrorsGlobal);
 		validityErrors.add(validityErrorsParam);
 		// Act
@@ -227,7 +227,7 @@ public class ActionsTableTest {
 		ArrayList<String> actualValidityErrors = table.getInvalidityErrorLines();
 		
 		// Assert
-				String[] arrayExpectedValidityErrors = {"Global Parameter Errors: \ninvalid 0"};
+				String[] arrayExpectedValidityErrors = {"Global Parameter Errors: ","Global Parameter: 1, Reason: ","invalid 0"};
 				List<String> expectedValidityErrors = Arrays.asList(arrayExpectedValidityErrors);
 				assertThat("We expect validity errors to match those set into actions",
 						expectedValidityErrors, equalTo(actualValidityErrors));
@@ -237,34 +237,39 @@ public class ActionsTableTest {
 	public void test_WHEN_setting_actions_as_invalid_THEN_correct_actions_are_invalid() {
 		// Arrange
 		addEmptyActions(5);
-		HashMap<Integer, String> validityErrors = new HashMap<Integer, String>();
-		validityErrors.put(0, "invalid 0");
-		validityErrors.put(1, "invalid 1");
-		validityErrors.put(4, "invalid 2");
-		validityErrors.put(3, "invalid 3");
+		Map<Integer, String> validityErrorsGlobal = new HashMap<Integer, String>();
+		Map<Integer, String> validityErrorsParam = new HashMap<Integer, String>();
+		List<Map<Integer, String>> validityErrors = new ArrayList<Map<Integer, String>>();
+		validityErrors.add(validityErrorsGlobal);
+		validityErrors.add(validityErrorsParam);
+		
+		validityErrors.get(0).put(0, "invalid 0");
+		validityErrors.get(1).put(1, "invalid 1");
+		validityErrors.get(1).put(4, "invalid 2");
+		validityErrors.get(1).put(3, "invalid 3");
 		
 		// Act
 		table.setValidityErrors(validityErrors);
 		
 		// Assert
-		assertThat("We set 0 to invalid, so global parameter error should be set",
-				table.getGlobalValidityErrors(), equalTo("invalid 0"));
-		assertThat("We set 1 to invalid so should not be valid", 
-				table.getActions().get(0).isValid(), is(false));
+		assertThat("We set 0 in global params to invalid, so global parameter error should be set",
+				table.getGlobalValidityErrors().get(0), equalTo("invalid 0"));
+		assertThat("We set 1 in params to invalid so should not be valid", 
+				table.getActions().get(1).isValid(), is(false));
 		assertThat("We set 1 to invalid so should give same invalidity error string",
-				table.getActions().get(0).getInvalidityReason().get(), equalTo("invalid 1"));
+				table.getActions().get(1).getInvalidityReason().get(), equalTo("invalid 1"));
 		assertThat("We did not set 2 to invalid so should be valid",
-				table.getActions().get(1).isValid(), is(true));
+				table.getActions().get(2).isValid(), is(true));
 		assertThat("As 2 is valid should return null",
-				table.getActions().get(1).getInvalidityReason(), is(Optional.empty()));
+				table.getActions().get(2).getInvalidityReason(), is(Optional.empty()));
 		assertThat("We set 3 to invalid so should not be valid",
-				table.getActions().get(2).isValid(), is(false));
-		assertThat("We set 3 to invalid so should give same invalidity error string",
-				table.getActions().get(2).getInvalidityReason().get(), equalTo("invalid 3"));
-		assertThat("We set 4 to invalid so should not be valid",
 				table.getActions().get(3).isValid(), is(false));
+		assertThat("We set 3 to invalid so should give same invalidity error string",
+				table.getActions().get(3).getInvalidityReason().get(), equalTo("invalid 3"));
+		assertThat("We set 4 to invalid so should not be valid",
+				table.getActions().get(4).isValid(), is(false));
 		assertThat("We set 4 to invalid so should give same invalidity error string",
-				table.getActions().get(3).getInvalidityReason().get(), equalTo("invalid 2"));
+				table.getActions().get(4).getInvalidityReason().get(), equalTo("invalid 2"));
 	}
 	
 	@Test

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ScriptGeneratorSingletonTest.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ScriptGeneratorSingletonTest.java
@@ -2,7 +2,9 @@ package uk.ac.stfc.isis.ibex.scriptgenerator.tests;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -22,6 +24,7 @@ import uk.ac.stfc.isis.ibex.scriptgenerator.NoScriptDefinitionSelectedException;
 import uk.ac.stfc.isis.ibex.scriptgenerator.ScriptGeneratorSingleton;
 import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ScriptDefinitionWrapper;
 import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ScriptDefinitionLoader;
+import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ActionParameter;
 import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.PythonInterface;
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ActionsTable;
 
@@ -45,7 +48,6 @@ public class ScriptGeneratorSingletonTest {
 		mockPythonInterface = mock(PythonInterface.class);
 		mockConfigLoader = mock(ScriptDefinitionLoader.class);
 		mockActionsTable = mock(ActionsTable.class);
-		model = new ScriptGeneratorSingleton(mockPythonInterface, mockConfigLoader, mockActionsTable);
 		
 		// Mock out the model to test some methods and make real calls to others
 		mockModel = mock(ScriptGeneratorSingleton.class);
@@ -53,6 +55,10 @@ public class ScriptGeneratorSingletonTest {
 		jsonLine = "{\"test:me\"}";
 		mockConfig = mock(ScriptDefinitionWrapper.class);
 		configName = "config";
+		List<ActionParameter> list = Collections.emptyList();
+		when(mockConfig.getGlobalParameters()).thenReturn(list);
+		when(mockConfigLoader.getScriptDefinition()).thenReturn(mockConfig);
+		model = new ScriptGeneratorSingleton(mockPythonInterface, mockConfigLoader, mockActionsTable);
 		
 		filepathPrefix = (System.getProperty("user.dir") + "\\test_script_gen_handler_scripts\\");
 		if(!(new File(filepathPrefix).mkdir())) {
@@ -62,6 +68,9 @@ public class ScriptGeneratorSingletonTest {
 		// Mock out some methods to test real calls to others
 		when(mockModel.getScriptDefinition()).thenReturn(Optional.of(mockConfig));
 		when(mockConfig.getName()).thenReturn(configName);
+		
+		
+		mockConfig.getGlobalParameters();
 		try {
 			when(mockModel.generateScriptFileName()).thenCallRealMethod();
 		} catch (NoScriptDefinitionSelectedException e) {

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
@@ -135,7 +135,7 @@ class ScriptDefinitionWrapper(object):
         """
         return self.script_definition.run(**action)
 
-    def globalParamsValid(self, global_params) -> Union[None, AnyStr]:
+    def globalParamsValid(self, global_param, index) -> Union[None, AnyStr]:
         """
         checks if global params are valid for the script definition
 
@@ -145,15 +145,8 @@ class ScriptDefinitionWrapper(object):
         Returns:
             None if all params are valid.
         """
-        logger = logging.getLogger("py4j")
-        logger.setLevel(logging.ERROR)
-        logger.addHandler(logging.StreamHandler())
-
         try:
-            for param in global_params:
-                logging.error(param)
-                logging.error(self.script_definition.global_params_definition[param])
-                self.script_definition.global_params_definition[param][1](param)
+            list(self.script_definition.global_params_definition.values())[index][1](global_param)
             return
         except Exception as e:
             return str(e)
@@ -230,9 +223,11 @@ class Generator(object):
         for action in list_of_actions:
             if script_definition.parametersValid(action) != None:
                 return False
-
-        if script_definition.globalParamsValid(global_params) !=None:
-            return False
+        i = 0
+        for global_param in global_params:
+            if script_definition.globalParamsValid(global_param, i) !=None:
+                return False
+            i += 1
         return True
 
     def getValidityErrors(self, list_of_actions, script_definition: ScriptDefinitionWrapper) -> Dict[int, AnyStr]:

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
@@ -182,8 +182,10 @@ class ScriptDefinitionWrapper(object):
             or None if the parameters are invalid or the estimate could not be calculated
         """
         try:
-            self.script_definition.global_params = dict(zip(self.script_definition.global_params_definition.keys(),
-                                                            globalparams))
+            if self.script_definition.global_params_definition is not None:
+                self.script_definition.global_params = dict(zip(self.script_definition.global_params_definition.keys(),
+                                                                globalparams))
+
             estimate = self.script_definition.estimate_time(**action)
             return round(estimate)
         except (ValueError, TypeError, KeyError) as ex:
@@ -240,7 +242,7 @@ class Generator(object):
         Get a map of validity errors
 
         Returns:
-            Dictionary containing keys of the line numbers where errors are and values of the error messages.
+            List of dictionaries containing keys of the line numbers where errors are and values of the error messages.
         """
         current_action_index = 0
         param_type_index = 0
@@ -298,7 +300,7 @@ class Generator(object):
                 rendered_template = self.template.render(inserted_script_definition=script_definition_template,
                                                          script_generator_actions=list_of_actions,
                                                          global_params=global_params, hexed_value=val)
-            except Exception:
+            except Exception as e:
                 rendered_template = None
             return rendered_template
         else:

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
@@ -105,13 +105,15 @@ class ScriptDefinitionWrapper(object):
         Returns:
             arguments: List of the parameter names (strings)
         """
-        arguments = self.script_definition.global_params_definition
         list_of_globals = []
-        for arg in arguments:
-            name = arg
-            default = arguments[arg][0]
-            action_parameter = PythonActionParameter(name, default, False)
-            list_of_globals.append(action_parameter)
+        if hasattr(self.script_definition, "global_params_definition"):
+            arguments = self.script_definition.global_params_definition
+            for arg in arguments:
+                name = arg
+                default = arguments[arg][0]
+                action_parameter = PythonActionParameter(name, default, False)
+                list_of_globals.append(action_parameter)
+
         return ListConverter().convert(list_of_globals, gateway._gateway_client)
 
     def getHelp(self) -> str:
@@ -143,7 +145,7 @@ class ScriptDefinitionWrapper(object):
         Returns:
             None if all params are valid.
         """
-        if self.script_definition.global_params_definition is None:
+        if not hasattr(self.script_definition, "global_params_definition"):
             return
         try:
             list(self.script_definition.global_params_definition.values())[index][1](global_param)
@@ -180,7 +182,7 @@ class ScriptDefinitionWrapper(object):
             or None if the parameters are invalid or the estimate could not be calculated
         """
         try:
-            if self.script_definition.global_params_definition is not None:
+            if hasattr(self.script_definition, "global_params_definition"):
                 self.script_definition.global_params = dict(zip(self.script_definition.global_params_definition.keys(),
                                                                 globalparams))
             estimate = self.script_definition.estimate_time(**action)

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
@@ -15,8 +15,6 @@ from genie_python import utilities
 import importlib.machinery
 import importlib.util
 
-import logging
-
 
 class PythonActionParameter(object):
     """
@@ -185,7 +183,6 @@ class ScriptDefinitionWrapper(object):
             if self.script_definition.global_params_definition is not None:
                 self.script_definition.global_params = dict(zip(self.script_definition.global_params_definition.keys(),
                                                                 globalparams))
-
             estimate = self.script_definition.estimate_time(**action)
             return round(estimate)
         except (ValueError, TypeError, KeyError) as ex:

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
@@ -148,8 +148,10 @@ class ScriptDefinitionWrapper(object):
         try:
             list(self.script_definition.global_params_definition.values())[index][1](global_param)
             return
-        except Exception as e:
-            return str(e)
+        except Exception:
+            return 'Expected type: "{}" for global: "{}", but recieved: "{}"\n'.format(
+                str(list(self.script_definition.global_params_definition.values())[index][1])[8:-2],
+                list(self.script_definition.global_params_definition.keys())[index], global_param)
 
     def parametersValid(self, action) -> Union[None, AnyStr]:
         """
@@ -225,12 +227,13 @@ class Generator(object):
                 return False
         i = 0
         for global_param in global_params:
-            if script_definition.globalParamsValid(global_param, i) !=None:
+            if script_definition.globalParamsValid(global_param, i) != None:
                 return False
             i += 1
         return True
 
-    def getValidityErrors(self, global_params, list_of_actions, script_definition: ScriptDefinitionWrapper) -> Dict[int, AnyStr]:
+    def getValidityErrors(self, global_params, list_of_actions, script_definition: ScriptDefinitionWrapper) -> Dict[
+        int, AnyStr]:
         """
         Get a map of validity errors
 
@@ -255,7 +258,8 @@ class Generator(object):
             current_action_index += 1
         return validityCheck
 
-    def estimateTime(self, list_of_actions, script_definition: ScriptDefinitionWrapper, global_params) -> Dict[int, int]:
+    def estimateTime(self, list_of_actions, script_definition: ScriptDefinitionWrapper, global_params) -> Dict[
+        int, int]:
         """
         Estimates the time necessary to complete each action.
         Actions are only estimated if their parameters are valid.
@@ -389,7 +393,7 @@ class ScriptDefinitionsWrapper(object):
         python_list_of_actions: List = ListConverter().convert(list_of_actions, gateway._gateway_client)
         return [MapConverter().convert(action, gateway._gateway_client) for action in python_list_of_actions]
 
-    def areParamsValid(self, list_of_actions, global_params,script_definition: ScriptDefinitionWrapper) -> bool:
+    def areParamsValid(self, list_of_actions, global_params, script_definition: ScriptDefinitionWrapper) -> bool:
         """
         Checks if a list of parameters are valid for the script_definition
 
@@ -408,10 +412,12 @@ class ScriptDefinitionsWrapper(object):
             Dictionary containing keys of the line numbers where errors are and values of the error messages.
         """
         return MapConverter().convert(self.generator.getValidityErrors(global_params,
-            self.convert_list_of_actions_to_python(list_of_actions), script_definition),
-            gateway._gateway_client)
+                                                                       self.convert_list_of_actions_to_python(
+                                                                           list_of_actions), script_definition),
+                                      gateway._gateway_client)
 
-    def estimateTime(self, list_of_actions, script_definition: ScriptDefinitionWrapper, global_parameters) -> Dict[int, int]:
+    def estimateTime(self, list_of_actions, script_definition: ScriptDefinitionWrapper, global_parameters) -> Dict[
+        int, int]:
         """
         Get the estimated time to complete the current actions
 

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
@@ -145,11 +145,13 @@ class ScriptDefinitionWrapper(object):
         Returns:
             None if all params are valid.
         """
+        if self.script_definition.global_params_definition is None:
+            return
         try:
             list(self.script_definition.global_params_definition.values())[index][1](global_param)
             return
-        except Exception:
-            return 'Expected type: "{}" for global: "{}", but recieved: "{}"\n'.format(
+        except (TypeError, ValueError):
+            return 'Expected type: "{}" for global: "{}" but recieved: "{}"\n'.format(
                 str(list(self.script_definition.global_params_definition.values())[index][1])[8:-2],
                 list(self.script_definition.global_params_definition.keys())[index], global_param)
 

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/script_definition_loader.py
@@ -151,7 +151,7 @@ class ScriptDefinitionWrapper(object):
             list(self.script_definition.global_params_definition.values())[index][1](global_param)
             return
         except (TypeError, ValueError):
-            return 'Expected type: "{}" for global: "{}" but recieved: "{}"\n'.format(
+            return 'Expected type: "{}" for global: "{}" but received: "{}"\n'.format(
                 str(list(self.script_definition.global_params_definition.values())[index][1])[8:-2],
                 list(self.script_definition.global_params_definition.keys())[index], global_param)
 

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/templates/generator_template.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/templates/generator_template.py
@@ -4,7 +4,8 @@
 
 def runscript():
     script_definition = DoRun()
-    script_definition.global_params = dict(zip(script_definition.global_params_definition.keys(), {{ global_params }}))
+    if hasattr(script_definition, "global_params_definition"):
+        script_definition.global_params = dict(zip(script_definition.global_params_definition.keys(), {{ global_params }}))
     {% for action in script_generator_actions -%}
     script_definition.run(**{{ action }})
     {% endfor %}

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/templates/generator_template.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/templates/generator_template.py
@@ -4,6 +4,7 @@
 
 def runscript():
     script_definition = DoRun()
+    script_definition.global_params = dict(zip(script_definition.global_params_definition.keys(), {{ global_params }}))
     {% for action in script_generator_actions -%}
     script_definition.run(**{{ action }})
     {% endfor %}

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_generator.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_generator.py
@@ -26,7 +26,7 @@ class TestGenerator(unittest.TestCase):
         # Arrange
         mock_script_definition: ScriptDefinitionWrapper = MagicMock()
         mock_script_definition.parametersValid.return_value = "invalid reason"
-        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors({}, [
+        validityCheck: List[Dict[int, AnyStr]] = self.generator.getValidityErrors({}, [
             {"param1": "param1Val", "param2": "param2Val"},
             {"param1": "param1Val", "param2": "param2Val"}
         ], mock_script_definition)
@@ -40,7 +40,7 @@ class TestGenerator(unittest.TestCase):
         mock_script_definition: ScriptDefinitionWrapper = MagicMock()
         mock_script_definition.parametersValid.return_value = "invalid reason"
         mock_script_definition.globalParamsValid.return_value = "invalid reason"
-        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors({"global1": "global1Val"}, [
+        validityCheck: List[Dict[int, AnyStr]] = self.generator.getValidityErrors({"global1": "global1Val"}, [
             {"param1": "param1Val", "param2": "param2Val"},
             {"param1": "param1Val", "param2": "param2Val"}
         ], mock_script_definition)
@@ -52,7 +52,7 @@ class TestGenerator(unittest.TestCase):
         # Arrange
         mock_script_definition: ScriptDefinitionWrapper = MagicMock()
         mock_script_definition.parametersValid.return_value = None
-        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors({}, [
+        validityCheck: List[Dict[int, AnyStr]] = self.generator.getValidityErrors({}, [
             {"param1": "param1Val", "param2": "param2Val"},
             {"param1": "param1Val", "param2": "param2Val"}
         ], mock_script_definition)
@@ -63,8 +63,8 @@ class TestGenerator(unittest.TestCase):
         # Arrange
         mock_script_definition: ScriptDefinitionWrapper = MagicMock()
         mock_script_definition.globalParamsValid.return_value = None
-        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors(
-            {"param1": "param1Val", "param2": "param2Val", "param1": "param1Val", "param2": "param2Val"}, [],
+        validityCheck: List[Dict[int, AnyStr]] = self.generator.getValidityErrors(
+            {"param1": "param1Val", "param2": "param2Val"}, [],
             mock_script_definition)
         # Act and Assert
         assert_that(validityCheck, equal_to([{}, {}]), "2 globals, both valid")
@@ -81,7 +81,7 @@ class TestGenerator(unittest.TestCase):
         # Arrange
         mock_script_definition: ScriptDefinitionWrapper = MagicMock()
         mock_script_definition.parametersValid.side_effect = self.params_valid_side_effect
-        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors({}, [
+        validityCheck: List[Dict[int, AnyStr]] = self.generator.getValidityErrors({}, [
             {"param1": "param1Val"}, {"param2": "param2Val"}
         ], mock_script_definition)
         # Act and Assert

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_generator.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_generator.py
@@ -7,40 +7,66 @@ from hamcrest.library.text import matches_regexp
 from test_script_definitions.valid_script_definition import DoRun as ValidDoRun
 from pprint import pprint
 
+
 class TestGenerator(unittest.TestCase):
 
     def _get_estimates_for_single_action(self, scriptDefinition):
         wrapper = ScriptDefinitionWrapper("test", scriptDefinition)
         estimates: Dict[int, int] = self.generator.estimateTime([
             {"param1": "param1Val", "param2": "param2Val"}
-        ], wrapper)
+        ], wrapper, {})
         return estimates
 
     def setUp(self):
         self.generator: Generator = Generator(repo_path="test_script_definitions")
 
-    def test_GIVEN_script_definitions_return_invalid_WHEN_get_generator_invalidity_reasons_THEN_context_as_expected(self):
+    def test_GIVEN_script_definitions_return_invalid_WHEN_get_generator_invalidity_reasons_THEN_context_as_expected(
+            self):
         # Arrange
         mock_script_definition: ScriptDefinitionWrapper = MagicMock()
         mock_script_definition.parametersValid.return_value = "invalid reason"
-        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors([
-            {"param1": "param1Val", "param2": "param2Val"}, 
+        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors({}, [
+            {"param1": "param1Val", "param2": "param2Val"},
             {"param1": "param1Val", "param2": "param2Val"}
         ], mock_script_definition)
         # Act and Assert
-        assert_that(validityCheck, equal_to({0: "invalid reason", 1: "invalid reason"}), 
-        "2 actions, both invalid with reason")
+        assert_that(validityCheck, equal_to([{}, {0: "invalid reason", 1: "invalid reason"}]),
+                    "2 actions, both invalid with reason")
+
+    def test_GIVEN_script_definitions_return_invalid_WHEN_get_generator_invalidity_reasons_with_global_THEN_context_as_expected(
+            self):
+        # Arrange
+        mock_script_definition: ScriptDefinitionWrapper = MagicMock()
+        mock_script_definition.parametersValid.return_value = "invalid reason"
+        mock_script_definition.globalParamsValid.return_value = "invalid reason"
+        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors({"global1": "global1Val"}, [
+            {"param1": "param1Val", "param2": "param2Val"},
+            {"param1": "param1Val", "param2": "param2Val"}
+        ], mock_script_definition)
+        # Act and Assert
+        assert_that(validityCheck, equal_to([{0: 'invalid reason'}, {0: "invalid reason", 1: "invalid reason"}]),
+                    "1 global, 2 actions, all invalid with reason")
 
     def test_GIVEN_script_definition_return_valid_WHEN_get_generator_invalidity_reasons_THEN_no_content(self):
         # Arrange
         mock_script_definition: ScriptDefinitionWrapper = MagicMock()
         mock_script_definition.parametersValid.return_value = None
-        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors([
-            {"param1": "param1Val", "param2": "param2Val"}, 
+        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors({}, [
+            {"param1": "param1Val", "param2": "param2Val"},
             {"param1": "param1Val", "param2": "param2Val"}
         ], mock_script_definition)
         # Act and Assert
-        assert_that(validityCheck, equal_to({}), "2 actions, both invalid with reason")
+        assert_that(validityCheck, equal_to([{}, {}]), "2 actions, both valid")
+
+    def test_GIVEN_script_definition_return_valid_WHEN_get_generator_global_invalidity_reasons_THEN_no_content(self):
+        # Arrange
+        mock_script_definition: ScriptDefinitionWrapper = MagicMock()
+        mock_script_definition.globalParamsValid.return_value = None
+        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors(
+            {"param1": "param1Val", "param2": "param2Val", "param1": "param1Val", "param2": "param2Val"}, [],
+            mock_script_definition)
+        # Act and Assert
+        assert_that(validityCheck, equal_to([{}, {}]), "2 globals, both valid")
 
     # Allows us to return whether invalid or not based on passed vals
     def params_valid_side_effect(self, params) -> AnyStr:
@@ -49,15 +75,16 @@ class TestGenerator(unittest.TestCase):
         else:
             return "invalid"
 
-    def test_GIVEN_script_definition_return_valid_and_invalid_WHEN_get_generator_invalidity_reasons_THEN_content_as_expected(self):
+    def test_GIVEN_script_definition_return_valid_and_invalid_WHEN_get_generator_invalidity_reasons_THEN_content_as_expected(
+            self):
         # Arrange
         mock_script_definition: ScriptDefinitionWrapper = MagicMock()
         mock_script_definition.parametersValid.side_effect = self.params_valid_side_effect
-        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors([
+        validityCheck: Dict[int, AnyStr] = self.generator.getValidityErrors({}, [
             {"param1": "param1Val"}, {"param2": "param2Val"}
         ], mock_script_definition)
         # Act and Assert
-        assert_that(validityCheck, equal_to({1: "invalid"}), "2 actions, one invalid with reason")
+        assert_that(validityCheck, equal_to([{}, {1: "invalid"}]), "2 actions, one invalid with reason")
 
     def test_GIVEN_valid_parameters_and_int_estimate_WHEN_estimate_time_THEN_return_estimate(self):
         # Arrange
@@ -108,7 +135,7 @@ class TestGenerator(unittest.TestCase):
 
         # Act and Assert
         assert_that(estimates, equal_to({}))
-    
+
     def test_GIVEN_valid_script_definition_WHEN_generate_THEN_new_script_is_as_expected(self):
         # Arrange
         expected_script_lines: List[AnyStr] = \
@@ -154,26 +181,27 @@ def runscript():
 
 value = b'789c030000000001'""".split("\n")
         params = [{"param1": "1", "param2": "2"}, {"param1": "1", "param2": "2"}]
-        script_definition: ScriptDefinitionWrapper = ScriptDefinitionWrapper(name="valid_script_definition", script_definition=ValidDoRun())
+        script_definition: ScriptDefinitionWrapper = ScriptDefinitionWrapper(name="valid_script_definition",
+                                                                             script_definition=ValidDoRun())
         # Act
-        generated_script: str = self.generator.generate(params, "", script_definition)
+        generated_script: str = self.generator.generate(params, "", {}, script_definition)
         # Assert
         self.assertIsNotNone(generated_script, "ScriptDefinitionWrapper is valid, so should not return None")
 
         generated_lines = generated_script.split("\n")
-        assert_that(len(generated_lines), equal_to(len(expected_script_lines)), 
-            "Should have the same amount of lines if they match")
+        assert_that(len(generated_lines), equal_to(len(expected_script_lines)),
+                    "Should have the same amount of lines if they match")
 
         for i in range(len(generated_lines)):
-            assert_that(generated_lines[i], equal_to(expected_script_lines[i]), 
-                "Each line of the generated script should match the expected line")
-    
+            assert_that(generated_lines[i], equal_to(expected_script_lines[i]),
+                        "Each line of the generated script should match the expected line")
+
     def test_GIVEN_invalid_script_definition_params_WHEN_generate_THEN_return_none(self):
         # Arrange
         params = [{"param1": "invalid", "param2": "2"}, {"param1": "1", "param2": "2"}]
-        script_definition: ScriptDefinitionWrapper = ScriptDefinitionWrapper(name="valid_script_definition", script_definition=ValidDoRun())
+        script_definition: ScriptDefinitionWrapper = ScriptDefinitionWrapper(name="valid_script_definition",
+                                                                             script_definition=ValidDoRun())
         # Act
-        generated_script: str = self.generator.generate(params, "", script_definition)
+        generated_script: str = self.generator.generate(params, "", {}, script_definition)
         # Assert
         self.assertIsNone(generated_script, "ScriptDefinitionWrapper is invalid, so should return None")
-

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_generator.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_generator.py
@@ -6,6 +6,7 @@ from hamcrest.core import assert_that, equal_to
 from hamcrest.library.text import matches_regexp
 from test_script_definitions.valid_script_definition import DoRun as ValidDoRun
 from pprint import pprint
+import pathlib
 
 
 class TestGenerator(unittest.TestCase):
@@ -174,6 +175,8 @@ class DoRun(ScriptDefinition):
 
 def runscript():
     script_definition = DoRun()
+    if hasattr(script_definition, "global_params_definition"):
+        script_definition.global_params = dict(zip(script_definition.global_params_definition.keys(), {}))
     script_definition.run(**{'param1': '1', 'param2': '2'})
     script_definition.run(**{'param1': '1', 'param2': '2'})
     

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -509,6 +509,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 		}
 		try {
 			refreshParameterValidityChecking();
+			refreshTimeEstimation();
 		}catch(NoScriptDefinitionSelectedException e) {
 			return;
 		}

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -79,6 +79,8 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	 * The table containing the script generator contents (actions).
 	 */
 	private ActionsTable scriptGeneratorTable = new ActionsTable(new ArrayList<JavaActionParameter>());
+	
+	private List<String> globalParams;
 
 	/**
 	 * The loader to select and update the script definition being used.
@@ -194,7 +196,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	 * The constructor, will create without a script definition loader and without loading
 	 * an initial script definition.
 	 */
-	public ScriptGeneratorSingleton() {   
+	public ScriptGeneratorSingleton() {  
 	}
 
 	/**
@@ -450,6 +452,21 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	public void moveActionDown(List<ScriptGeneratorAction> actionsToMove) {
 		scriptGeneratorTable.moveActionDown(actionsToMove);
 	}
+	
+	public void updateGlobalParams(String params, int index) {
+		if(this.globalParams != null) {
+			
+			if(this.globalParams.size()>index) {
+				this.globalParams.set(index, params);			
+			}else {
+				this.globalParams.add(params);
+			}
+			
+		}else {
+			this.globalParams = new ArrayList<String>();
+			this.globalParams.add(params);
+		}
+	}
 
 	/**
 	 * Get the list of actions in the ActionsTable.
@@ -554,7 +571,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 				.orElseThrow(() -> new NoScriptDefinitionSelectedException(
 						"Tried to refresh parameter validity with no script definition selected"));
 		try {
-			generator.refreshAreParamsValid(scriptGeneratorTable, scriptDefinition);
+			generator.refreshAreParamsValid(scriptGeneratorTable, scriptDefinition, this.globalParams);
 			generator.refreshValidityErrors(scriptGeneratorTable, scriptDefinition);
 			languageSupported = true;
 			threadError = false;
@@ -614,7 +631,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 			if (areParamsValid()) {
 				Path filePath = getScriptDefinitionPath(scriptDefinition);
 				String jsonContent = scriptGenFileHandler.createJsonString(scriptGeneratorTable.getActions(), scriptGenFileHandler.readFileContent(filePath), filePath);
-				return generator.refreshGeneratedScript(scriptGeneratorTable, scriptDefinition, jsonContent);
+				return generator.refreshGeneratedScript(scriptGeneratorTable, scriptDefinition, jsonContent, this.globalParams);
 			} else {
 				throw new InvalidParamsException("Parameters are invalid, cannot generate script");
 			}

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -236,7 +236,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 		// If the validity error message property of the generator is changed update the
 		// validity errors in the scriptGeneratorTable
 		generator.addPropertyChangeListener(VALIDITY_ERROR_MESSAGE_PROPERTY, evt -> {
-			scriptGeneratorTable.setValidityErrors(convertToMap(evt.getNewValue(), Integer.class, String.class));
+			scriptGeneratorTable.setValidityErrors(convertToListMap(evt.getNewValue()));
 			firePropertyChange(VALIDITY_ERROR_MESSAGE_PROPERTY, evt.getOldValue(), evt.getNewValue());
 		});
         // If the time estimation message property of the generator is changed update the
@@ -372,6 +372,29 @@ public class ScriptGeneratorSingleton extends ModelObject {
 			return new HashMap<T, S>();
 		}
 	}
+	
+	/**
+	 * Convert the VALIDITY_ERROR_MESSAGE_PROPERTY return to the list<Map<Integer,
+	 * String>> representation. Required because of casting generics in Java.
+	 * 
+	 * @param validityMessages The validity messages to convert.
+	 * @return The converted messages property.
+	 */
+	@SuppressWarnings("rawtypes")
+	private static List<Map<Integer, String>> convertToListMap(Object validityMessages) {
+		try {
+			List listCastValidityMessages = List.class.cast(validityMessages);
+			List<Map<Integer, String>> castValidityMessages = new ArrayList<Map<Integer, String>>();
+			for (Object nonCastEntry : listCastValidityMessages) {
+				Map<Integer, String> castEntry = convertToMap(nonCastEntry, Integer.class, String.class);
+				castValidityMessages.add(castEntry);
+			}
+			return castValidityMessages;
+		} catch (ClassCastException e) {
+			LOG.error(e);
+			return new ArrayList<Map<Integer, String>>();
+		}
+	}
 
 	/**
 	 * Get the python interface.
@@ -492,6 +515,15 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	 */
 	public List<ScriptGeneratorAction> getActions() {
 		return scriptGeneratorTable.getActions();
+	}
+	
+	/**
+	 * Get the map of global parameter errors.
+	 * 
+	 * @return map of global parameter errors in the table.
+	 */
+	public Map<Integer, String> getGlobalParamErrors() {
+		return scriptGeneratorTable.getGlobalValidityErrors();
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -478,6 +478,11 @@ public class ScriptGeneratorSingleton extends ModelObject {
 			this.globalParams = new ArrayList<String>();
 			this.globalParams.add(params);
 		}
+		try {
+			refreshParameterValidityChecking();
+		}catch(NoScriptDefinitionSelectedException e) {
+			return;
+		}
 	}
 
 	/**
@@ -584,7 +589,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 						"Tried to refresh parameter validity with no script definition selected"));
 		try {
 			generator.refreshAreParamsValid(scriptGeneratorTable, scriptDefinition, this.globalParams);
-			generator.refreshValidityErrors(scriptGeneratorTable, scriptDefinition);
+			generator.refreshValidityErrors(this.globalParams ,scriptGeneratorTable, scriptDefinition);
 			languageSupported = true;
 			threadError = false;
 		} catch (UnsupportedLanguageException e) {

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -288,7 +288,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 
 		setActionParameters(scriptDefinitionLoader.getParameters());
 		try {
-			List<ActionParameter> globals =this.scriptDefinitionLoader.getScriptDefinition().getGlobalParameters();
+			List<ActionParameter> globals = this.scriptDefinitionLoader.getScriptDefinition().getGlobalParameters();
 			for(ActionParameter global:globals) {
 				this.globalParams.add(global.getDefaultValue());
 			}

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -488,6 +488,12 @@ public class ScriptGeneratorSingleton extends ModelObject {
 		scriptGeneratorTable.moveActionDown(actionsToMove);
 	}
 	
+	/**
+	 * Updates the globalParams 
+	 * @param params The new value for the parameter
+	 * @param index The global parameter to be update
+	 */
+	
 	public void updateGlobalParams(String params, int index) {
 		if(this.globalParams != null) {
 			
@@ -506,6 +512,10 @@ public class ScriptGeneratorSingleton extends ModelObject {
 		}catch(NoScriptDefinitionSelectedException e) {
 			return;
 		}
+	}
+	
+	public void clearGlobalParams() {
+		this.globalParams.clear();
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/AbstractGenerator.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/AbstractGenerator.java
@@ -81,7 +81,7 @@ public abstract class AbstractGenerator extends ModelObject {
 	 * @throws ExecutionException A failure to execute the call to generate a script
 	 * @throws InterruptedException The call to generate a script was interrupted
 	 */
-	public abstract void refreshValidityErrors(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition) throws InterruptedException, ExecutionException;
+	public abstract void refreshValidityErrors(List<String> globalParams, List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition) throws InterruptedException, ExecutionException;
     
     /**
      * Refresh the time estimation of the specified actions (Map<Integer,Double>).

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/AbstractGenerator.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/AbstractGenerator.java
@@ -91,7 +91,7 @@ public abstract class AbstractGenerator extends ModelObject {
      * @throws ExecutionException A failure to execute the call to generate a script
      * @throws InterruptedException The call to generate a script was interrupted
      */
-    public abstract void refreshTimeEstimation(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition) throws InterruptedException, ExecutionException;
+    public abstract void refreshTimeEstimation(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition, List<String> globalParams) throws InterruptedException, ExecutionException;
 
     /**
      * Get the generated script from the given ID.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/AbstractGenerator.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/AbstractGenerator.java
@@ -61,7 +61,7 @@ public abstract class AbstractGenerator extends ModelObject {
 	 * @throws InterruptedException The call to generate a script was interrupted
 	 * @return An ID for the generated script.
 	 */
-	public abstract Optional<Integer> refreshGeneratedScript(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition, String currentlyLoadedDataFileContent) throws InterruptedException, ExecutionException;
+	public abstract Optional<Integer> refreshGeneratedScript(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition, String currentlyLoadedDataFileContent, List<String> globalParams) throws InterruptedException, ExecutionException;
 	
 	/**
 	 * Refresh the property of whether the contents of the script generator (actionsTable) are valid (bool).
@@ -71,7 +71,7 @@ public abstract class AbstractGenerator extends ModelObject {
 	 * @throws ExecutionException A failure to execute the call to generate a script
 	 * @throws InterruptedException The call to generate a script was interrupted
 	 */
-	public abstract void refreshAreParamsValid(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition) throws InterruptedException, ExecutionException;
+	public abstract void refreshAreParamsValid(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition, List<String> globalParams) throws InterruptedException, ExecutionException;
 	
 	/**
 	 * Refresh the validity errors returned when checking validity (Map<Integer,String>).

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorContext.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorContext.java
@@ -171,10 +171,10 @@ public class GeneratorContext extends ModelObject {
      * @throws ExecutionException A failure to execute the call to generate.
      * @throws InterruptedException The call to generate was interrupted.
      */
-    public void refreshTimeEstimation(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, GeneratedLanguage generatedLanguage)
+    public void refreshTimeEstimation(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, GeneratedLanguage generatedLanguage, List<String> globalParams)
             throws UnsupportedLanguageException, InterruptedException, ExecutionException {
         AbstractGenerator generator = getGenerator(generatedLanguage);
-        generator.refreshTimeEstimation(actionsTable.getActions(), scriptDefinition);
+        generator.refreshTimeEstimation(actionsTable.getActions(), scriptDefinition, globalParams);
     }
     
     /**
@@ -187,9 +187,9 @@ public class GeneratorContext extends ModelObject {
      * @throws ExecutionException A failure to execute the call to generate.
      * @throws InterruptedException The call to generate was interrupted.
      */
-    public void refreshTimeEstimation(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition)
+    public void refreshTimeEstimation(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition,List<String> globalParams)
             throws UnsupportedLanguageException, InterruptedException, ExecutionException {
-        refreshTimeEstimation(actionsTable, scriptDefinition, GeneratedLanguage.PYTHON);
+        refreshTimeEstimation(actionsTable, scriptDefinition, GeneratedLanguage.PYTHON, globalParams);
     }
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorContext.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorContext.java
@@ -202,10 +202,10 @@ public class GeneratorContext extends ModelObject {
 	 * @throws ExecutionException A failure to execute the call to generate.
 	 * @throws InterruptedException The call to generate was interrupted.
 	 */
-	public void refreshValidityErrors(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, GeneratedLanguage generatedLanguage) 
+	public void refreshValidityErrors(List<String> globalParams, ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, GeneratedLanguage generatedLanguage) 
 			throws UnsupportedLanguageException, InterruptedException, ExecutionException {
 		AbstractGenerator generator = getGenerator(generatedLanguage);
-		generator.refreshValidityErrors(actionsTable.getActions(), scriptDefinition);
+		generator.refreshValidityErrors(globalParams, actionsTable.getActions(), scriptDefinition);
 	}
 
 	/**
@@ -217,9 +217,9 @@ public class GeneratorContext extends ModelObject {
 	 * @throws ExecutionException A failure to execute the call to generate.
 	 * @throws InterruptedException The call to generate was interrupted.
 	 */
-	public void refreshValidityErrors(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition) 
+	public void refreshValidityErrors(List<String> globalParams, ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition) 
 			throws UnsupportedLanguageException, InterruptedException, ExecutionException {
-		refreshValidityErrors(actionsTable, scriptDefinition, GeneratedLanguage.PYTHON);
+		refreshValidityErrors(globalParams, actionsTable, scriptDefinition, GeneratedLanguage.PYTHON);
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorContext.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorContext.java
@@ -1,6 +1,7 @@
 package uk.ac.stfc.isis.ibex.scriptgenerator.generation;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -106,10 +107,10 @@ public class GeneratorContext extends ModelObject {
 	 * @throws ExecutionException A failure to execute the call to generate.
 	 * @throws InterruptedException The call to generate was interrupted.
 	 */
-	public Optional<Integer> refreshGeneratedScript(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, GeneratedLanguage generatedLanguage, String jsonContent)
+	public Optional<Integer> refreshGeneratedScript(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, GeneratedLanguage generatedLanguage, String jsonContent, List<String> globalParams)
 			throws UnsupportedLanguageException, InterruptedException, ExecutionException {
 		AbstractGenerator generator = getGenerator(generatedLanguage);
-		return generator.refreshGeneratedScript(actionsTable.getActions(), scriptDefinition, jsonContent);
+		return generator.refreshGeneratedScript(actionsTable.getActions(), scriptDefinition, jsonContent, globalParams);
 	}
 	
 	/**
@@ -123,9 +124,9 @@ public class GeneratorContext extends ModelObject {
 	 * @throws InterruptedException The call to generate was interrupted.
 	 * @return An ID for the generated script.
 	 */
-	public Optional<Integer> refreshGeneratedScript(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, String jsonContent) 
+	public Optional<Integer> refreshGeneratedScript(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, String jsonContent, List<String> globalParams) 
 			throws UnsupportedLanguageException, InterruptedException, ExecutionException {
-		return refreshGeneratedScript(actionsTable, scriptDefinition, GeneratedLanguage.PYTHON, jsonContent);
+		return refreshGeneratedScript(actionsTable, scriptDefinition, GeneratedLanguage.PYTHON, jsonContent, globalParams);
 	}
 	
 	/**
@@ -139,10 +140,10 @@ public class GeneratorContext extends ModelObject {
 	 * @throws ExecutionException A failure to execute the call to generate.
 	 * @throws InterruptedException The call to generate was interrupted.
 	 */
-	public void refreshAreParamsValid(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, GeneratedLanguage generatedLanguage) 
+	public void refreshAreParamsValid(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, GeneratedLanguage generatedLanguage, List<String> globalParams) 
 			throws UnsupportedLanguageException, InterruptedException, ExecutionException {
 		AbstractGenerator generator = getGenerator(generatedLanguage);
-		generator.refreshAreParamsValid(actionsTable.getActions(), scriptDefinition);
+		generator.refreshAreParamsValid(actionsTable.getActions(), scriptDefinition, globalParams);
 	}
 	
 	/**
@@ -155,9 +156,9 @@ public class GeneratorContext extends ModelObject {
 	 * @throws ExecutionException A failure to execute the call to generate.
 	 * @throws InterruptedException The call to generate was interrupted.
 	 */
-	public void refreshAreParamsValid(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition) 
+	public void refreshAreParamsValid(ActionsTable actionsTable, ScriptDefinitionWrapper scriptDefinition, List<String> globalParams) 
 			throws UnsupportedLanguageException, InterruptedException, ExecutionException {
-		refreshAreParamsValid(actionsTable, scriptDefinition, GeneratedLanguage.PYTHON);
+		refreshAreParamsValid(actionsTable, scriptDefinition, GeneratedLanguage.PYTHON, globalParams);
 	}
 	
     /**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorPython.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorPython.java
@@ -56,9 +56,9 @@ public class GeneratorPython extends AbstractGenerator {
 	 * @throws ExecutionException A failure to execute the py4j call.
 	 * @throws InterruptedException The Py4J call was interrupted.
 	 */
-	public void refreshAreParamsValid(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition) throws InterruptedException, ExecutionException {
+	public void refreshAreParamsValid(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition, List<String> globalParams) throws InterruptedException, ExecutionException {
 		try {	
-			pythonInterface.refreshAreParamsValid(scriptGenContent, scriptDefinition);
+			pythonInterface.refreshAreParamsValid(scriptGenContent, globalParams, scriptDefinition);
 		} catch (PythonNotReadyException e) {
 			// ScriptGeneratorSingleton is listening to python interface readiness changes (handled there)
 			LOG.error(e);
@@ -95,9 +95,9 @@ public class GeneratorPython extends AbstractGenerator {
 
 	@Override
 	public Optional<Integer> refreshGeneratedScript(List<ScriptGeneratorAction> scriptGenContent,
-			ScriptDefinitionWrapper scriptDefinition, String jsonContent) throws InterruptedException, ExecutionException {
+			ScriptDefinitionWrapper scriptDefinition, String jsonContent, List<String> globalParams) throws InterruptedException, ExecutionException {
 		try {
-			return Optional.of(pythonInterface.refreshGeneratedScript(scriptGenContent, jsonContent, scriptDefinition));
+			return Optional.of(pythonInterface.refreshGeneratedScript(scriptGenContent, jsonContent, globalParams, scriptDefinition));
 		} catch (PythonNotReadyException e) {
 			// ScriptGeneratorSingleton is listening to python interface readiness changes (handled there)
 			LOG.error(e);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorPython.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorPython.java
@@ -84,9 +84,9 @@ public class GeneratorPython extends AbstractGenerator {
 	}
 
 	@Override
-	public void refreshTimeEstimation(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition) throws InterruptedException, ExecutionException {
+	public void refreshTimeEstimation(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition, List<String> globalParams) throws InterruptedException, ExecutionException {
         try {
-            pythonInterface.refreshTimeEstimation(scriptGenContent, scriptDefinition);
+            pythonInterface.refreshTimeEstimation(scriptGenContent, scriptDefinition, globalParams);
         } catch (PythonNotReadyException e) {
             // ScriptGeneratorSingleton is listening to python interface readiness changes (handled there)
             LOG.error(e);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorPython.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorPython.java
@@ -74,9 +74,9 @@ public class GeneratorPython extends AbstractGenerator {
 	 * @throws InterruptedException The Py4J call was interrupted.
 	 */
 	@Override
-	public void refreshValidityErrors(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefintion) throws InterruptedException, ExecutionException {
+	public void refreshValidityErrors(List<String> globalParams, List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefintion) throws InterruptedException, ExecutionException {
 		try {
-			pythonInterface.refreshValidityErrors(scriptGenContent, scriptDefintion);
+			pythonInterface.refreshValidityErrors(globalParams,scriptGenContent, scriptDefintion);
 		} catch (PythonNotReadyException e) {
 			// ScriptGeneratorSingleton is listening to python interface readiness changes (handled there)
 			LOG.error(e);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
@@ -390,12 +390,12 @@ public class PythonInterface extends ModelObject {
 	 * @throws InterruptedException The Py4J call was interrupted
 	 * @throws PythonNotReadyException When python is not ready to accept calls.
 	 */
-	public void refreshValidityErrors(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition)
+	public void refreshValidityErrors(List<String> globalParams, List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition)
 			throws InterruptedException, ExecutionException, PythonNotReadyException {
 		if (pythonReady) {
 			CompletableFuture.supplyAsync(() -> {
 				try {
-					return scriptDefinitionsWrapper.getValidityErrors(convertScriptGenContentToPython(scriptGenContent), scriptDefinition);
+					return scriptDefinitionsWrapper.getValidityErrors(globalParams,convertScriptGenContentToPython(scriptGenContent), scriptDefinition);
 				} catch (Py4JException e) {
 					LOG.error(e);
 					handlePythonReadinessChange(false);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
@@ -419,12 +419,12 @@ public class PythonInterface extends ModelObject {
 	 * @throws InterruptedException The Py4J call was interrupted
 	 * @throws PythonNotReadyException When python is not ready to accept calls.
 	 */
-	public void refreshAreParamsValid(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition)
+	public void refreshAreParamsValid(List<ScriptGeneratorAction> scriptGenContent, List<String> globalParams, ScriptDefinitionWrapper scriptDefinition)
 			throws InterruptedException, ExecutionException, PythonNotReadyException {
 		if (pythonReady) {
 			CompletableFuture.supplyAsync(() -> {
 				try {
-					return scriptDefinitionsWrapper.areParamsValid(convertScriptGenContentToPython(scriptGenContent), scriptDefinition);
+					return scriptDefinitionsWrapper.areParamsValid(convertScriptGenContentToPython(scriptGenContent), globalParams, scriptDefinition);
 				} catch (Py4JException e) {
 					LOG.error(e);
 					handlePythonReadinessChange(false);
@@ -477,9 +477,9 @@ public class PythonInterface extends ModelObject {
 	 * @param scriptDefinition           The script definition to generate the script with.
 	 * @return An optional script.
      */
-    private Optional<String> generateScript(List<ScriptGeneratorAction> scriptGenContent, String jsonContent, ScriptDefinitionWrapper scriptDefinition) {
+    private Optional<String> generateScript(List<ScriptGeneratorAction> scriptGenContent, String jsonContent, List<String> globalParams, ScriptDefinitionWrapper scriptDefinition) {
     	try {
-			return Optional.of(scriptDefinitionsWrapper.generate(convertScriptGenContentToPython(scriptGenContent), jsonContent, scriptDefinition));
+			return Optional.of(scriptDefinitionsWrapper.generate(convertScriptGenContentToPython(scriptGenContent), jsonContent, globalParams, scriptDefinition));
 		} catch (Py4JException e) {
 			LOG.error(e);
 			handlePythonReadinessChange(false);
@@ -498,14 +498,14 @@ public class PythonInterface extends ModelObject {
 	 * @throws PythonNotReadyException When python is not ready to accept calls.
 	 * @return An ID for the generated script.
 	 */
-	public int refreshGeneratedScript(List<ScriptGeneratorAction> scriptGenContent, String jsonContent, ScriptDefinitionWrapper scriptDefinition)
+	public int refreshGeneratedScript(List<ScriptGeneratorAction> scriptGenContent, String jsonContent, List<String> globalParams, ScriptDefinitionWrapper scriptDefinition)
 			throws InterruptedException, ExecutionException, PythonNotReadyException {
 		lastScriptId += 1;
 		var scriptId = lastScriptId;
 		generatedScripts.put(scriptId, Optional.empty());
 		if (pythonReady) {
 			CompletableFuture.supplyAsync(() -> {
-				return generateScript(scriptGenContent, jsonContent, scriptDefinition);
+				return generateScript(scriptGenContent, jsonContent, globalParams, scriptDefinition);
 			}, THREAD)
 				.thenAccept(generatedScript -> {
 					generatedScripts.put(scriptId, generatedScript);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
@@ -448,12 +448,12 @@ public class PythonInterface extends ModelObject {
      * @throws InterruptedException The Py4J call was interrupted
      * @throws PythonNotReadyException When python is not ready to accept calls.
      */
-    public void refreshTimeEstimation(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition)
+    public void refreshTimeEstimation(List<ScriptGeneratorAction> scriptGenContent, ScriptDefinitionWrapper scriptDefinition, List<String> globalParams)
             throws InterruptedException, ExecutionException, PythonNotReadyException {
         if (pythonReady) {
             CompletableFuture.supplyAsync(() -> {
                 try {
-                    return scriptDefinitionsWrapper.estimateTime(convertScriptGenContentToPython(scriptGenContent), scriptDefinition);
+                    return scriptDefinitionsWrapper.estimateTime(convertScriptGenContentToPython(scriptGenContent), scriptDefinition, globalParams);
                 } catch (Py4JException e) {
                     LOG.error(e);
                     handlePythonReadinessChange(false);

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionWrapper.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionWrapper.java
@@ -14,11 +14,23 @@ public interface ScriptDefinitionWrapper {
 	List<ActionParameter> getParameters();
 	
 	/**
+	 * @return The global parameter names and their values. e.g. ["param1", "val1", "param2", "val2"]
+	 */
+	List<ActionParameter> getGlobalParameters();
+	/**
 	 * Performs the defined action.
 	 * @param action The action to do.
 	 * @return The error if there has been one.
 	 */
 	String doAction(Map<String, String> action);
+	
+	/**
+	 * checks global params are valid
+	 * @param the global param to check validity of
+	 * @return the error if the arugements are not valid.
+	 */
+    String globalParamsValid(List<String> globalParams);
+      
 	
 	/**
 	 * Performs the check that the arguments are valid.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionWrapper.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionWrapper.java
@@ -44,7 +44,7 @@ public interface ScriptDefinitionWrapper {
      * @param action The action to estimate
      * @return An estimate in seconds
      */
-    Number estimateTime(Map<String, String> action);
+    Number estimateTime(Map<String, String> action, List<String> global_params);
 	
 	/**
 	 * @return The name of this script definition.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionWrapper.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionWrapper.java
@@ -29,7 +29,7 @@ public interface ScriptDefinitionWrapper {
 	 * @param the global param to check validity of
 	 * @return the error if the arugements are not valid.
 	 */
-    String globalParamsValid(List<String> globalParams);
+    String globalParamsValid(String globalParam, int index);
       
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionsWrapper.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionsWrapper.java
@@ -51,7 +51,7 @@ public interface ScriptDefinitionsWrapper {
 	 * @return A map where the key is the index of the action in the list and 
 	 * 		the value is the invalidity reason. Empty if there are no invalidity errors.
 	 */
-	Map<Integer, String> getValidityErrors(List<Map<String, String>> scriptGenContent, ScriptDefinitionWrapper scriptDefinition);
+	Map<Integer, String> getValidityErrors(List<String> globalParams, List<Map<String, String>> scriptGenContent, ScriptDefinitionWrapper scriptDefinition);
 	
 	/**
 	 * Check if a list of actions are valid under the passed script definitions.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionsWrapper.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionsWrapper.java
@@ -44,14 +44,14 @@ public interface ScriptDefinitionsWrapper {
 	String generate(List<Map<String, String>> scriptGenContent, String jsonString, List<String> globalParams ,ScriptDefinitionWrapper scriptDefinition);
 	
 	/**
-	 * Get a mapping of validity errors of the scriptGenContent against the script definition.
+	 * Get a list of mappings of validity errors of the scriptGenContent against the script definition.
 	 * 
 	 * @param scriptGenContent The list of actions to check.
 	 * @param scriptDefinition The script definition to check with.
-	 * @return A map where the key is the index of the action in the list and 
+	 * @return A list of maps where the key is the index of the action in the list and 
 	 * 		the value is the invalidity reason. Empty if there are no invalidity errors.
 	 */
-	Map<Integer, String> getValidityErrors(List<String> globalParams, List<Map<String, String>> scriptGenContent, ScriptDefinitionWrapper scriptDefinition);
+	List<Map<Integer, String>> getValidityErrors(List<String> globalParams, List<Map<String, String>> scriptGenContent, ScriptDefinitionWrapper scriptDefinition);
 	
 	/**
 	 * Check if a list of actions are valid under the passed script definitions.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionsWrapper.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionsWrapper.java
@@ -41,7 +41,7 @@ public interface ScriptDefinitionsWrapper {
 	 * @param scriptDefinition The script definition to generate the script with.
 	 * @return A string containing the generated script.
 	 */
-	String generate(List<Map<String, String>> scriptGenContent, String jsonString, ScriptDefinitionWrapper scriptDefinition);
+	String generate(List<Map<String, String>> scriptGenContent, String jsonString, List<String> globalParams ,ScriptDefinitionWrapper scriptDefinition);
 	
 	/**
 	 * Get a mapping of validity errors of the scriptGenContent against the script definition.
@@ -60,7 +60,7 @@ public interface ScriptDefinitionsWrapper {
 	 * @param scriptDefinition The script definition to check with.
 	 * @return True if valid, False if not.
 	 */
-	boolean areParamsValid(List<Map<String, String>> scriptGenContent, ScriptDefinitionWrapper scriptDefinition);
+	boolean areParamsValid(List<Map<String, String>> scriptGenContent, List<String> globalParams,ScriptDefinitionWrapper scriptDefinition);
 	
     /**
      * Estimate how long (in seconds) the current actions will take.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionsWrapper.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionsWrapper.java
@@ -70,7 +70,7 @@ public interface ScriptDefinitionsWrapper {
      * @return A map where the key is the index of the action in the list and 
      *      the value is the estimated time in seconds
      */
-	Map<Integer, Number> estimateTime(List<Map<String, String>> scriptGenContent, ScriptDefinitionWrapper scriptDefinition);
+	Map<Integer, Number> estimateTime(List<Map<String, String>> scriptGenContent, ScriptDefinitionWrapper scriptDefinition,List<String> globalParams);
 	
 	/**
 	 * Check if Python is ready.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -51,6 +51,14 @@ public class ActionsTable extends ModelObject {
 	public List<ScriptGeneratorAction> getActions() {
 		return actions;
 	}
+	
+	/**
+	 * 
+	 * @return The globalValidError string on this object.
+	 */
+	public String getGlobalValidityErrors() {
+		return this.globalValidError;
+	}
 
 	/**
 	 * The actions table holds each action and its parameter values in an ordered list.
@@ -340,10 +348,14 @@ public class ActionsTable extends ModelObject {
 			String errorString = "Global Parameter Errors: \n" + globalValidError;
 			errors.add(errorString);
 		}
-		errors.add("Action Errors:");
+		boolean first = true;
 		for (int i = 0; i < actions.size(); i++) {
 			ScriptGeneratorAction action = actions.get(i);
 			if (!action.isValid()) {
+				if(first) {
+					errors.add("Action Errors:");
+					first = false;
+				}
 				String errorString = "Row: " + (i+1) + ", Reason: " + "\n" + action.getInvalidityReason().get() + "\n";
 				
 				errors.addAll(Arrays.asList(errorString.split("\n")));

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -27,6 +27,8 @@ public class ActionsTable extends ModelObject {
 	 */
 	private List<JavaActionParameter> actionParameters;
 	
+	private String globalValidError = "";
+	
 	/**
 	 * The actions (rows) of the table that have values for the action parameters.
 	 */
@@ -304,9 +306,12 @@ public class ActionsTable extends ModelObject {
 	 * @param validityErrors The hashmap to set validity errors based on.
 	 */
 	public void setValidityErrors(Map<Integer, String> validityErrors) {
+		if(validityErrors.containsKey(0)) {
+			this.globalValidError = validityErrors.get(0);
+		}
 		for (int i = 0; i < actions.size(); i++) {
-			if (validityErrors.containsKey(i)) {
-				actions.get(i).setInvalid(validityErrors.get(i));
+			if (validityErrors.containsKey(i+1)) {
+				actions.get(i).setInvalid(validityErrors.get(i+1));
 			} else {
 				actions.get(i).setValid();
 			}
@@ -331,10 +336,14 @@ public class ActionsTable extends ModelObject {
 	 */
 	public ArrayList<String> getInvalidityErrorLines() {
 		var errors = new ArrayList<String>();
+		if (this.globalValidError!="") {
+			String errorString = "Global Parameter Errors: \n" + globalValidError + "\n";
+			errors.add(errorString);
+		}
 		for (int i = 0; i < actions.size(); i++) {
 			ScriptGeneratorAction action = actions.get(i);
 			if (!action.isValid()) {
-				String errorString = "Row: " + (i + 1) + ", Reason: " + "\n" + action.getInvalidityReason().get() + "\n";
+				String errorString = "Row: " + (i+1) + ", Reason: " + "\n" + action.getInvalidityReason().get() + "\n";
 				
 				errors.addAll(Arrays.asList(errorString.split("\n")));
 			}

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -27,7 +27,7 @@ public class ActionsTable extends ModelObject {
 	 */
 	private List<JavaActionParameter> actionParameters;
 	
-	private String globalValidError = "";
+	private Map<Integer, String> globalValidError = Collections.emptyMap();
 	
 	/**
 	 * The actions (rows) of the table that have values for the action parameters.
@@ -56,7 +56,7 @@ public class ActionsTable extends ModelObject {
 	 * 
 	 * @return The globalValidError string on this object.
 	 */
-	public String getGlobalValidityErrors() {
+	public Map<Integer, String> getGlobalValidityErrors() {
 		return this.globalValidError;
 	}
 
@@ -311,15 +311,13 @@ public class ActionsTable extends ModelObject {
 	/**
 	 * Set the validity errors for each action based on the hashmap.
 	 * 
-	 * @param validityErrors The hashmap to set validity errors based on.
+	 * @param validityErrors The list of hashmaps to set validity errors based on.
 	 */
-	public void setValidityErrors(Map<Integer, String> validityErrors) {
-		if(validityErrors.containsKey(0)) {
-			this.globalValidError = validityErrors.get(0);
-		}
+	public void setValidityErrors(List<Map<Integer, String>> validityErrors) {
+		this.globalValidError = validityErrors.get(0);
 		for (int i = 0; i < actions.size(); i++) {
-			if (validityErrors.containsKey(i+1)) {
-				actions.get(i).setInvalid(validityErrors.get(i+1));
+			if (validityErrors.get(1).containsKey(i)) {
+				actions.get(i).setInvalid(validityErrors.get(1).get(i));
 			} else {
 				actions.get(i).setValid();
 			}
@@ -344,9 +342,19 @@ public class ActionsTable extends ModelObject {
 	 */
 	public ArrayList<String> getInvalidityErrorLines() {
 		var errors = new ArrayList<String>();
-		if (this.globalValidError!="") {
-			String errorString = "Global Parameter Errors: \n" + globalValidError;
-			errors.add(errorString);
+		if (this.globalValidError.size()>0) {
+			String errorString = "Global Parameter Errors: \n";
+			int initialLen = errorString.length();
+			for(int i = 0; i < globalValidError.size(); i++) {
+				String reason = globalValidError.get(i);
+				if(reason != "") {
+					errorString += "Global Parameter: " + (i+1) +", Reason: " + "\n" + globalValidError.get(i) + "\n";
+				}
+			}
+			if (errorString.length() > initialLen){
+				errors.addAll(Arrays.asList(errorString.split("\n")));
+			}
+				
 		}
 		boolean first = true;
 		for (int i = 0; i < actions.size(); i++) {

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -337,9 +337,10 @@ public class ActionsTable extends ModelObject {
 	public ArrayList<String> getInvalidityErrorLines() {
 		var errors = new ArrayList<String>();
 		if (this.globalValidError!="") {
-			String errorString = "Global Parameter Errors: \n" + globalValidError + "\n";
+			String errorString = "Global Parameter Errors: \n" + globalValidError;
 			errors.add(errorString);
 		}
+		errors.add("Action Errors:");
 		for (int i = 0; i < actions.size(); i++) {
 			ScriptGeneratorAction action = actions.get(i);
 			if (!action.isValid()) {

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
@@ -285,7 +285,13 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
 			}
 		}
 	} 
-	
+	/**
+	 * Sets Rows without touching focus, called when updating globals so table is updated but focus
+	 * not changed.
+	 */
+	public void setRowsNoFocus(Collection<ScriptGeneratorAction> rows) {
+		viewer.setInput(new WritableList<ScriptGeneratorAction>(rows, null));
+	}
 	/**
 	 * Sets focus of cell.
 	 * @param row row number of table

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -19,6 +19,8 @@
 package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
 
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -50,6 +52,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.wb.swt.ResourceManager;
 
 import uk.ac.stfc.isis.ibex.preferences.PreferenceSupplier;
+import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ActionParameter;
 
 /**
  * Provides the UI to control the script generator.
@@ -316,7 +319,12 @@ public class ScriptGeneratorView {
             );
         
         new ScriptGeneratorHelpMenu(topBarComposite);
-
+        Composite globalParamComposite = new Composite(mainParent, SWT.NONE);
+        globalParamComposite.setLayout(new GridLayout(24, false));
+        globalParamComposite.setLayoutData(new GridData(SWT.FILL, SWT.BEGINNING, true, false, 1, 5));
+        
+        List<Label> globalLabel = new ArrayList<Label>();
+        List<Text> globalParamText = new ArrayList<Text>();
         Map<String, String> scriptDefinitionLoadErrors = scriptGeneratorViewModel.getScriptDefinitionLoadErrors();
 
         if (!scriptDefinitionLoadErrors.isEmpty()) {
@@ -463,8 +471,11 @@ public class ScriptGeneratorView {
         loadExperimentalParametersButton.addListener(SWT.Selection, e -> scriptGeneratorViewModel.loadParameterValues());
         // Bind the context and the validity checking listeners
         bind(scriptDefinitionSelector,
-            helpText);
-
+            helpText,
+            globalLabel,
+            globalParamText,
+            globalParamComposite);
+        scriptGeneratorViewModel.createGlobalParamsWidgets();
         } else {
 
         Label warningMessage = new Label(mainParent, SWT.NONE);
@@ -552,8 +563,11 @@ public class ScriptGeneratorView {
      * @param helpText The help text
      */
     private void bind(ComboViewer scriptDefinitionSelector,
-        Text helpText) {
-    scriptGeneratorViewModel.bindScriptDefinitionLoader(scriptDefinitionSelector, helpText);
+        Text helpText,
+        List<Label> globalLabel,
+        List<Text> globalParamText,
+        Composite globalParamsComposite) {
+    scriptGeneratorViewModel.bindScriptDefinitionLoader(scriptDefinitionSelector, helpText, globalLabel, globalParamText, globalParamsComposite, mainParent);
 
     scriptGeneratorViewModel.bindActionProperties(table, generateScriptButton, saveExperimentalParametersButton, saveAsExperimentalParametersButton);
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -966,7 +966,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     		}
     		i++;
     	}
-    	actionChangeHandler(viewTable, btnGetValidityErrors, btnGenerateScript, btnSaveParam, btnSaveParamAs);
+    	actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs);
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -623,6 +623,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
         for(Text text: globalParamText) {
         	text.dispose();
         }
+        scriptGeneratorModel.clearGlobalParams();
         currentGlobals.clear();
         globalParamText.clear();
         createGlobalParamsWidgets();

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -324,7 +324,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     protected void addEmptyAction() {
     scriptGeneratorModel.addEmptyAction();
     // Make sure the table is updated with the new action before selecting it
-    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs);
+    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, true);
     DISPLAY.asyncExec(() -> {
     	viewTable.setCellFocus(scriptGeneratorModel.getActions().size() - 1, ActionsViewTable.NON_EDITABLE_COLUMNS_ON_LEFT);
     });
@@ -338,7 +338,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     protected void insertEmptyAction(Integer insertionLocation) {
     scriptGeneratorModel.insertEmptyAction(insertionLocation);
     // Make sure the table is updated with the new action before selecting it
-    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs);
+    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, true);
     DISPLAY.asyncExec(() -> {
         viewTable.setCellFocus(insertionLocation, 0);
     });
@@ -365,7 +365,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     protected void duplicateAction(List<ScriptGeneratorAction> actionsToDuplicate, Integer insertionLocation) {
     scriptGeneratorModel.duplicateAction(actionsToDuplicate, insertionLocation);
     // Make sure the table is updated with the new action before selecting it
-    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs);
+    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, true);
     DISPLAY.asyncExec(() -> {
     	viewTable.setCellFocus(insertionLocation, ActionsViewTable.NON_EDITABLE_COLUMNS_ON_LEFT);
     });
@@ -478,7 +478,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
      * Listen for changes in actions and activate the handler.
      */
     private PropertyChangeListener actionChangeListener = evt -> {
-    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs);
+    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, false);
     };
 
     /**
@@ -587,9 +587,9 @@ public class ScriptGeneratorViewModel extends ModelObject {
      * @param btnSaveParam Save Parameter button's visibility to manipulate
      * @param btnSaveParamAs Save Parameter As button's visibility to manipulate
      */
-    private void actionChangeHandler(ActionsViewTable viewTable, Button btnGenerateScript, Button btnSaveParam, Button btnSaveParamAs) {
+    private void actionChangeHandler(ActionsViewTable viewTable, Button btnGenerateScript, Button btnSaveParam, Button btnSaveParamAs, boolean rowsChanged) {
     DISPLAY.asyncExec(() -> {
-        if (!viewTable.isDisposed()) {
+        if ((!viewTable.isDisposed()) && rowsChanged) {
         viewTable.setRows(scriptGeneratorModel.getActions());
         updateValidityChecks(viewTable);
         }
@@ -966,7 +966,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     		}
     		i++;
     	}
-    	actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs);
+    	actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, false);
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -615,9 +615,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     private PropertyChangeListener scriptDefinitionSwitchHelpListener = new PropertyChangeListener() {
 
     @Override
-    public void propertyChange(PropertyChangeEvent evt) {
-    	List<ActionParameter> temp = null;
-    	
+    public void propertyChange(PropertyChangeEvent evt) {    	
         for (Label label : globalLabel) {
         	label.dispose();
         }
@@ -783,6 +781,18 @@ public class ScriptGeneratorViewModel extends ModelObject {
         LOG.warn("ScriptGeneratorViewModel - ActionsTable and UI Table mismatch");
         }
     }
+    Map<Integer, String> globals = scriptGeneratorModel.getGlobalParamErrors();
+    for(int i = 0; i< this.globalParamText.size(); i++) {
+    	if(globals.containsKey(i)) {
+    		globalParamText.get(i).setBackground(INVALID_LIGHT_COLOR);
+    		globalParamText.get(i).setBackground(INVALID_DARK_COLOR);
+    		globalParamText.get(i).setToolTipText(globals.get(i));
+    	}else {
+    		globalParamText.get(i).setBackground(CLEAR_COLOR);
+    		globalParamText.get(i).setToolTipText(null);
+    	}
+    }
+    
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -955,6 +955,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     		}
     		i++;
     	}
+    	actionChangeHandler(viewTable, btnGetValidityErrors, btnGenerateScript, btnSaveParam, btnSaveParamAs);
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -589,8 +589,12 @@ public class ScriptGeneratorViewModel extends ModelObject {
      */
     private void actionChangeHandler(ActionsViewTable viewTable, Button btnGenerateScript, Button btnSaveParam, Button btnSaveParamAs, boolean rowsChanged) {
     DISPLAY.asyncExec(() -> {
-        if ((!viewTable.isDisposed()) && rowsChanged) {
-        viewTable.setRows(scriptGeneratorModel.getActions());
+        if (!viewTable.isDisposed()) {
+        if(rowsChanged) {
+        	viewTable.setRows(scriptGeneratorModel.getActions());
+        }else {
+        	viewTable.setRowsNoFocus(scriptGeneratorModel.getActions());
+        }
         updateValidityChecks(viewTable);
         }
         if (!btnGenerateScript.isDisposed()) {


### PR DESCRIPTION
### Description of work
Added check for script definition having global parameters, and if it does, GUI ability to display and and set them.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5616

### Acceptance criteria
For updated script that contains `global_params_definition` see https://github.com/ISISComputingGroup/ScriptDefinitions/pull/4
- Upon loading a script definition with a `global_params_definition` dictionary in the script generator. Text boxes are available to enter values for all paameters defined in the dictionary.
- Enterring values that do not match the type set in the `global_params_definition` for that parameter leads to the text box being highlighted in red, and displays a tooltip explaining the validity error.
- The script can make use of the global parameters set in the script generator, both in estimating the time during script generation itself, and in a generated script by allowing actions to make use of them.
- All modified tests pass.

### Unit tests
ActionTableTest.java
ScriptGeneratorSingletonTest.java
test_generator.py

### System tests
Needs squish tests.

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

