### PR TITLE
Ticket 6351: Do not open plot outside scripting

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/ConnectionHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/ConnectionHandler.java
@@ -2,6 +2,8 @@ package uk.ac.stfc.isis.ibex.ui.graphing;
 
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IPerspectiveDescriptor;
+import org.eclipse.ui.IPerspectiveListener;
+import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -14,29 +16,67 @@ import uk.ac.stfc.isis.ibex.logger.IsisLog;
 public class ConnectionHandler {
 
     /**
-     * The ID of the reflectometry perspective
+     * The ID of the reflectometry and scripting perspectives
      */
     private static final String REFL_PERSPECTIVE_ID = "uk.ac.stfc.isis.ibex.client.e4.product.perspective.reflectometry";
-
+    private static final String SCRIPTING_PERSPECTIVE_ID = "uk.ac.stfc.isis.ibex.ui.scripting.perspective";
+    
+    private String url;
+    private boolean isPrimary;
+    private Boolean graphRefreshRequired = false;
+    
+    private IPerspectiveListener openOnSwitchingPerspective = new IPerspectiveListener() {   
+        @Override
+        public void perspectiveChanged(IWorkbenchPage page, IPerspectiveDescriptor perspective, String changeId) {
+        }
+        
+        @Override
+        public void perspectiveActivated(IWorkbenchPage page, IPerspectiveDescriptor perspective) {
+            if (graphRefreshRequired) {
+                Display.getDefault().asyncExec(new Runnable() {
+                    @Override
+                    public void run() {
+                        openPlotInCurrentPerspective(perspective, url, isPrimary);
+                    }
+                });
+                graphRefreshRequired = false;
+            }
+        }
+    };
+    
+    private Boolean openPlotInCurrentPerspective(IPerspectiveDescriptor currentPerspective, final String url, final boolean isPrimary) {
+        Boolean plotOpened = true;
+        if (currentPerspective.getId().equals(REFL_PERSPECTIVE_ID)) {
+            FixedMatplotlibOpiTargetView.displayOpi(url);
+        } else if (currentPerspective.getId().equals(SCRIPTING_PERSPECTIVE_ID)) {
+            MatplotlibOpiTargetView.displayOpi(url, isPrimary);
+        } else {
+            plotOpened = false;
+        }
+        return plotOpened;
+    }
+    
     /**
      * Opens the plotting OPI pointing at the given URL.
      * @param url the URL to point at
      * @param isPrimary True if this is the primary plot window; False for secondary
      */
     public void openPlot(final String url, final boolean isPrimary) {
-	IsisLog.getLogger(ConnectionHandler.class).info("Opening matplotlib OPI. Primary display " + isPrimary);
-	Display.getDefault().asyncExec(new Runnable() {
-	    @Override
-	    public void run() {
-		IPerspectiveDescriptor currentPerspective = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getPerspective();
-		boolean isReflectometryView = currentPerspective.getId().equals(REFL_PERSPECTIVE_ID);
-
-		if (isReflectometryView) {
-		    FixedMatplotlibOpiTargetView.displayOpi(url);
-		} else {
-		    MatplotlibOpiTargetView.displayOpi(url, isPrimary);
-		}
-	    }
-	});
+        this.url = url;
+        this.isPrimary = isPrimary;
+    	IsisLog.getLogger(ConnectionHandler.class).info("Opening matplotlib OPI. Primary display " + isPrimary);
+    	Display.getDefault().asyncExec(new Runnable() {
+    	    @Override
+    	    public void run() {
+    	        PlatformUI.getWorkbench().getActiveWorkbenchWindow().addPerspectiveListener(openOnSwitchingPerspective);
+        		IPerspectiveDescriptor currentPerspective = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getPerspective();    		
+        		graphRefreshRequired = !openPlotInCurrentPerspective(currentPerspective, url, isPrimary);
+    	    }
+    	});
+    }
+    
+    @Override
+    protected void finalize() {
+        PlatformUI.getWorkbench().getActiveWorkbenchWindow().removePerspectiveListener(openOnSwitchingPerspective);
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Commands.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Commands.java
@@ -43,7 +43,8 @@ public final class Commands {
 	public static final String GENIE_INITIALISATION_CMDS = 
 			"import matplotlib \n"
 			+ "matplotlib.use('module://genie_python.matplotlib_backend.ibex_web_backend') \n"
-			+ "from genie_python.genie_startup import * \n";
+			+ "from genie_python.genie_startup import * \n"
+			+ "g.from_ibex = True \n";
 
 	
     private Commands() {

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Commands.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Commands.java
@@ -43,8 +43,7 @@ public final class Commands {
 	public static final String GENIE_INITIALISATION_CMDS = 
 			"import matplotlib \n"
 			+ "matplotlib.use('module://genie_python.matplotlib_backend.ibex_web_backend') \n"
-			+ "from genie_python.genie_startup import * \n"
-			+ "g.from_ibex = True \n";
+			+ "from genie_python.genie_startup import * \n";
 
 	
     private Commands() {


### PR DESCRIPTION
### Description of work

See https://github.com/ISISComputingGroup/IBEX/issues/6351 

To test:
* Start a python script that will plot after some time e.g.
```
def sleep_then_plot():
    from time import sleep
    sleep(2)
    g.adv.open_plot_window(True)
```
* Switch to a different perspective and confirm that a plot window does not open there
* Switch back to the scripting perspective and confirm it does open a window
* Confirm that after running such a script and switching to the refl perspective it will also refresh the plotting window there

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

