### PR TITLE
Script Generator: Reformulate save and load parameters workflow

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -773,16 +773,35 @@ public class ScriptGeneratorSingleton extends ModelObject {
 				.orElseThrow(() -> new NoScriptDefinitionSelectedException("No Configuration Selected"));
 		
 		try {
-			if (!filePath.endsWith(SCRIPT_GEN_PARAMS_EXT)) {
-				//Strip out other any pre-existing file extension and add the SGP (script generator parameters) file extension
-				filePath = filePath.substring(0, filePath.lastIndexOf('.')) + SCRIPT_GEN_PARAMS_EXT;
-			}
+			filePath = this.setParametersFileExtension(filePath);
 			scriptGenFileHandler.saveParameters(scriptGeneratorTable.getActions(), getScriptDefinitionPath(scriptDefinition), filePath);
 		} catch (InterruptedException | ExecutionException e) {
 			registerThreadError(e);
 		}
 	}
 	
+	/**
+	 * Strip out other any pre-existing file extension and add the SGP (script generator parameters) file extension.
+	 * @param filePath The file path, with or without the parameter file extension.
+	 * @return The file path with the parameters file extension.
+	 */
+	public String setParametersFileExtension(String filePath) {
+		return (!filePath.endsWith(SCRIPT_GEN_PARAMS_EXT)) ? filePath.substring(0, filePath.lastIndexOf('.')) + SCRIPT_GEN_PARAMS_EXT : filePath;
+	}
+	
+	/**
+	 * Strip out other any pre-existing file extension and add the script file extension.
+	 * @param filePath The file path, with or without the script file extension.
+	 * @return The file path with the script file extension.
+	 */
+	public String setScriptFileExtension(String filePath) {
+		try {
+			return (!filePath.endsWith(PYTHON_EXT)) ? filePath.substring(0, filePath.lastIndexOf('.')) + PYTHON_EXT : filePath;
+		} catch (StringIndexOutOfBoundsException e) {
+			// If path has file with no extension
+			return filePath + PYTHON_EXT;
+		}
+	}
 	
 	/**
 	 * Get the file writer to use to write scripts to file.

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/SaveScriptGeneratorFileMessageDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/SaveScriptGeneratorFileMessageDialog.java
@@ -55,8 +55,9 @@ public class SaveScriptGeneratorFileMessageDialog {
 
 	/**
 	 * Opens the dialog and saves the file to the location specified by the user.
+	 * @return The path of the saved script file.
 	 */
-	public void open() {
+	public String open() {
 		String filepath = saveDialog.open();
 		
 		if (filepath != null) {
@@ -80,5 +81,6 @@ public class SaveScriptGeneratorFileMessageDialog {
 				}
 			}
 		}
+		return filepath;
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -432,7 +432,7 @@ public class ScriptGeneratorView {
         // Composite for generate buttons
         Composite generateButtonsGrp = new Composite(mainParent, SWT.NONE);
         generateButtonsGrp.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-        GridLayout gbgLayout = new GridLayout(5, true);
+        GridLayout gbgLayout = new GridLayout(4, true);
         gbgLayout.marginHeight = 10;
         gbgLayout.marginWidth = 10;
         generateButtonsGrp.setLayout(gbgLayout);

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -121,8 +121,7 @@ public class ScriptGeneratorView {
     private Label estimateText;
     private Button queueScriptButton;
     private Button generateScriptButton;
-    private Button saveExperimentalParametersButton;
-    private Button saveAsExperimentalParametersButton;
+    private Button generateScriptAsButton;
     private Button btnDuplicateAction;
 
     /**
@@ -367,7 +366,7 @@ public class ScriptGeneratorView {
         // Label for Location of Saved Parameters File
         parametersFileText = new Label(paramFileAndEstimateGrp, SWT.LEFT);
         parametersFileText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-        parametersFileText.setText("Current parameters file: <new file>");
+        parametersFileText.setText("Current Script: <new file>");
         
         Composite utilitiesGrp = new Composite(mainParent, SWT.NONE);
         utilitiesGrp.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
@@ -449,24 +448,19 @@ public class ScriptGeneratorView {
         	scriptId.ifPresent(id -> scriptGeneratorViewModel.setNicosScript(id));
         });
 
-        // Button to generate a script
+        // Buttons to generate a script
         generateScriptButton = new Button(generateButtonsGrp, SWT.NONE);
         generateScriptButton.setText("Generate Script");
         generateScriptButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-        generateScriptButton.addListener(SWT.Selection, e -> scriptGeneratorViewModel.generate());
-
-        saveExperimentalParametersButton = new Button(generateButtonsGrp, SWT.NONE);
-        saveExperimentalParametersButton.setText("Save Parameters");
-        saveExperimentalParametersButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-        saveExperimentalParametersButton.addListener(SWT.Selection, e -> scriptGeneratorViewModel.saveParameterValuesToCurrentFile());
-
-        saveAsExperimentalParametersButton = new Button(generateButtonsGrp, SWT.NONE);
-        saveAsExperimentalParametersButton.setText("Save Parameters As ...");
-        saveAsExperimentalParametersButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-        saveAsExperimentalParametersButton.addListener(SWT.Selection, e -> scriptGeneratorViewModel.saveParameterValues());
+        generateScriptButton.addListener(SWT.Selection, e -> scriptGeneratorViewModel.generateToCurrent());
+        
+        generateScriptAsButton = new Button(generateButtonsGrp, SWT.NONE);
+        generateScriptAsButton.setText("Generate Script As");
+        generateScriptAsButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+        generateScriptAsButton.addListener(SWT.Selection, e -> scriptGeneratorViewModel.generate());
         
         final Button loadExperimentalParametersButton = new Button(generateButtonsGrp, SWT.NONE);
-        loadExperimentalParametersButton.setText("Load Parameters");
+        loadExperimentalParametersButton.setText("Load Script");
         loadExperimentalParametersButton.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
         loadExperimentalParametersButton.addListener(SWT.Selection, e -> scriptGeneratorViewModel.loadParameterValues());
         // Bind the context and the validity checking listeners
@@ -569,7 +563,7 @@ public class ScriptGeneratorView {
         Composite globalParamsComposite) {
     scriptGeneratorViewModel.bindScriptDefinitionLoader(scriptDefinitionSelector, helpText, globalLabel, globalParamText, globalParamsComposite, mainParent);
 
-    scriptGeneratorViewModel.bindActionProperties(table, generateScriptButton, saveExperimentalParametersButton, saveAsExperimentalParametersButton);
+    scriptGeneratorViewModel.bindActionProperties(table, generateScriptButton, generateScriptAsButton);
 
     table.addSelectionChangedListener(event -> scriptGeneratorViewModel.setSelected(table.selectedRows()));
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.nio.file.Paths;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -160,7 +161,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     /**
      * Path to the current parameters save file.
      */
-    private String currentParametersFile;
+    private String currentParametersFilePath;
     
     /**
      * The actions of the currently loaded parameters file.
@@ -175,7 +176,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     /**
      * Default string to display the current parameters save file name and location.
      */
-    private String parametersFileDisplayString = "Current parameters file: <new file>";
+    private String parametersFileDisplayString = "Current Script: <new file>";
     
     /**
      * Default string to display for time estimation.
@@ -196,16 +197,17 @@ public class ScriptGeneratorViewModel extends ModelObject {
      * The current generate script button in the view.
      */
     private Button btnGenerateScript;
-
+    
     /**
-     * The current Save Parameters button in the view
+     * The current Generate Script As button in the view.
      */
-    private Button btnSaveParam;
-
+    private Button btnGenerateScriptAs;
+    
+    
     /**
-     * The current Save Parameters As button in the view
+     * Whether to save the generated script to the current file or create a new one.
      */
-    private Button btnSaveParamAs;
+    private boolean generateToCurrent;
     
     /**
      * The currently selected rows
@@ -262,8 +264,33 @@ public class ScriptGeneratorViewModel extends ModelObject {
             		if (nicosScriptIds.contains(generatedScriptId)) {
             			firePropertyChange(NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
             		} else {
-            			(new SaveScriptGeneratorFileMessageDialog(Display.getDefault().getActiveShell(), "Script Generated", scriptFilename, 
-                                scriptGeneratorModel.getDefaultScriptDirectory(), generatedScript, scriptGeneratorModel)).open();
+            			if (generateToCurrent) {
+            				try {
+            					// Get the script file name using the current parameters file. If no file is loaded, generate name.
+            					String scriptFilePath = currentParametersFilePath != null
+            											? currentParametersFilePath
+            											: scriptGeneratorModel.getDefaultScriptDirectory() + scriptGeneratorModel.generateScriptFileName();
+            					scriptFilePath = scriptGeneratorModel.setScriptFileExtension(scriptFilePath);
+            					scriptGeneratorModel.getFileHandler().generate(scriptFilePath, generatedScript);
+            					scriptGeneratorModel.saveParameters(scriptFilePath);
+            					MessageDialog.openInformation(DISPLAY.getActiveShell(), "Script Generated", 
+            							String.format("Generated script saved to %s.", scriptFilePath));
+            					this.updateParametersFilePath(scriptGeneratorModel.setParametersFileExtension(scriptFilePath));
+            				} catch (IOException e) {
+            					LOG.error(e);
+            					MessageDialog.openError(DISPLAY.getActiveShell(), "Error", "Failed to write generated script to file");
+            				} catch (NoScriptDefinitionSelectedException e) {
+            			        MessageDialog.openWarning(DISPLAY.getActiveShell(), "No script definition selection", 
+            			                "Cannot generate script. No script definition has been selected");
+            				}
+            			} else {
+							String genFilePath = (new SaveScriptGeneratorFileMessageDialog(Display.getDefault().getActiveShell(), "Script Generated", scriptFilename, 
+												  scriptGeneratorModel.getDefaultScriptDirectory(), generatedScript, scriptGeneratorModel)).open();
+							if (genFilePath != null) {
+								String paramsFilePath = scriptGeneratorModel.setParametersFileExtension(genFilePath);
+								this.updateParametersFilePath(paramsFilePath);
+							}
+            			}
             		}
             	}, () -> {
             		MessageDialog.openWarning(DISPLAY.getActiveShell(), "Error", "Failed to generate the script");
@@ -324,7 +351,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     protected void addEmptyAction() {
     scriptGeneratorModel.addEmptyAction();
     // Make sure the table is updated with the new action before selecting it
-    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, true);
+    actionChangeHandler(viewTable, btnGenerateScript, btnGenerateScriptAs, true);
     DISPLAY.asyncExec(() -> {
     	viewTable.setCellFocus(scriptGeneratorModel.getActions().size() - 1, ActionsViewTable.NON_EDITABLE_COLUMNS_ON_LEFT);
     });
@@ -338,7 +365,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     protected void insertEmptyAction(Integer insertionLocation) {
     scriptGeneratorModel.insertEmptyAction(insertionLocation);
     // Make sure the table is updated with the new action before selecting it
-    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, true);
+    actionChangeHandler(viewTable, btnGenerateScript, btnGenerateScriptAs, true);
     DISPLAY.asyncExec(() -> {
         viewTable.setCellFocus(insertionLocation, 0);
     });
@@ -365,7 +392,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     protected void duplicateAction(List<ScriptGeneratorAction> actionsToDuplicate, Integer insertionLocation) {
     scriptGeneratorModel.duplicateAction(actionsToDuplicate, insertionLocation);
     // Make sure the table is updated with the new action before selecting it
-    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, true);
+    actionChangeHandler(viewTable, btnGenerateScript, btnGenerateScriptAs, true);
     DISPLAY.asyncExec(() -> {
     	viewTable.setCellFocus(insertionLocation, ActionsViewTable.NON_EDITABLE_COLUMNS_ON_LEFT);
     });
@@ -478,7 +505,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
      * Listen for changes in actions and activate the handler.
      */
     private PropertyChangeListener actionChangeListener = evt -> {
-    actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, false);
+    actionChangeHandler(viewTable, btnGenerateScript, btnGenerateScriptAs, false);
     };
 
     /**
@@ -487,14 +514,12 @@ public class ScriptGeneratorViewModel extends ModelObject {
      * 
      * @param viewTable The view table to update.
      * @param btnGenerateScript The generate script button to style change.
-     * @param btnSaveParam The save parameters button.
-     * @param btnSaveParamAs The save parameters as button.
+     * @param btnGenerateScriptAs The generate script as button to style change.
      */
-    protected void bindActionProperties(ActionsViewTable viewTable, Button btnGenerateScript, Button btnSaveParam, Button btnSaveParamAs) {
+    protected void bindActionProperties(ActionsViewTable viewTable, Button btnGenerateScript, Button btnGenerateScriptAs) {
     this.viewTable = viewTable;
     this.btnGenerateScript = btnGenerateScript;
-    this.btnSaveParam = btnSaveParam;
-    this.btnSaveParamAs = btnSaveParamAs;
+    this.btnGenerateScriptAs = btnGenerateScriptAs;
     // Remove listeners so as not to bind them twice
     this.scriptGeneratorModel.getScriptGeneratorTable().removePropertyChangeListener(ACTIONS_PROPERTY, actionChangeListener);
     this.scriptGeneratorModel.getScriptGeneratorTable().addPropertyChangeListener(ACTIONS_PROPERTY, actionChangeListener);
@@ -507,10 +532,10 @@ public class ScriptGeneratorViewModel extends ModelObject {
     this.scriptGeneratorModel.addPropertyChangeListener(TIME_ESTIMATE_PROPERTY, actionChangeListener);
     }
 
-    private void updateParametersFile(String parametersFilePath) {
-	String displayFile = "Current parameters file: " + parametersFilePath;
-	currentParametersFile = parametersFilePath;		// Update the current parameter file path for Save.
-	unsavedChangesMarkerDisplayed = false;			// Reset unsaved changes
+    private void updateParametersFilePath(String parametersFilePath) {
+	String displayFile = "Current Script: " + parametersFilePath;
+	currentParametersFilePath = parametersFilePath;		// Update the current parameter file path for Save.
+	unsavedChangesMarkerDisplayed = false;				// Reset unsaved changes marker.
 	
 	// Save the loaded actions to check if modified.
 	try {
@@ -584,23 +609,22 @@ public class ScriptGeneratorViewModel extends ModelObject {
      * 
      * @param viewTable The view table to update.
      * @param btnGenerateScript Generate Script button's visibility to manipulate
-     * @param btnSaveParam Save Parameter button's visibility to manipulate
-     * @param btnSaveParamAs Save Parameter As button's visibility to manipulate
      */
-    private void actionChangeHandler(ActionsViewTable viewTable, Button btnGenerateScript, Button btnSaveParam, Button btnSaveParamAs, boolean rowsChanged) {
+    private void actionChangeHandler(ActionsViewTable viewTable, Button btnGenerateScript, Button btnGenerateScriptAs, boolean rowsChanged) {
     DISPLAY.asyncExec(() -> {
         if (!viewTable.isDisposed()) {
-        if(rowsChanged) {
+        if (rowsChanged) {
         	viewTable.setRows(scriptGeneratorModel.getActions());
-        }else {
+        } else {
         	viewTable.setRowsNoFocus(scriptGeneratorModel.getActions());
         }
         updateValidityChecks(viewTable);
         }
         if (!btnGenerateScript.isDisposed()) {
         setButtonGenerateStyle(btnGenerateScript);
-        setButtonGenerateStyle(btnSaveParam);
-        setButtonGenerateStyle(btnSaveParamAs);
+        }
+        if (!btnGenerateScriptAs.isDisposed()) {
+        setButtonGenerateStyle(btnGenerateScriptAs);
         }
         updateTotalEstimatedTime();
     });
@@ -624,7 +648,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
         	label.dispose();
         }
         globalLabel.clear();
-        for(Text text: globalParamText) {
+        for (Text text: globalParamText) {
         	text.dispose();
         }
         scriptGeneratorModel.clearGlobalParams();
@@ -651,24 +675,26 @@ public class ScriptGeneratorViewModel extends ModelObject {
 		List<ActionParameter> temp;
 		String param = "No Global Paramaters";
     	String paramVal = "";
-        if(getScriptDefinition().get().getGlobalParameters() != null) {
+        if (getScriptDefinition().get().getGlobalParameters() != null) {
       	  temp = getScriptDefinition().get().getGlobalParameters();
-      	  if(!temp.isEmpty()) {
+      	  if (!temp.isEmpty()) {
       		  for (ActionParameter global : temp) {
-      			  param=global.getName();
+      			  param = global.getName();
       			  currentGlobals.add(global.getName());
       			  paramVal = global.getDefaultValue();
 
-                	  Label globalLabelCurrent = new Label (globalParamsComposite, SWT.NONE);
-                	  globalLabelCurrent.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER,false,false, 1, 1));
-                	  globalLabelCurrent.setText(param);
-                	  globalLabel.add(globalLabelCurrent);
-                	  Text globalParamTextCurrent = new Text(globalParamsComposite,SWT.NONE);
-                	  globalParamTextCurrent.setLayoutData(new GridData(SWT.FILL,SWT.CENTER,true,false,5,1));
-                	  globalParamTextCurrent.setEnabled(true);
-                	  globalParamTextCurrent.addListener(SWT.Modify, e->{updateGlobalParams(globalParamTextCurrent.getText(), globalLabelCurrent.getText());});
-                	  globalParamTextCurrent.setText(paramVal);
-                	  globalParamText.add(globalParamTextCurrent);
+            	  Label globalLabelCurrent = new Label(globalParamsComposite, SWT.NONE);
+            	  globalLabelCurrent.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1));
+            	  globalLabelCurrent.setText(param);
+            	  globalLabel.add(globalLabelCurrent);
+            	  Text globalParamTextCurrent = new Text(globalParamsComposite, SWT.NONE);
+            	  globalParamTextCurrent.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 5, 1));
+            	  globalParamTextCurrent.setEnabled(true);
+            	  globalParamTextCurrent.addListener(SWT.Modify, e -> {
+            		  updateGlobalParams(globalParamTextCurrent.getText(), globalLabelCurrent.getText());
+            	  });
+            	  globalParamTextCurrent.setText(paramVal);
+            	  globalParamText.add(globalParamTextCurrent);
       		  }
       	  }
       }
@@ -970,14 +996,32 @@ public class ScriptGeneratorViewModel extends ModelObject {
     		}
     		i++;
     	}
-    	actionChangeHandler(viewTable, btnGenerateScript, btnSaveParam, btnSaveParamAs, false);
+    	actionChangeHandler(viewTable, btnGenerateScript, btnGenerateScriptAs, false);
     }
 
+    /**
+     * Generate a script and save it to the current script file. If fail display warnings.
+     * @throws UnsupportedLanguageException 
+     */
+    public Optional<Integer> generateToCurrent() {
+        this.generateToCurrent = true;
+    	return this.generateScript();
+    }
+    
     /**
      * Generate a script and display the file it was generated to. If fail display warnings.
      * @throws UnsupportedLanguageException 
      */
     public Optional<Integer> generate() {
+        this.generateToCurrent = false;
+    	return this.generateScript();
+    }
+    
+    /**
+     * Generate a script and display the file it was generated to. If fail display warnings.
+     * @throws UnsupportedLanguageException 
+     */
+    private Optional<Integer> generateScript() {
     try {
         return scriptGeneratorModel.refreshGeneratedScript();
     } catch (InvalidParamsException e) {
@@ -1055,45 +1099,6 @@ public class ScriptGeneratorViewModel extends ModelObject {
     }
 
     /**
-     * Save Parameter Values to the current file.
-     */
-    public void saveParameterValuesToCurrentFile() {
-    	// If there is no current file, do Save As to new file.
-    	if (currentParametersFile == null || currentParametersFile.isEmpty()) {
-    		saveParameterValues();
-    	} else {
-    		try {
-    		scriptGeneratorModel.saveParameters(currentParametersFile);
-    		updateParametersFile(currentParametersFile);
-            MessageDialog.openInformation(DISPLAY.getActiveShell(), "Saved", "File saved!");  
-    		} catch (NoScriptDefinitionSelectedException e) {
-            LOG.error(e);
-            MessageDialog.openWarning(DISPLAY.getActiveShell(), "No script definition selection", 
-                "Cannot generate script. No script definition has been selected");
-    		}
-    	}
-    }
-    
-    /**
-     * Save Parameter Values to a file. Checks if file already exists and asks if user wants to overwrite it.
-     */
-    public void saveParameterValues() {        
-    Optional<String> fileName  = openFileDialog(SWT.SAVE);
-    // filename will be null if user has clicked cancel button
-    if (fileName.isPresent()) {
-        try {
-        scriptGeneratorModel.saveParameters(fileName.get());
-        updateParametersFile(fileName.get());
-        MessageDialog.openInformation(DISPLAY.getActiveShell(), "Saved", "File saved!");  
-        } catch (NoScriptDefinitionSelectedException e) {
-        LOG.error(e);
-        MessageDialog.openWarning(DISPLAY.getActiveShell(), "No script definition selection", 
-            "Cannot generate script. No script definition has been selected");
-        } 
-    }
-    }
-
-    /**
      * Open file dialog which opens file browser for saving and loading parameter values.
      * @param action save or load
      * @return filename to save or load
@@ -1155,7 +1160,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
         
         if (emptyModel || dialogResponse == 1) {
 	        // Get the save file path from Optional value and update the current file path label.
-	        updateParametersFile(selectedFile.get());
+	        updateParametersFilePath(selectedFile.get());
         }
 
     }


### PR DESCRIPTION
### Description of work

Removed "Save Parameters", "Save Parameters As".
Renamed "Generate Script" to "Generate Script As", added new "Generate Script" to save to current file, or create a new one with the suggested name.

Updated squish tests: https://github.com/ISISComputingGroup/System_Tests_UI_E4/pull/101

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6492

### Acceptance criteria

- [ ] The "Save Parameters" and "Save Parameters As" buttons are removed
- [ ] When I press "Generate Script" two files are saved and the current script parameters file asterisk is updated
- [ ] When I press "Generate Script As" I am able to give a name to the files saved and the current script parameters name and asterisk is updated
- [ ] The "Load Parameters" button is renamed to "Load Script"
- [ ] The "Current Parameters File" label is changed to "Current Script"
- [ ] Fix squish and unit tests to work with changes

### Unit tests

N/A

### System tests

https://github.com/ISISComputingGroup/System_Tests_UI_E4/pull/101

### Documentation
https://github.com/ISISComputingGroup/IBEX/pull/6610

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

