### PR TITLE
Update checkstyle.xml to be compatible with latest plugin version

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.client.tycho.parent/checkstyle.xml
+++ b/base/uk.ac.stfc.isis.ibex.client.tycho.parent/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Check Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     This configuration file was written by the eclipse-cs plugin configuration editor
@@ -14,11 +14,11 @@
     <module name="SuppressWarningsHolder"/>
     <module name="ConstantName"/>
     <module name="JavadocMethod">
-      <property name="scope" value="protected"/>
+      <property name="accessModifiers" value="public, protected"/>
     </module>
     <module name="JavadocType">
       <property name="scope" value="protected"/>
-      <property name="tokens" value="INTERFACE_DEF,ENUM_DEF,CLASS_DEF,ANNOTATION_DEF"/>
+      <property name="tokens" value="INTERFACE_DEF,CLASS_DEF,ENUM_DEF,ANNOTATION_DEF"/>
     </module>
     <module name="JavadocStyle">
       <property name="scope" value="protected"/>
@@ -68,9 +68,7 @@
     <module name="EmptyStatement"/>
     <module name="EqualsHashCode"/>
     <module name="IllegalInstantiation"/>
-    <module name="MagicNumber">
-      <property name="constantWaiverParentToken" value="TYPECAST,METHOD_CALL,EXPR,ARRAY_INIT,UNARY_MINUS,UNARY_PLUS,ELIST,STAR,ASSIGN,PLUS,MINUS,DIV,LITERAL_NEW"/>
-    </module>
+    <module name="MagicNumber"/>
     <module name="MissingSwitchDefault"/>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>


### PR DESCRIPTION
The latest version of checkstyle throws errors with our config xml, because some properties in the API have been changed. Encountered this issue while building workspace for new starters

### To test:
1. Checkout current master
2.  Find checkstyle plugin in Eclipse under `Help > Eclipse Marketplace > Installed` and update it to the latest version
3. Build in Eclipse
4. Confirm you get lots of checkstyle problems and the highlighting breaks
5. Check out this branch and build again
6. Confirm checkstyle problems disappear and checkstyle highlighting works again