### PR TITLE
Added generated script preview when queuing script

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/QueueScriptPreviewDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/QueueScriptPreviewDialog.java
@@ -1,0 +1,76 @@
+package uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs;
+
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.dialogs.TitleAreaDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+
+/**
+ * A message dialog box for previewing a script before queuing to NICOS.
+ */
+public class QueueScriptPreviewDialog extends TitleAreaDialog {
+	private Shell parentShell;
+	private String generatedScript;
+	
+	/**
+	 * Sets dialog window and data.
+	 * @param parentShell Shell to open log dialog box
+	 * @param generatedScript The generated script to preview
+	 */
+	public QueueScriptPreviewDialog(Shell parentShell, String generatedScript) {
+		super(parentShell);
+		setShellStyle(getShellStyle() | SWT.RESIZE | SWT.MAX);
+		this.generatedScript = generatedScript;
+		this.parentShell = parentShell;
+	}
+	
+	@Override
+	protected void configureShell(Shell shell) {
+		super.configureShell(shell);
+		shell.setText("Queue Script - Preview");
+	}
+	
+	@Override
+    @SuppressWarnings({ "checkstyle:magicnumber"})
+	protected Control createDialogArea(Composite parent) {
+		setTitle("Script Preview");
+		setMessage("Preview the generated script before sending it to NICOS.");
+		Composite container = (Composite) super.createDialogArea(parent);
+		GridLayout gl_container = new GridLayout(1, false);
+		container.setLayout(gl_container);
+
+		Text text = new Text(container, SWT.BORDER | SWT.READ_ONLY | SWT.H_SCROLL
+							| SWT.V_SCROLL | SWT.MULTI);
+		GridData gd_text = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
+		gd_text.heightHint = 800;
+		gd_text.widthHint = 800;
+		
+		text.setLayoutData(gd_text);
+		text.setText(generatedScript);
+		
+		return container;
+	}
+	
+	@Override
+	public void createButtonsForButtonBar(Composite parent) {
+		createButton(parent, IDialogConstants.OK_ID, "Queue Script", true);
+		createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
+	}
+	
+	/**
+	 * Asks the user if they want to preview the script before sending to NICOS.
+	 * @return Whether to preview the script or not.
+	 */
+	public Boolean askIfPreviewScript() {
+		String dialogMessage = "Preview the generated script before queuing?";
+		Boolean previewScript = MessageDialog.openQuestion(parentShell, "Preview Script", dialogMessage); 
+		return previewScript;
+	}
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/QueueScriptPreviewDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/QueueScriptPreviewDialog.java
@@ -69,8 +69,8 @@ public class QueueScriptPreviewDialog extends TitleAreaDialog {
 	 * @return Whether to preview the script or not.
 	 */
 	public Boolean askIfPreviewScript() {
-		String dialogMessage = "Preview the generated script before queuing?";
-		Boolean previewScript = MessageDialog.openQuestion(parentShell, "Preview Script", dialogMessage); 
+		Boolean previewScript = MessageDialog.openQuestion(parentShell, "Preview Script", 
+				"Preview the generated script before queuing?"); 
 		return previewScript;
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -22,6 +22,7 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.CellLabelProvider;
 import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.ComboViewer;
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -54,6 +55,7 @@ import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ActionParameter;
 import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ScriptDefinitionWrapper;
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
 import uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs.SaveScriptGeneratorFileMessageDialog;
+import uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs.QueueScriptPreviewDialog;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
 import uk.ac.stfc.isis.ibex.ui.widgets.StringEditingSupport;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -268,7 +270,15 @@ public class ScriptGeneratorViewModel extends ModelObject {
             generatedScriptId -> {
             	scriptGeneratorModel.getScriptFromId(generatedScriptId).ifPresentOrElse(generatedScript -> {
             		if (nicosScriptIds.contains(generatedScriptId)) {
-            			firePropertyChange(NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
+            			QueueScriptPreviewDialog scriptPreview = new QueueScriptPreviewDialog(Display.getDefault().getActiveShell(), generatedScript);
+            			if (scriptPreview.askIfPreviewScript()) {
+            				if (scriptPreview.open() == IDialogConstants.OK_ID) {
+            					firePropertyChange(NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
+            				}
+            			}
+            			else {
+            				firePropertyChange(NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
+            			}
             		} else {
             			if (scriptsToGenerateToCurrentFilepath.contains(generatedScriptId)) {
             				saveScriptToCurrentFilepath(generatedScript);

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -270,15 +270,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
             generatedScriptId -> {
             	scriptGeneratorModel.getScriptFromId(generatedScriptId).ifPresentOrElse(generatedScript -> {
             		if (nicosScriptIds.contains(generatedScriptId)) {
-            			QueueScriptPreviewDialog scriptPreview = new QueueScriptPreviewDialog(Display.getDefault().getActiveShell(), generatedScript);
-            			if (scriptPreview.askIfPreviewScript()) {
-            				if (scriptPreview.open() == IDialogConstants.OK_ID) {
-            					firePropertyChange(NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
-            				}
-            			}
-            			else {
-            				firePropertyChange(NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
-            			}
+            			previewScriptOrQueueDirectly(generatedScript);
             		} else {
             			if (scriptsToGenerateToCurrentFilepath.contains(generatedScriptId)) {
             				saveScriptToCurrentFilepath(generatedScript);
@@ -297,6 +289,18 @@ public class ScriptGeneratorViewModel extends ModelObject {
         });
     });
 
+    }
+    
+    private void previewScriptOrQueueDirectly(String generatedScript) {
+		QueueScriptPreviewDialog scriptPreview = new QueueScriptPreviewDialog(Display.getDefault().getActiveShell(), generatedScript);
+		if (scriptPreview.askIfPreviewScript()) {
+			if (scriptPreview.open() == IDialogConstants.OK_ID) {
+				firePropertyChange(NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
+			}
+		}
+		else {
+			firePropertyChange(NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
+		}
     }
     
     private void saveScriptToCurrentFilepath(String generatedScript) {


### PR DESCRIPTION
### Description of work

Added optional dialog with preview of the generated script.
If user chooses to preview the script before queuing, the preview dialog with the script will be displayed. The script can then be queued or cancelled.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/4170

### Acceptance criteria

* Users can preview the generated script(s) before sending them to NICOS

### Unit tests

N/A

### System tests

https://github.com/ISISComputingGroup/System_Tests_UI_E4/pull/105

### Documentation
https://github.com/ISISComputingGroup/IBEX/pull/6638

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

