### PR TITLE
Add feedback on Run Control screen

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/META-INF/MANIFEST.MF
@@ -18,3 +18,4 @@ Require-Bundle: org.eclipse.ui,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.ui.runcontrol
+Import-Package: uk.ac.stfc.isis.ibex.ui.blocks.groups

--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/EditRunControlDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/EditRunControlDialog.java
@@ -35,6 +35,7 @@ import uk.ac.stfc.isis.ibex.configserver.ConfigServer;
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
 import uk.ac.stfc.isis.ibex.runcontrol.RunControlServer;
 import uk.ac.stfc.isis.ibex.ui.runcontrol.RunControlViewModel;
+import uk.ac.stfc.isis.ibex.ui.runcontrol.commands.RunControlHandler;
 import uk.ac.stfc.isis.ibex.validators.ErrorMessage;
 
 /**
@@ -48,6 +49,7 @@ public class EditRunControlDialog extends TitleAreaDialog {
 	private final RunControlServer runControlServer;
 	private RunControlSettingsPanel editor;
 	private final RunControlViewModel viewModel;
+	private RunControlHandler handler;
 	
 	/**
 	 * Creates a dialog for configuring the run-control settings.
@@ -85,7 +87,7 @@ public class EditRunControlDialog extends TitleAreaDialog {
 	protected Control createDialogArea(Composite parent) {
         setTitle("Configure Run Control");
 		
-		editor = new RunControlSettingsPanel(parent, SWT.NONE, configServer, runControlServer, viewModel);
+		editor = new RunControlSettingsPanel(this, parent, SWT.NONE, configServer, runControlServer, viewModel);
 		editor.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 
 		return editor;

--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlEditorPanel.java
@@ -19,9 +19,11 @@
 
 package uk.ac.stfc.isis.ibex.ui.runcontrol.dialogs;
 
+import org.apache.logging.log4j.Logger;
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
+import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.DisposeEvent;
@@ -35,13 +37,26 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.browser.IWebBrowser;
 
 import uk.ac.stfc.isis.ibex.configserver.ConfigServer;
+import uk.ac.stfc.isis.ibex.configserver.Configurations;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.configserver.displaying.DisplayBlock;
 import uk.ac.stfc.isis.ibex.epics.observing.Subscription;
 import uk.ac.stfc.isis.ibex.epics.writing.SameTypeWriter;
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
+import uk.ac.stfc.isis.ibex.runcontrol.RunControlActivator;
+import uk.ac.stfc.isis.ibex.runcontrol.RunControlServer;
+import uk.ac.stfc.isis.ibex.ui.configserver.commands.EditBlockHandler;
 import uk.ac.stfc.isis.ibex.ui.runcontrol.RunControlViewModel;
+import uk.ac.stfc.isis.ibex.ui.runcontrol.commands.RunControlHandler;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * A panel to edit the run control settings for the selected block.
@@ -50,7 +65,8 @@ import uk.ac.stfc.isis.ibex.ui.runcontrol.RunControlViewModel;
 public class RunControlEditorPanel extends Composite {
     private static final String RESET_ALL_DIALOG_TITLE = "Confirm Run-Control Restore";
     private static final String RESET_ALL_DIALOG_MESSAGE = "Are you sure you want to restore all run-control settings to their configuration values?";
-    private final ConfigServer configServer;
+	private static final String CONFIRM_CHANGES_HINT = "WARNING! The settings applied here are not permanent and will be overriden if current configuration changes (see: User Manual - Run Controls)";
+	private final ConfigServer configServer;
 	private final Label name;
 	private final Text txtLowLimit;
 	private final Text txtHighLimit;
@@ -59,15 +75,21 @@ public class RunControlEditorPanel extends Composite {
 	private final Button btnSend;
     private final Button btnRestoreSingle;
     private final Button btnRestoreAll;
+	private final Button btnShowManual;
+	private final Button btnDisplayBlockInfo;
     private final Label spacerLabel;
     private final Label spacerLabel2;
     private final Label spacerLabel3;
     private Group grpGlobalSettings;
+    private Group grpAdditionalSection;
     private boolean canSend;
+    private DisplayBlock currentBlock;
 
     private final RunControlViewModel viewModel;
 	
     private Subscription saveAsSubscription;
+    
+    private static final Logger LOG = IsisLog.getLogger(RunControlEditorPanel.class);
 
 	/**
 	 * Disable the send button if does not have permission to edit configs.
@@ -91,15 +113,17 @@ public class RunControlEditorPanel extends Composite {
      *            The config server object used to write to the instrument.
      * @param viewModel
      *            The view model for this panel.
+     * @param dialog
+     * 			  The initial dialog that opened this panel.
+     *            
      */
-    public RunControlEditorPanel(Composite parent, int style, ConfigServer configServer,
+    public RunControlEditorPanel(EditRunControlDialog dialog, Composite parent, int style, ConfigServer configServer,
             final RunControlViewModel viewModel) {
 		super(parent, style);
-		
 		this.configServer = configServer;
         this.viewModel = viewModel;
 
-        setLayout(new GridLayout(2, false));
+        setLayout(new GridLayout(3, false));
 
 		Group grpSelectedSetting = new Group(this, SWT.NONE);
         grpSelectedSetting.setText("Block Settings");
@@ -160,13 +184,14 @@ public class RunControlEditorPanel extends Composite {
             }
         });
         btnRestoreSingle.setEnabled(false);
-
+        
 		btnSend = new Button(grpSelectedSetting, SWT.NONE);
 		btnSend.setText("Apply Changes");
         btnSend.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 3, 1));
         btnSend.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
+            	dialog.setMessage(CONFIRM_CHANGES_HINT, IMessageProvider.INFORMATION);
                 viewModel.sendChanges();
             }
         });
@@ -183,6 +208,38 @@ public class RunControlEditorPanel extends Composite {
         btnRestoreAll.setLayoutData(gdBtnRestoreAll);
         btnRestoreAll.setText("Restore All \n Configuration Values");
         btnRestoreAll.addSelectionListener(restoreAllConfigurationValues);
+        
+        grpAdditionalSection = new Group(this, SWT.NONE);
+        grpAdditionalSection.setText("Additional");
+        grpAdditionalSection.setLayoutData(new GridData(SWT.LEFT, SWT.FILL, false, false, 1, 1));
+        grpAdditionalSection.setLayout(new GridLayout(2, false));
+        
+		btnShowManual = new Button(grpAdditionalSection,  SWT.WRAP | SWT.PUSH);
+		GridData gdBtnManual = new GridData(SWT.CENTER, SWT.CENTER, true, true, 1, 1);
+		gdBtnManual.widthHint = 100;
+		btnShowManual.setLayoutData(gdBtnManual);
+		btnShowManual.setText("Show Manual \n Run Control");
+		btnShowManual.addSelectionListener(new SelectionAdapter() {
+	        @Override
+	        public void widgetSelected(SelectionEvent e) {
+	        		openLink("https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Menu-Bar#run-control-menu");
+	            }
+	        }
+		);
+		
+		btnDisplayBlockInfo = new Button(grpAdditionalSection,  SWT.WRAP | SWT.PUSH);
+		GridData gdBtnBlockInfo = new GridData(SWT.CENTER, SWT.CENTER, true, true, 1, 1);
+		gdBtnBlockInfo.widthHint = 100;
+		btnDisplayBlockInfo.setLayoutData(gdBtnBlockInfo);
+		btnDisplayBlockInfo.setText("Edit Host \n Configuration");
+		btnDisplayBlockInfo.addSelectionListener(new SelectionAdapter() {
+	        @Override
+	        public void widgetSelected(SelectionEvent e) {
+	        	new EditBlockHandler(currentBlock.getName()).execute(getShell());
+	            }
+	        }
+		);
+		btnDisplayBlockInfo.setEnabled(false);
 
         // A bit of a work-around to see if we have write permissions
         // by seeing if we are able to edit the config.
@@ -221,6 +278,7 @@ public class RunControlEditorPanel extends Composite {
         chkInvalid.setEnabled(enabled);
         btnRestoreSingle.setEnabled(enabled);
         viewModel.setSendEnabled(enabled);
+        btnDisplayBlockInfo.setEnabled(enabled);
     }
 
     /**
@@ -241,6 +299,7 @@ public class RunControlEditorPanel extends Composite {
         setAllEnabled(canSend);
 
 		name.setText(block.getName());
+		currentBlock = block;
 	}
 
     private SelectionAdapter restoreAllConfigurationValues = new SelectionAdapter() {
@@ -252,4 +311,21 @@ public class RunControlEditorPanel extends Composite {
             }
         }
     };
+    
+    /**
+     * Helper method for opening links from a url presented as string
+     * 
+     * @param url
+     * 			the string that represents url to be opened in a browser.
+     */
+    private void openLink(String url) {
+        try {
+        	IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser();
+			browser.openURL(new URL(url));
+        } catch (PartInitException ex) {
+		    LoggerUtils.logErrorWithStackTrace(LOG, "Failed to open URL in browser: " + url, ex);
+		} catch (MalformedURLException ex) {
+			LoggerUtils.logErrorWithStackTrace(LOG, "Failed to open URL in browser: " + url, ex);
+		}
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlEditorPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlEditorPanel.java
@@ -218,7 +218,7 @@ public class RunControlEditorPanel extends Composite {
 		GridData gdBtnManual = new GridData(SWT.CENTER, SWT.CENTER, true, true, 1, 1);
 		gdBtnManual.widthHint = 100;
 		btnShowManual.setLayoutData(gdBtnManual);
-		btnShowManual.setText("Show Manual \n Run Control");
+		btnShowManual.setText("Show User Manual \n Run Control");
 		btnShowManual.addSelectionListener(new SelectionAdapter() {
 	        @Override
 	        public void widgetSelected(SelectionEvent e) {

--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlSettingsPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlSettingsPanel.java
@@ -39,6 +39,7 @@ import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 import uk.ac.stfc.isis.ibex.runcontrol.RunControlServer;
 import uk.ac.stfc.isis.ibex.ui.runcontrol.RunControlViewModel;
+import uk.ac.stfc.isis.ibex.ui.runcontrol.commands.RunControlHandler;
 
 /**
  * UI elements for editing run control settings, as used by run control dialog.
@@ -72,8 +73,9 @@ public class RunControlSettingsPanel extends Composite {
      * @param configServer the configuration server
      * @param runControlServer the runcontrol server
      * @param viewModel the view model
+     * @param dialog The initial dialog that opened this panel
      */
-	public RunControlSettingsPanel(Composite parent, int style, ConfigServer configServer, RunControlServer runControlServer,
+	public RunControlSettingsPanel(EditRunControlDialog dialog, Composite parent, int style, ConfigServer configServer, RunControlServer runControlServer,
 			RunControlViewModel viewModel) {
 		super(parent, style);
 		
@@ -88,7 +90,7 @@ public class RunControlSettingsPanel extends Composite {
 		table.setLayoutData(gdTable);
         table.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1));
 		
-        editor = new RunControlEditorPanel(this, SWT.NONE, this.configServer, viewModel);
+        editor = new RunControlEditorPanel(dialog, this, SWT.NONE, this.configServer, viewModel);
         
         config.addPropertyChangeListener(updateTable, true);
         table.addSelectionChangedListener(new ISelectionChangedListener() {

--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlSettingsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlSettingsTable.java
@@ -69,7 +69,9 @@ public class RunControlSettingsTable extends DataboundTable<DisplayBlock> {
                     @Override
 					public String stringFromRow(DisplayBlock setting) {
                         if (setting != null) {
-                            return setting.getName();
+                        	if (setting.getName() != null) {
+                        		return setting.getName();
+                        	}
                         }
                         return "";
                     }
@@ -81,7 +83,9 @@ public class RunControlSettingsTable extends DataboundTable<DisplayBlock> {
                     @Override
 					public String stringFromRow(DisplayBlock setting) {
                         if (setting != null) {
-                            return setting.getValue();
+                        	if (setting.getValue() != null) {
+                        		return setting.getValue();
+                        	}
                         }
                         return "";
                     }
@@ -93,7 +97,9 @@ public class RunControlSettingsTable extends DataboundTable<DisplayBlock> {
                     @Override
 					public String stringFromRow(DisplayBlock setting) {
                         if (setting != null) {
-                            return setting.getInRange().toString();
+                        	if (setting.getInRange() != null) {
+                        		return setting.getInRange().toString();
+                        	}
                         }
                         return "";
                     }
@@ -105,7 +111,9 @@ public class RunControlSettingsTable extends DataboundTable<DisplayBlock> {
                     @Override
 					public String stringFromRow(DisplayBlock setting) {
                         if (setting != null) {
-                            return setting.getRunControlEnabled().toString();
+                        	if (setting.getRunControlEnabled() != null) {
+                        		return setting.getRunControlEnabled().toString();
+                        	}
                         }
                         return "";
                     }
@@ -117,7 +125,9 @@ public class RunControlSettingsTable extends DataboundTable<DisplayBlock> {
                     @Override
 					public String stringFromRow(DisplayBlock setting) {
                         if (setting != null) {
-                            return setting.getRunControlLowLimit().toString();
+                        	if (setting.getRunControlLowLimit() != null) {
+                        		return setting.getRunControlLowLimit().toString();
+                        	}
                         }
                         return "";
                     }
@@ -130,7 +140,9 @@ public class RunControlSettingsTable extends DataboundTable<DisplayBlock> {
             @Override
 			public String stringFromRow(DisplayBlock setting) {
                 if (setting != null) {
-                    return setting.getRunControlHighLimit().toString();
+                	if (setting.getRunControlHighLimit() != null) {
+                		 return setting.getRunControlHighLimit().toString();
+                	}
                 }
                 return "";
             }
@@ -143,7 +155,9 @@ public class RunControlSettingsTable extends DataboundTable<DisplayBlock> {
             @Override
 			public String stringFromRow(DisplayBlock setting) {
                 if (setting != null) {
-                    return setting.getSuspendIfInvalid().toString();
+                	if (setting.getSuspendIfInvalid() != null) {
+                		return setting.getSuspendIfInvalid().toString();
+                	}
                 }
                 return "";
             }


### PR DESCRIPTION
### Description of work

Created functionality for the ticket's acceptance criteria. There is now a message popping up on top to inform user about non-permanent nature of changes in Run Control. 'Additional' group was added to contain Show Wiki page button and button to open configurations menu. The button is greyed out if no block is selected.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6488

### Acceptance criteria


    There is a message to this effect on the menu
    There is a link to the user manual providing more detail on how the differences between the run controls
    Optionally, there is a button that guides you to where you can edit the run control in the configuration


### Unit tests

There are no unit tests, see [ticket #6639](https://github.com/ISISComputingGroup/IBEX/issues/6639)

### System tests

There are no system tests, see [ticket #6639](https://github.com/ISISComputingGroup/IBEX/issues/6639)

### Documentation

[ticket #6639](https://github.com/ISISComputingGroup/IBEX/issues/6639) requires tests to be added to this

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

