### PR TITLE
Interrupt script console only if it exists

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/plugin.xml
@@ -86,6 +86,12 @@
       <handler
             class="uk.ac.stfc.isis.ibex.ui.scripting.InterruptScript"
             commandId="uk.ac.stfc.isis.ibex.ui.scripting.KillScript">
+    	      <activeWhen>
+		       <with variable="activeWorkbenchWindow.activePerspective">
+		          <equals value="uk.ac.stfc.isis.ibex.ui.reflectometry.perspective">
+		         </equals>
+		      </with>
+	   </activeWhen>
       </handler>
    </extension>
 

--- a/base/uk.ac.stfc.isis.ibex.ui.reflectometry/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.reflectometry/plugin.xml
@@ -81,16 +81,14 @@
             restorable="true">
       </view>
    </extension>
-   <extension
-         point="org.eclipse.ui.handlers">
-      <handler
-            class="uk.ac.stfc.isis.ibex.ui.scripting.InterruptScript"
-            commandId="uk.ac.stfc.isis.ibex.ui.scripting.KillScript">
-    	      <activeWhen>
-		       <with variable="activeWorkbenchWindow.activePerspective">
-		          <equals value="uk.ac.stfc.isis.ibex.ui.reflectometry.perspective">
-		         </equals>
-		      </with>
+   <extension point="org.eclipse.ui.handlers">
+      <handler class="uk.ac.stfc.isis.ibex.ui.scripting.InterruptScript"
+      commandId="uk.ac.stfc.isis.ibex.ui.scripting.KillScript">
+	     <activeWhen>
+	       <with variable="activeWorkbenchWindow.activePerspective">
+	          <equals value="uk.ac.stfc.isis.ibex.client.e4.product.perspective.reflectometry">
+	         </equals>
+	      </with>
 	   </activeWhen>
       </handler>
    </extension>

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/InterruptScript.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/InterruptScript.java
@@ -12,7 +12,10 @@ public class InterruptScript extends AbstractHandler {
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		ScriptConsole.getActiveScriptConsole().interrupt();
+		ScriptConsole console = ScriptConsole.getActiveScriptConsole();
+		if (console != null) {
+			console.interrupt();
+		}
 		return null;
 	}
 


### PR DESCRIPTION
### Description of work

Attempt to interrupt active scripting console only if one exists.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6238

### Acceptance criteria

Pressing Ctrl+C before the scripting console is open does not freeze the GUI

### Unit tests

N/A

### System tests

N/A

### Documentation
https://github.com/ISISComputingGroup/IBEX/pull/6648

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

