### PR TITLE
Script Gen: Focus on action delete, add key shortcut, minor renaming

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -445,10 +445,10 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	/**
 	 * Removes action at position index from ActionsTable.
 	 * 
-	 * @param actionsToDeletes the actions to delete.
+	 * @param actionsToDelete the actions to delete.
 	 */
-	public void deleteAction(List<ScriptGeneratorAction> actionsToDeletes) {
-		scriptGeneratorTable.deleteAction(actionsToDeletes);
+	public void deleteAction(List<ScriptGeneratorAction> actionsToDelete) {
+		scriptGeneratorTable.deleteAction(actionsToDelete);
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -226,12 +226,12 @@ public class ActionsTable extends ModelObject {
 
 	/**
 	 * Removes an action from the list in specified location.
-	 * @param actionsToDeletes
+	 * @param actionsToDelete
 	 * 		  	The actions to remove from the actions list.
 	 */
-	public void deleteAction(List<ScriptGeneratorAction> actionsToDeletes) {
+	public void deleteAction(List<ScriptGeneratorAction> actionsToDelete) {
 		final List<ScriptGeneratorAction> newList = new ArrayList<ScriptGeneratorAction>(actions);
-		newList.removeAll(actionsToDeletes);
+		newList.removeAll(actionsToDelete);
 		firePropertyChange(ACTIONS_PROPERTY, actions, actions = newList);
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ActionsViewTable.java
@@ -62,6 +62,8 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
 	*/
 	private static final int CTRL_C = 0x003; 
 	private static final int CTRL_V = 0x016;
+	private static final int CTRL_A = 0x001;
+	private static final int DEL = 0x07F;
 	private static final String TAB = "\t";
 	private static final String NEW_LINE = "\r\n";
 	private final ScriptGeneratorViewModel scriptGeneratorViewModel;
@@ -101,15 +103,20 @@ public class ActionsViewTable extends DataboundTable<ScriptGeneratorAction> {
 			public void keyPressed(KeyEvent e) {	 
 				if (e.character == CTRL_C) {	
 					 scriptGeneratorViewModel.copyActions(getSelectedTableData());
-			
 				} else if (e.character == CTRL_V) {
 					scriptGeneratorViewModel.pasteActions(table.getSelectionIndex());
+				} else if (e.character == CTRL_A) {
+					table.selectAll();
+				} else if (e.character == DEL) {
+					List<ScriptGeneratorAction> selected = selectedRows();
+					if (selected != null && !selected.isEmpty())  {
+						scriptGeneratorViewModel.deleteAction(selected);
+					}
 				}
 			}
 		});
-		
     }
-	
+		
     /**
      * Format String data such that copying and pasting into excel would work. Clipboard does not support
      * transferring/pasting data to excel so we format plain text data ourselves.

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -424,6 +424,7 @@ public class ScriptGeneratorView {
         
         btnDeleteAction = new Button(actionsControlsGrp, SWT.NONE);
         btnDeleteAction.setText("Delete Selected Actions");
+        btnDeleteAction.setToolTipText("Delete a single or multiple actions.\nTo select multiple actions, use Ctrl+Click or Shift+Click.");
         btnDeleteAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
         btnDeleteAction.addListener(SWT.Selection, e -> scriptGeneratorViewModel.deleteAction(table.selectedRows()));
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -398,7 +398,17 @@ public class ScriptGeneratorViewModel extends ModelObject {
      *             the actions to delete.
      */
     protected void deleteAction(List<ScriptGeneratorAction> actionsToDelete) {
+    int selectedIndex = viewTable.getSelectionIndex();
+    // Exclude the last empty row
+    int actionCount = viewTable.table().getItemCount() - 1;
+    // If last action is selected, select new last action, otherwise select next action
+    int toSelect = selectedIndex == actionCount - 1 ? selectedIndex - actionsToDelete.size() : selectedIndex - actionsToDelete.size() + 1;
+    
     scriptGeneratorModel.deleteAction(actionsToDelete);
+    
+    DISPLAY.asyncExec(() -> {
+    	viewTable.setCellFocus(toSelect, ActionsViewTable.NON_EDITABLE_COLUMNS_ON_LEFT);
+    });
     }
 
     /**


### PR DESCRIPTION
### Description of work

Add focus on action delete.
Add key shortcut for deleting actions.
Updated https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Using-the-Script-Generator.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5967

### Acceptance criteria

* Currently, after deleting an action the focus is lost. The focus should be put on the next action, or if the last action was deleted the new last action.
* A keyboard shortcut to delete the selected lines (this should be clearly documented).

### Unit tests

N/A

### System tests

N/A

### Documentation
https://github.com/ISISComputingGroup/IBEX/pull/6649

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

