### PR TITLE
IOC Log: add time to search datetime filter

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.log/src/uk/ac/stfc/isis/ibex/ui/log/widgets/SearchControl.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.log/src/uk/ac/stfc/isis/ibex/ui/log/widgets/SearchControl.java
@@ -322,9 +322,9 @@ public class SearchControl extends Canvas {
                 final String value = txtValue.getText();
 
                 final Calendar from = chkFrom.getSelection()
-                        ? dtFromDate.getDateTime() : null;
+                        ? getSearchDateAndTime(dtFromDate.getDateTime(), dtFromTime.getDateTime()) : null;
                 final Calendar to = chkTo.getSelection()
-                        ? dtToDate.getDateTime() : null;
+                        ? getSearchDateAndTime(dtToDate.getDateTime(), dtToTime.getDateTime())  : null;
 
                 runSearchJob(field, value, from, to);
 
@@ -348,6 +348,19 @@ public class SearchControl extends Canvas {
 
         searchJobThread.start();
 	}
+    
+    /**
+     * Get both the date and time search filter as one object.
+     * @param The search date filter.
+     * @param The search time filter.
+     * @return The search calendar date and time filter.
+     */
+    private Calendar getSearchDateAndTime(Calendar date, Calendar time) {
+    	date.set(Calendar.HOUR, time.get(Calendar.HOUR));
+    	date.set(Calendar.MINUTE, time.get(Calendar.MINUTE));
+    	date.set(Calendar.SECOND, time.get(Calendar.SECOND));
+    	return date;
+    }
 
     private void setProgressIndicatorsVisible(final boolean visible) {
 


### PR DESCRIPTION
### Description of work

Add time to the IOC log from & to date search filter, as before it was only checking the date.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5305

### Acceptance criteria

Messages can also be filtered by time.

### Unit tests

N/A

### System tests

N/A

### Documentation
https://github.com/ISISComputingGroup/IBEX/pull/6687

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

