### PR TITLE
Script Gen: handle missing notepad++

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/SaveScriptGeneratorFileMessageDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/SaveScriptGeneratorFileMessageDialog.java
@@ -83,7 +83,15 @@ public class SaveScriptGeneratorFileMessageDialog {
 		
 		if (openInEditor) {
 			try {
-				model.getFileHandler().openFile(filepath);
+				String notepadExe = "notepad";
+				try {
+					notepadExe = model.getFileHandler().findNotepadExe();
+				} catch (IOException e) {
+					MessageDialog.openWarning(parentShell, "Notepad++ not found",
+							"Notepad++ was not found, file will be opened using the default Windows Notepad.\n"
+							+ "Note: Installing Notepad++ is highly recommended.");
+				}
+				model.getFileHandler().openFile(filepath, notepadExe);
 			} catch (OpenFileException | IOException e) {
 				MessageDialog.openWarning(parentShell, "Error", "Failed to open file: " + e.getMessage());
 			}


### PR DESCRIPTION
### Description of work

When trying to open generated script file and Notepad++ is not found, display warning and open with the Windows Notepad.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6692

### Acceptance criteria

* Error message has been amended to give clearer information to user
* Optionally: Use normal Notepad instead and inform user they could/should obtain Notepad++
* There are tests for this

### Unit tests

N/A

### System tests

Not sure what is the best way of testing this, and if it's worth it. Let me know what you think

### Documentation
https://github.com/ISISComputingGroup/IBEX/pull/6699

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

