### PR TITLE
Added dialogs to confirm before deleting components or configs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteComponentsHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteComponentsHandler.java
@@ -28,7 +28,6 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.PlatformUI;
 
 import uk.ac.stfc.isis.ibex.managermode.ManagerModeModel;
 import uk.ac.stfc.isis.ibex.managermode.ManagerModePvNotConnectedException;

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteComponentsHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteComponentsHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.ui.PlatformUI;
 import uk.ac.stfc.isis.ibex.managermode.ManagerModeModel;
 import uk.ac.stfc.isis.ibex.managermode.ManagerModePvNotConnectedException;
 import uk.ac.stfc.isis.ibex.ui.configserver.DeleteComponentsViewModel;
+import uk.ac.stfc.isis.ibex.ui.configserver.commands.helpers.DeleteItemsDialogHelper;
 import uk.ac.stfc.isis.ibex.ui.configserver.dialogs.DeleteComponentsDialog;
 import uk.ac.stfc.isis.ibex.ui.configserver.dialogs.MultipleConfigsSelectionDialog;
 
@@ -49,16 +50,6 @@ public class DeleteComponentsHandler extends DisablingConfigHandler<Collection<S
 	public DeleteComponentsHandler() {
 		super(SERVER.deleteComponents());
 	}
-	
-	/**
-	 * Opens dialog to confirm deleting components
-	 * @param selectedConfigs Components that will be displayed in confirmation
-	 * @return
-	 */
-    private boolean deleteComponentsConfirmDialog(Collection<String> selectedComponents) {
-        return MessageDialog.openQuestion(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Confirm Delete Components",
-                "The following components " + selectedComponents + " will be permanently deleted. Are you sure you want to delete them?");
-    }
 
     /**
      * Open the delete components dialogue.
@@ -74,7 +65,8 @@ public class DeleteComponentsHandler extends DisablingConfigHandler<Collection<S
                 SERVER.componentsInfo().getValue(), viewModel.getDependencies().keySet(), compNamesWithFlags);
         if (dialog.open() == Window.OK) {
             Collection<String> toDelete = dialog.selectedConfigs();
-            if(deleteComponentsConfirmDialog(toDelete))
+            DeleteItemsDialogHelper helper = new DeleteItemsDialogHelper();
+            if(helper.deleteItemsConfirmDialog(toDelete, "Components"))
             {
                 Map<String, Collection<String>> selectedDependencies = viewModel.filterSelected(toDelete);
                 try {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteConfigsHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteConfigsHandler.java
@@ -33,6 +33,7 @@ import org.eclipse.ui.PlatformUI;
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
 import uk.ac.stfc.isis.ibex.managermode.ManagerModeModel;
 import uk.ac.stfc.isis.ibex.managermode.ManagerModePvNotConnectedException;
+import uk.ac.stfc.isis.ibex.ui.configserver.commands.helpers.DeleteItemsDialogHelper;
 import uk.ac.stfc.isis.ibex.ui.configserver.dialogs.MultipleConfigsSelectionDialog;
 
 /**
@@ -48,16 +49,6 @@ public class DeleteConfigsHandler extends DisablingConfigHandler<Collection<Stri
 	}
 	
 	/**
-	 * Opens dialog to confirm deleting configurations
-	 * @param selectedConfigs Configs that will be displayed in confirmation
-	 * @return
-	 */
-    private boolean deleteConfigsConfirmDialog(Collection<String> selectedConfigs) {
-        return MessageDialog.openQuestion(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Confirm Delete Configurations",
-                "The following configurations " + selectedConfigs + " will be permanently deleted. Are you sure you want to delete them?");
-    }
-	
-	/**
 	 * Open the delete configs dialogue.
 	 *
 	 * @param shell the shell
@@ -68,7 +59,8 @@ public class DeleteConfigsHandler extends DisablingConfigHandler<Collection<Stri
         MultipleConfigsSelectionDialog dialog = new MultipleConfigsSelectionDialog(shell, "Delete Configurations",
                 SERVER.configsInfo().getValue(), configNamesWithFlags, false, false);
 		if (dialog.open() == Window.OK) {
-	    	if(deleteConfigsConfirmDialog(dialog.selectedConfigs()))
+	        DeleteItemsDialogHelper helper = new DeleteItemsDialogHelper();
+	    	if(helper.deleteItemsConfirmDialog(dialog.selectedConfigs(), "Configurations"))
 	    	{
 			    try {		        
 			        configService.write(dialog.selectedConfigs());

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteConfigsHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteConfigsHandler.java
@@ -28,7 +28,6 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.ui.PlatformUI;
 
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
 import uk.ac.stfc.isis.ibex.managermode.ManagerModeModel;

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/DeleteItemsDialogHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/DeleteItemsDialogHelper.java
@@ -1,0 +1,19 @@
+package uk.ac.stfc.isis.ibex.ui.configserver.commands.helpers;
+
+import java.util.Collection;
+
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.ui.PlatformUI;
+
+public class DeleteItemsDialogHelper {
+	/**
+	 * Opens dialog to confirm deleting items
+	 * @param selectedItems Items that will be displayed in confirmation
+	 * @param itemsType The type of items (eg. Configurations) to be deleted
+	 * @return
+	 */
+    public boolean deleteItemsConfirmDialog(Collection<String> selectedItems, String itemsType) {
+        return MessageDialog.openQuestion(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Confirm Delete " + itemsType,
+                "The following " + itemsType.toLowerCase() + " " + selectedItems + " will be permanently deleted. Are you sure you want to delete them?");
+    }
+}


### PR DESCRIPTION
### Description of work

Added dialogs to confirm before deleting components or configs

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6627

### Acceptance criteria
- [x] Delete confirmation dialog is displayed before deleting a component/configuration 

- [ ] Squish test is added

### Unit tests

N/A

### System tests

N/A

### Documentation

N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

