### PR TITLE
Ticket6577 multiple gui clients running give warning

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.product/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Require-Bundle: org.eclipse.ui,
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.e4.product
+Import-Package: uk.ac.stfc.isis.ibex.preferences

--- a/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchAdvisor.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchAdvisor.java
@@ -37,10 +37,13 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
 	
 	private static final String DIALOG_BOX_TITLE = "Close the application?";
 	private static final String DIALOG_QUESTION = "Are you sure you want to close this application?";
+
+	private ApplicationWorkbenchWindowAdvisor windowAdvisor;
 	
     @Override
     public WorkbenchWindowAdvisor createWorkbenchWindowAdvisor(IWorkbenchWindowConfigurer configurer) {
-        return new ApplicationWorkbenchWindowAdvisor(configurer);
+    	windowAdvisor = new ApplicationWorkbenchWindowAdvisor(configurer);
+        return windowAdvisor;
     }
 
 	@Override
@@ -67,6 +70,9 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
         configurer.setSaveAndRestore(true);
 
 		Shell shell = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell();
+		if (windowAdvisor.shutDown) {
+			return true;
+		}
 		return MessageDialog.openQuestion(shell, DIALOG_BOX_TITLE, DIALOG_QUESTION);
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
@@ -154,7 +154,9 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
 		} catch (OverlappingFileLockException e1) {
 			return null;
 		} catch (IOException e) {
-		    throw new Error(e);
+			LOG.warn("Exception found while locking file.\n");
+		    e.printStackTrace();
+		    return null;
 		}
     }
 

--- a/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
@@ -22,7 +22,6 @@ package uk.ac.stfc.isis.ibex.e4.product;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
@@ -33,7 +32,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 import org.apache.logging.log4j.Logger;
 import org.eclipse.core.resources.ResourcesPlugin;

--- a/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
+++ b/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
@@ -229,6 +229,9 @@ public class PreferenceSupplier {
      */
     private static final String HIDE_SCRIPT_DEFINITION_ERRORS = "hide_script_definition_error_table";
     
+    /**
+     * User defined location for temporary folder.
+     */
     private static final String USER_TEMP_PATH = "temporary_files_folder";
     
     /**

--- a/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
+++ b/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
@@ -228,6 +228,13 @@ public class PreferenceSupplier {
      * Defines whether to hide script definition error table.
      */
     private static final String HIDE_SCRIPT_DEFINITION_ERRORS = "hide_script_definition_error_table";
+    
+    private static final String USER_TEMP_PATH = "temporary_files_folder";
+    
+    /**
+     * Default location for temporary folder for use by GUI.
+     */
+    private static final String DEFAULT_USER_TEMP_PATH = Paths.get(System.getProperty("user.home"), "AppData", "Local", "IBEX").toString();
 	
     /**
      * Gets a string from the IBEX preference store.
@@ -294,6 +301,15 @@ public class PreferenceSupplier {
      */
 	public String epicsUtilsPath() {
 		return getString(EPICS_UTILS_DIRECTORY, DEFAULT_EPICS_UTILS_DIRECTORY);
+	}
+	
+	/**
+	 * Gets the preference location for temporary files.
+	 * 
+	 * @return Temporary files directory
+	 */
+	public String tempFilePath() {
+		return getString(USER_TEMP_PATH, DEFAULT_USER_TEMP_PATH);
 	}
 	
 	/**


### PR DESCRIPTION
### Description of work

https://github.com/ISISComputingGroup/IBEX/issues/6577

Added warning to opening multiple clients. This is accomplished using combination of:
1. Temporary files in an user/local/IBEX/tmp folder [more here](https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Local-files-and-start-up)
2. Locking those temporary files to make sure files are not left-over after a crash
3. Detecting those files and checking for a lock at startup of every new instance of client

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6577

### Acceptance criteria
- [x]  if a second GUI is started, a warning dialogue notifies the user and asks if they wish to continue
- [ ] (optional) if it is easy/possible. one of the options could be "switch to existing gui"

### Unit tests


### System tests


### Documentation
New wiki page added https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Local-files-and-start-up
This can be helpful next time we want to change something in this area as now we have a temporary files folder
that can be re-used.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

