### PR TITLE
Added expected finish time to script generator

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
@@ -4,8 +4,6 @@ import java.time.LocalDateTime;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 import java.time.format.DateTimeFormatter;
 
-import org.eclipse.swt.widgets.Label;
-
 
 /***
  * 
@@ -13,11 +11,10 @@ import org.eclipse.swt.widgets.Label;
  *
  */
 public class ScriptGeneratorExpectedFinishTimer extends ModelObject implements Runnable{
-	private Label expectedFinishTime;
 	private volatile long timeEstimateVal;
+	private volatile String finishTime; 
 	
-	public ScriptGeneratorExpectedFinishTimer(Label expectedFinishTime, long timeEstimateVal) {
-		this.expectedFinishTime = expectedFinishTime;
+	public ScriptGeneratorExpectedFinishTimer(long timeEstimateVal) {
 		this.timeEstimateVal = timeEstimateVal;
 		System.out.println("made class");
 	}
@@ -25,11 +22,14 @@ public class ScriptGeneratorExpectedFinishTimer extends ModelObject implements R
 	public void SetTimeEstimateVal(long timeEstimateVal) {
 		this.timeEstimateVal = timeEstimateVal;
 	}
+	
+	public String getFinishTime() {
+		return finishTime;
+	}
 	public void run() {
 		LocalDateTime currentTime = LocalDateTime.now();
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
-		currentTime.plusSeconds(timeEstimateVal);
-		firePropertyChange("finishTimeVal", "now", "Expected Finish Time: "+ currentTime.format(formatter));
-		System.out.println("Expected Finish Time: "+ currentTime.format(formatter));
+		currentTime = currentTime.plusSeconds(timeEstimateVal);
+		firePropertyChange("finishTimeVal", finishTime, finishTime = "Expected Finish Time: "+ currentTime.format(formatter));
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
@@ -1,0 +1,34 @@
+package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.eclipse.core.databinding.beans.typed.BeanProperties;
+import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
+import org.eclipse.swt.widgets.Label;
+
+
+/***
+ * 
+ * Helper class that calculates expected finish time.
+ *
+ */
+public class ScriptGeneratorExpectedFinishTimer implements Runnable{
+	private Label expectedFinishTime;
+	private volatile long timeEstimateVal;
+	
+	public ScriptGeneratorExpectedFinishTimer(Label expectedFinishTime, long timeEstimateVal) {
+		this.expectedFinishTime = expectedFinishTime;
+		this.timeEstimateVal = timeEstimateVal;
+	}
+	
+	public void SetTimeEstimateVal(long timeEstimateVal) {
+		this.timeEstimateVal = timeEstimateVal;
+	}
+	public void run() {
+		LocalDateTime currentTime = LocalDateTime.now();
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+		expectedFinishTime.setText(currentTime.format(formatter));
+		
+	}
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
@@ -1,6 +1,7 @@
 package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
 
 import java.time.LocalDateTime;
+import uk.ac.stfc.isis.ibex.model.ModelObject;
 import java.time.format.DateTimeFormatter;
 
 import org.eclipse.swt.widgets.Label;
@@ -11,13 +12,14 @@ import org.eclipse.swt.widgets.Label;
  * Helper class that calculates expected finish time.
  *
  */
-public class ScriptGeneratorExpectedFinishTimer implements Runnable{
+public class ScriptGeneratorExpectedFinishTimer extends ModelObject implements Runnable{
 	private Label expectedFinishTime;
 	private volatile long timeEstimateVal;
 	
 	public ScriptGeneratorExpectedFinishTimer(Label expectedFinishTime, long timeEstimateVal) {
 		this.expectedFinishTime = expectedFinishTime;
 		this.timeEstimateVal = timeEstimateVal;
+		System.out.println("made class");
 	}
 	
 	public void SetTimeEstimateVal(long timeEstimateVal) {
@@ -27,6 +29,7 @@ public class ScriptGeneratorExpectedFinishTimer implements Runnable{
 		LocalDateTime currentTime = LocalDateTime.now();
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
 		currentTime.plusSeconds(timeEstimateVal);
-		expectedFinishTime.setText(currentTime.format(formatter));
+		firePropertyChange("finishTimeVal", "now", "Expected Finish Time: "+ currentTime.format(formatter));
+		System.out.println("Expected Finish Time: "+ currentTime.format(formatter));
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
@@ -28,7 +28,7 @@ public class ScriptGeneratorExpectedFinishTimer implements Runnable{
 	public void run() {
 		LocalDateTime currentTime = LocalDateTime.now();
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+		currentTime.plusSeconds(timeEstimateVal);
 		expectedFinishTime.setText(currentTime.format(formatter));
-		
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
@@ -14,7 +14,7 @@ public class ScriptGeneratorExpectedFinishTimer extends ModelObject implements R
 	private String finishTime; 
 	
 	/**
-	 * The default constructor
+	 * The default constructor.
 	 *
 	 */
 	public ScriptGeneratorExpectedFinishTimer() {
@@ -22,8 +22,8 @@ public class ScriptGeneratorExpectedFinishTimer extends ModelObject implements R
 	}
 	
 	/**
-	 * Function to set the current time estimate
-	 * @param timeEstimateVal the current time estimate of the script
+	 * Function to set the current time estimate.
+	 * @param timeEstimateVal the current time estimate of the script.
 	 */
 	public void SetTimeEstimateVal(long timeEstimateVal) {
 		this.timeEstimateVal = timeEstimateVal;

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
@@ -13,14 +13,27 @@ public class ScriptGeneratorExpectedFinishTimer extends ModelObject implements R
 	private volatile long timeEstimateVal;
 	private String finishTime; 
 	
+	/**
+	 * The default constructor
+	 *
+	 */
 	public ScriptGeneratorExpectedFinishTimer() {
 		this.timeEstimateVal = 0;
 	}
 	
+	/**
+	 * Function to set the current time estimate
+	 * @param timeEstimateVal the current time estimate of the script
+	 */
 	public void SetTimeEstimateVal(long timeEstimateVal) {
 		this.timeEstimateVal = timeEstimateVal;
 	}
 	
+	/**
+	 * Function to be ran by a scheduler every second.
+	 * 
+	 * Adds the timeEstimateVal to the current time and then alerts the gui that the property has changed.
+	 */
 	public void run() {
 		LocalDateTime currentTime = LocalDateTime.now();
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
 import java.time.format.DateTimeFormatter;
 
-
 /***
  * 
  * Helper class that calculates expected finish time.
@@ -12,24 +11,21 @@ import java.time.format.DateTimeFormatter;
  */
 public class ScriptGeneratorExpectedFinishTimer extends ModelObject implements Runnable{
 	private volatile long timeEstimateVal;
-	private volatile String finishTime; 
+	private String finishTime; 
 	
-	public ScriptGeneratorExpectedFinishTimer(long timeEstimateVal) {
-		this.timeEstimateVal = timeEstimateVal;
-		System.out.println("made class");
+	public ScriptGeneratorExpectedFinishTimer() {
+		this.timeEstimateVal = 0;
 	}
 	
 	public void SetTimeEstimateVal(long timeEstimateVal) {
 		this.timeEstimateVal = timeEstimateVal;
 	}
 	
-	public String getFinishTime() {
-		return finishTime;
-	}
 	public void run() {
 		LocalDateTime currentTime = LocalDateTime.now();
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
 		currentTime = currentTime.plusSeconds(timeEstimateVal);
-		firePropertyChange("finishTimeVal", finishTime, finishTime = "Expected Finish Time: "+ currentTime.format(formatter));
+		finishTime = "Expected Finish Time: "+ currentTime.format(formatter);
+		firePropertyChange("finishTimeVal", null, finishTime);
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorExpectedFinishTimer.java
@@ -3,8 +3,6 @@ package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import org.eclipse.core.databinding.beans.typed.BeanProperties;
-import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.swt.widgets.Label;
 
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -602,8 +602,11 @@ public class ScriptGeneratorView {
     bindingContext.bindValue(WidgetProperties.text().observe(estimateText),
         BeanProperties.value("timeEstimate").observe(scriptGeneratorViewModel));
     
-    scriptGeneratorViewModel.getFinishTimer().addPropertyChangeListener("finishTimeVal",
-    		e->{DISPLAY.asyncExec(()->{expectedFinishText.setText((String) e.getNewValue());});});
+    scriptGeneratorViewModel.getFinishTimer().addPropertyChangeListener("finishTimeVal", e->{
+    	DISPLAY.asyncExec(()->{
+    		expectedFinishText.setText((String) e.getNewValue());
+    	});
+    });
 
     bindToHasSelected(btnDeleteAction);
     bindToHasSelected(btnMoveActionUp);

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -387,13 +387,28 @@ public class ScriptGeneratorView {
 	        paste.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 	        paste.addListener(SWT.Selection, e -> scriptGeneratorViewModel.pasteActions(table.getSelectionIndex()));
 	        
+	        // Composite for the row containing  total estimated run time
+	        Composite scriptTimeGrp = new Composite(scriptInfoGrp, SWT.RIGHT);
+	        scriptTimeGrp.setLayoutData(new GridData(SWT.RIGHT, SWT.NONE, true, false, 1, 2));
+	        GridLayout scriptTimeLayout = new GridLayout(1, true);
+	        scriptTimeLayout.marginRight = 40;
+	        scriptTimeGrp.setLayout(scriptTimeLayout);
+	        
 	        // Label for the total estimated run time
-	        estimateText = new Label(scriptInfoGrp, SWT.RIGHT);
-	        estimateText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+	        estimateText = new Label(scriptTimeGrp, SWT.TOP);
+	        estimateText.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, true, false, 1, 1));
 	        String currentFont = estimateText.getFont().getFontData()[0].getName();
 	        Font font = new Font(estimateText.getDisplay(), new FontData(currentFont, 11, SWT.BOLD));
 	        estimateText.setFont(font);
 	        estimateText.setText("Total estimated run time: 0 seconds");
+	        
+	     // Label for the expected finish time
+	        expectedFinishText = new Label(scriptTimeGrp, SWT.BOTTOM);
+	        expectedFinishText.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, true, false, 1, 1));
+	        currentFont = expectedFinishText.getFont().getFontData()[0].getName();
+	        font = new Font(expectedFinishText.getDisplay(), new FontData(currentFont, 11, SWT.BOLD));
+	        expectedFinishText.setFont(font);
+	        expectedFinishText.setText("Expected Finish Time: 00:00:00");
 	
 	        // Composite for laying out new/delete/duplicate action buttons
 	        Composite actionsControlsGrp = new Composite(mainParent, SWT.NONE);

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -119,6 +119,7 @@ public class ScriptGeneratorView {
     private Label parametersFileText;
     private Label scriptGenerationTimeText;
     private Label estimateText;
+    private Label expectedFinishText;
     private Button queueScriptButton;
     private Button generateScriptButton;
     private Button generateScriptAsButton;

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -492,8 +492,7 @@ public class ScriptGeneratorView {
 	            helpText,
 	            globalLabel,
 	            globalParamText,
-	            globalParamComposite,
-                expectedFinishText);
+	            globalParamComposite);
 	        scriptGeneratorViewModel.createGlobalParamsWidgets();
 	        
         } else {
@@ -587,9 +586,8 @@ public class ScriptGeneratorView {
         Text helpText,
         List<Label> globalLabel,
         List<Text> globalParamText,
-        Composite globalParamsComposite,
-        Label expectedFinishTime) {
-    scriptGeneratorViewModel.bindScriptDefinitionLoader(scriptDefinitionSelector, helpText, globalLabel, globalParamText, globalParamsComposite, mainParent, expectedFinishTime);
+        Composite globalParamsComposite) {
+    scriptGeneratorViewModel.bindScriptDefinitionLoader(scriptDefinitionSelector, helpText, globalLabel, globalParamText, globalParamsComposite, mainParent);
 
     scriptGeneratorViewModel.bindActionProperties(table, generateScriptButton, generateScriptAsButton);
 
@@ -603,6 +601,9 @@ public class ScriptGeneratorView {
     
     bindingContext.bindValue(WidgetProperties.text().observe(estimateText),
         BeanProperties.value("timeEstimate").observe(scriptGeneratorViewModel));
+    
+    scriptGeneratorViewModel.getFinishTimer().addPropertyChangeListener("finishTimeVal",
+    		e->{DISPLAY.asyncExec(()->{expectedFinishText.setText((String) e.getNewValue());});});
 
     bindToHasSelected(btnDeleteAction);
     bindToHasSelected(btnMoveActionUp);

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -403,7 +403,7 @@ public class ScriptGeneratorView {
 	        estimateText.setFont(font);
 	        estimateText.setText("Total estimated run time: 0 seconds");
 	        
-	     // Label for the expected finish time
+	        // Label for the expected finish time
 	        expectedFinishText = new Label(scriptTimeGrp, SWT.BOTTOM);
 	        expectedFinishText.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, true, false, 1, 1));
 	        currentFont = expectedFinishText.getFont().getFontData()[0].getName();
@@ -492,7 +492,8 @@ public class ScriptGeneratorView {
 	            helpText,
 	            globalLabel,
 	            globalParamText,
-	            globalParamComposite);
+	            globalParamComposite,
+                expectedFinishText);
 	        scriptGeneratorViewModel.createGlobalParamsWidgets();
 	        
         } else {
@@ -586,8 +587,9 @@ public class ScriptGeneratorView {
         Text helpText,
         List<Label> globalLabel,
         List<Text> globalParamText,
-        Composite globalParamsComposite) {
-    scriptGeneratorViewModel.bindScriptDefinitionLoader(scriptDefinitionSelector, helpText, globalLabel, globalParamText, globalParamsComposite, mainParent);
+        Composite globalParamsComposite,
+        Label expectedFinishTime) {
+    scriptGeneratorViewModel.bindScriptDefinitionLoader(scriptDefinitionSelector, helpText, globalLabel, globalParamText, globalParamsComposite, mainParent, expectedFinishTime);
 
     scriptGeneratorViewModel.bindActionProperties(table, generateScriptButton, generateScriptAsButton);
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -208,7 +208,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     private ScriptGeneratorExpectedFinishTimer finishTimer;
     
     /**
-     * The Scheduler for finish timer
+     * The Scheduler for finish timer.
      */
     private ScheduledExecutorService scheduler;
     

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -700,15 +700,6 @@ public class ScriptGeneratorViewModel extends ModelObject {
     public ScriptGeneratorExpectedFinishTimer getFinishTimer() {
     	return this.finishTimer;
     }
-    
-    /**
-     * Get the Finish timer.
-     * @return The finish timer object of the view model.
-     */
-    public ScriptGeneratorExpectedFinishTimer getFinishTimer() {
-    	return this.finishTimer;
-    }
-    
 
     /**
      * Handle a change in the actions or their properties.

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -59,7 +59,6 @@ import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ScriptDefinitionWrap
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
 import uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs.SaveScriptGeneratorFileMessageDialog;
 import uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs.QueueScriptPreviewDialog;
-import uk.ac.stfc.isis.ibex.ui.scriptgenerator.views.ScriptGeneratorExpectedFinishTimer;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
 import uk.ac.stfc.isis.ibex.ui.widgets.StringEditingSupport;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -207,6 +206,11 @@ public class ScriptGeneratorViewModel extends ModelObject {
      * Class to handle updating the expected finish time.
      */
     private ScriptGeneratorExpectedFinishTimer finishTimer;
+    
+    /**
+     * The Scheduler for finish timer
+     */
+    private ScheduledExecutorService scheduler;
     
     /**
      * The reference to the singleton model that the ViewModel is to use.
@@ -687,6 +691,14 @@ public class ScriptGeneratorViewModel extends ModelObject {
      */
     public String getTimeEstimate() {
     	return displayString;
+    }
+    
+    /**
+     * Get the Finish timer.
+     * @return The finish timer object of the view model.
+     */
+    public ScriptGeneratorExpectedFinishTimer getFinishTimer() {
+    	return this.finishTimer;
     }
     
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -646,7 +646,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
 
 	    long totalSeconds = scriptGeneratorModel.getTotalEstimatedTime().isPresent() ? scriptGeneratorModel.getTotalEstimatedTime().get() : 0;
 	    String displayTotal = "Total estimated run time: " + changeSecondsToTimeFormat(totalSeconds);
-	
+	    finishTimer.SetTimeEstimateVal(totalSeconds);
 	    firePropertyChange("timeEstimate", displayString, displayString = displayTotal);
     }
 
@@ -678,6 +678,14 @@ public class ScriptGeneratorViewModel extends ModelObject {
      */
     public String getTimeEstimate() {
     	return displayString;
+    }
+    
+    /**
+     * Get the Finish timer.
+     * @return The finish timer object of the view model.
+     */
+    public ScriptGeneratorExpectedFinishTimer getFinishTimer() {
+    	return this.finishTimer;
     }
 
     /**
@@ -837,6 +845,9 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	    this.globalParamsComposite = scriptDefintionComposite;
 	    this.mainParent = mainParent;
 	    this.currentGlobals = new ArrayList<String>();
+	    this.finishTimer = new ScriptGeneratorExpectedFinishTimer();
+	    this.scheduler = Executors.newScheduledThreadPool(1);
+	    this.scheduler.scheduleWithFixedDelay(finishTimer, 0, 1, TimeUnit.SECONDS);
 	    scriptGeneratorModel.getScriptDefinitionLoader().addPropertyChangeListener(SCRIPT_DEFINITION_SWITCH_PROPERTY, scriptDefinitionSwitchHelpListener);
     }
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -16,6 +16,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -56,6 +59,7 @@ import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ScriptDefinitionWrap
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
 import uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs.SaveScriptGeneratorFileMessageDialog;
 import uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs.QueueScriptPreviewDialog;
+import uk.ac.stfc.isis.ibex.ui.scriptgenerator.views.ScriptGeneratorExpectedFinishTimer;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
 import uk.ac.stfc.isis.ibex.ui.widgets.StringEditingSupport;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -198,7 +202,12 @@ public class ScriptGeneratorViewModel extends ModelObject {
      * Default string to display for time estimation.
      */
     private String displayString = "Total estimated run time: 00:00:00";
-
+    
+    /**
+     * Class to handle updating the expected finish time.
+     */
+    private ScriptGeneratorExpectedFinishTimer finishTimer;
+    
     /**
      * The reference to the singleton model that the ViewModel is to use.
      */
@@ -687,6 +696,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
     public ScriptGeneratorExpectedFinishTimer getFinishTimer() {
     	return this.finishTimer;
     }
+    
 
     /**
      * Handle a change in the actions or their properties.


### PR DESCRIPTION
### Description of work
Added an expected finish time to script generator below the time estimate, the finish time is the current time + the time estimate

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/6483

### Acceptance criteria
The script generator has a finish time displayed beneath the time estimate.

### System tests
Squish tests at https://github.com/ISISComputingGroup/System_Tests_UI_E4/pull/108


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

