### PR TITLE
Add popup message on error

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic/src/uk/ac/stfc/isis/ibex/ui/synoptic/component/WritableComponentView.java
@@ -32,6 +32,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.wb.swt.SWTResourceManager;
 
@@ -134,9 +135,16 @@ public class WritableComponentView extends Composite {
                 BeanProperties.value("pvState", PvState.class).observe(property.sourceReadableProperty()), null, borderStrategy);
     }
 
-    private void sendValue() {
-        property.writer().uncheckedWrite(text.getText());
-        parent.setFocus();
-
-    }
+	private void sendValue() {
+		try {
+			property.writer().uncheckedWrite(text.getText());
+		} catch (RuntimeException e) {
+			MessageBox errorMessage = new MessageBox(getShell(), SWT.ICON_ERROR);
+			errorMessage.setMessage("Could not write to PV - is it missing the setpoint suffix :SP?\n"
+					+ "Check the PV address in the Synoptic setup dialog.");
+	        errorMessage.setText("Error setting value");
+	        errorMessage.open();
+		}
+		parent.setFocus();
+	}
 }


### PR DESCRIPTION
### Description of work

Synoptic write PVs do not automatically handle the distinction between readback and setpoint PVs, so if  you e.g. just have a block on the base PV and add this as a write PV on a synoptic, writing to it from the synoptic may not work.

Possible solutions I thought of:
1. Check for this condition on Edit Synoptic dialog and display warning
2. Check for this condition on failed write and retry with :SP appended
3. Check for this condition on failed write and pop up dialog

Ended up going with 3. My rationale was that 1 would give a lot of false positive (many write PVs do not need the :SP suffix), and 2, although arguably more seamless, would make the writes take twice as long, without telling the user why, which would mean it would likely stay like that forever. Thought it would be preferable to make the actual issue visible with suggestions how to fix (plus this was trivial to implement and the issue does not seem serious enough to warrant investing a lot of effort).

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/7023

### Acceptance criteria

- [ ] Trying to write to a PV that does not accept setpoints (e.g. `EUROTHRM_01:A01:TEMP`) brings up a sensible error message

### Unit tests

/

### System tests

/

### Documentation

/

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

