### PR TITLE
uncomment nicos code

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/NicosModel.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/NicosModel.java
@@ -126,17 +126,17 @@ public class NicosModel extends ModelObject {
         this.session = session;
         this.connectionJob = connectionJob;
         this.lastEntryTime = initialTime;
-//
-//        updateStatusJob = new RepeatingJob("update script status", UPDATE_STATUS_TIME) {
-//            @Override
-//            protected IStatus doTask(IProgressMonitor monitor) {
-//                updateScriptStatus();
-//                updateLogEntries();
-//                return Status.OK_STATUS;
-//            }
-//        };
-//        updateStatusJob.setRunning(false);
-//        this.connectionJob.schedule();
+
+        updateStatusJob = new RepeatingJob("update script status", UPDATE_STATUS_TIME) {
+            @Override
+            protected IStatus doTask(IProgressMonitor monitor) {
+                updateScriptStatus();
+                updateLogEntries();
+                return Status.OK_STATUS;
+            }
+        };
+        updateStatusJob.setRunning(false);
+        this.connectionJob.schedule();
     }
 
     private void failConnection(String message) {


### PR DESCRIPTION
Undo some local changes for stopping Nicos from trying to connect, that were accidentally committed previously. Fixes ibex_gui pipeline tests