### PR TITLE
Ticket6810 script generator click action table column header bug fix

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -1037,14 +1037,14 @@ public class ScriptGeneratorViewModel extends ModelObject {
         ColumnViewerToolTipSupport.enableFor(viewTable.viewer());
         
         // Add selection listener to table headers, to ensure actions remain visible
-		for (int i = 0; i <  viewTable.table().getColumns().length; i++) {
-			viewTable.table().getColumn(i).addSelectionListener(new SelectionAdapter() {
-				@Override
-				public void widgetSelected(SelectionEvent e) {
-					scriptGeneratorModel.reloadActions();
-				}
-			});
-		}
+	for (int i = 0; i <  viewTable.table().getColumns().length; i++) {
+		viewTable.table().getColumn(i).addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				scriptGeneratorModel.reloadActions();
+			}
+		});
+	}
     }
 
     /**


### PR DESCRIPTION
### Description of work

A bug fix for the Script Generator actions table that when clicking any of the table headers would cause all the actions within the table cells to disappear for the user, and wouldn't reappear until an edit function such as inserting or deleting an action was triggered.  

Note: Table headers are not keyboard selectable.

This PR adds a listener to each table header when constructing the columns after loading the current script definition. The selection listener triggers whenever the table header is clicked and fires `reloadActions()` to re-display the actions in the table immediately.

### Ticket

[*Ticket 6810*](https://github.com/ISISComputingGroup/IBEX/issues/6810)

### Acceptance criteria

- [ ] When clicking an actions table column header the actions do not dissappear
- [ ] Actions do not reorder when clicking a column header

<hr>

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

