### PR TITLE
Ticket7135 nicos reliability

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
+++ b/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
@@ -21,6 +21,9 @@
 -Dpython.import.site=false
 -XX:+CreateCoredumpOnCrash
 -Dlog4j2.formatMsgNoLookups=true
+--add-opens java.desktop/java.beans=ALL-UNNAMED
+--add-opens java.base/java.util=ALL-UNNAMED
+--add-opens java.base/java.lang=ALL-UNNAMED
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>

--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/NicosErrorState.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/NicosErrorState.java
@@ -36,7 +36,8 @@ public enum NicosErrorState {
     /**
      * Error for when the connection to nicos throws an exception.
      */
-    CONNECTION_FAILED("The connection to the script server failed"),
+    CONNECTION_FAILED("The connection to the script server failed. "
+    		+ "Check that the NICOSDAEMON IOC has been added to the current configuration and is running."),
     
     /**
      * Error for when a response was expected but none was received.

--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/NicosModel.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/NicosModel.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -140,8 +139,7 @@ public class NicosModel extends ModelObject {
     }
 
     private void failConnection(String message) {
-        setError(NicosErrorState.CONNECTION_FAILED);
-        LOG.error(message);
+        setError(NicosErrorState.CONNECTION_FAILED, message);
         connectionJob.setRunning(true);
         updateStatusJob.setRunning(false);
     }
@@ -182,6 +180,7 @@ public class NicosModel extends ModelObject {
         	setError(NicosErrorState.FAILED_LOGIN, loginSentMessageDetails.getFailureReason());
             return;
         } else {
+        	LOG.info(String.format("Successfully connected to NICOS on %s (%s)", instrument.name(), instrument.hostName()));
         	setError(NicosErrorState.NO_ERROR);
         }
         connectionJob.setRunning(false);
@@ -230,10 +229,14 @@ public class NicosModel extends ModelObject {
     }
 
     private void setError(NicosErrorState error, String additionalInformation) {
-    	firePropertyChange("error", this.error, this.error = error);
-    	if (!Objects.equals(error, NicosErrorState.NO_ERROR)) {
+    	// Don't spam connection failures repeatedly to the log - these are expected in the case where the NICOS
+    	// IOC has not been added to the configuration
+    	if (error != NicosErrorState.NO_ERROR && 
+    			!(this.error == NicosErrorState.CONNECTION_FAILED && error == NicosErrorState.CONNECTION_FAILED)) {
             LOG.error("NICOS error: " + error.toString() + ", " + Strings.nullToEmpty(additionalInformation));
     	}
+    	
+    	firePropertyChange("error", this.error, this.error = error);
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/comms/ZMQSession.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/comms/ZMQSession.java
@@ -84,7 +84,6 @@ public class ZMQSession {
         synchronized (zmq.getLock()) {
         	zmq.connect(connectionString);
         }
-        LOG.info("Connected to NICOS at " + connectionString);
     }
 
     private String createConnectionURI(InstrumentInfo instrument) {
@@ -133,7 +132,6 @@ public class ZMQSession {
     	var resp = sentMessage.getResponse();
         
         if (status == null || resp == null || Objects.equals(status, "")) {
-            LOG.warn("No response from server after sending " + sentMessage.toString());
             return SentMessageDetails.createSendFail(NO_DATA_RECEIVED);
         }
         

--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/comms/ZMQWrapper.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/comms/ZMQWrapper.java
@@ -114,7 +114,6 @@ public class ZMQWrapper {
      */
     public void connect(String connectionUri) throws ZMQException {
     	checkCommsLockHeld();
-    	LOG.info("Opening ZMQ connection to NICOS");
 
 		// disconnect old session first
 		disconnect();

--- a/base/uk.ac.stfc.isis.ibex.ui.banner/src/uk/ac/stfc/isis/ibex/ui/banner/models/ServerStatusViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.banner/src/uk/ac/stfc/isis/ibex/ui/banner/models/ServerStatusViewModel.java
@@ -1,7 +1,7 @@
 package uk.ac.stfc.isis.ibex.ui.banner.models;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import uk.ac.stfc.isis.ibex.epics.observing.BaseObserver;
 import uk.ac.stfc.isis.ibex.instrument.status.ServerStatusVariables;
@@ -21,8 +21,6 @@ public class ServerStatusViewModel extends ModelObject {
 	private ServerStatus psControlStatus = ServerStatus.UNKNOWN;
 	private ServerStatus alarmServerStatus = ServerStatus.UNKNOWN;
 	private ServerStatus overallStatus = ServerStatus.UNKNOWN;
-	
-	private List<ServerStatus> individualStatus = new ArrayList<ServerStatus>();
 	
 	/**
 	 * The constructor.
@@ -259,18 +257,19 @@ public class ServerStatusViewModel extends ModelObject {
 	public void refreshOverallStatus() {
 		ServerStatus statusToSet = ServerStatus.PARTIAL;
 		
-		individualStatus.clear();
-		individualStatus.add(runControlStatus);
-		individualStatus.add(blockServerStatus);
-		individualStatus.add(blockGatewayStatus);
-		individualStatus.add(isisDaeRunning);
-		individualStatus.add(instetcStatus);
-		individualStatus.add(dbServerStatus);
-		individualStatus.add(psControlStatus);
-		individualStatus.add(alarmServerStatus);
-		if (individualStatus.stream().allMatch(t -> t.equals(ServerStatus.UP))) {
+		final var individualStatus = List.of(
+				runControlStatus, 
+				blockServerStatus, 
+				blockGatewayStatus, 
+				isisDaeRunning, 
+				instetcStatus, 
+				dbServerStatus, 
+				psControlStatus, 
+				alarmServerStatus);
+
+		if (individualStatus.stream().allMatch(t -> Objects.equals(t, ServerStatus.UP))) {
 			statusToSet = ServerStatus.UP;
-		} else if (individualStatus.stream().allMatch(t -> t.equals(ServerStatus.DOWN) || t.equals(ServerStatus.UNKNOWN))) {
+		} else if (individualStatus.stream().allMatch(t -> Objects.equals(t, ServerStatus.DOWN) || Objects.equals(t, ServerStatus.UNKNOWN))) {
 			statusToSet = ServerStatus.DOWN;
 		} else {
 			statusToSet = ServerStatus.PARTIAL;


### PR DESCRIPTION
### Description of work

Don't log messages continuously to the GUI log file if NICOS cannot connect. This will now be an expected condition on many instruments which do not use NICOS.

Also fix a recurrent exception caused in the GUI by non-threadsafe code.

### Ticket

https://github.com/IsisComputingGroup/ibex/issues/7135

### Acceptance criteria

- GUI does not log repeated connection failures to NICOS
- GUI still logs the first connection failure after a working connection

### Unit tests



### System tests

See system tests PR

### Documentation

https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Running-Nicos

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

