### PR TITLE
Add warning on OPI if eurotherm started with no channels configured

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm.opi
@@ -298,7 +298,7 @@
       <show_scrollbar>true</show_scrollbar>
       <tooltip></tooltip>
       <transparent>true</transparent>
-      <visible>false</visible>
+      <visible>true</visible>
       <widget_type>Grouping Container</widget_type>
       <width>792</width>
       <wuid>4fbad31a:1436c3e166f:-6faf</wuid>
@@ -1118,7 +1118,7 @@
       <show_scrollbar>true</show_scrollbar>
       <tooltip></tooltip>
       <transparent>true</transparent>
-      <visible>true</visible>
+      <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
       <width>792</width>
       <wuid>-620d3863:17acd4438eb:-7b9f</wuid>
@@ -3382,6 +3382,15 @@ $(pv_value)</tooltip>
         <exp bool_exp="pvInt6 != 0">
           <value>false</value>
         </exp>
+        <exp bool_exp="pvInt7 != 0">
+          <value>false</value>
+        </exp>
+        <exp bool_exp="pvInt8 != 0">
+          <value>false</value>
+        </exp>
+        <exp bool_exp="pvInt9 != 0">
+          <value>false</value>
+        </exp>
         <pv trig="true">$(PV_ROOT):A01:ACTIVE</pv>
         <pv trig="true">$(PV_ROOT):A02:ACTIVE</pv>
         <pv trig="true">$(PV_ROOT):A03:ACTIVE</pv>
@@ -3389,6 +3398,9 @@ $(pv_value)</tooltip>
         <pv trig="true">$(PV_ROOT):A05:ACTIVE</pv>
         <pv trig="true">$(PV_ROOT):A06:ACTIVE</pv>
         <pv trig="true">$(PV_ROOT):A07:ACTIVE</pv>
+        <pv trig="true">$(PV_ROOT):A08:ACTIVE</pv>
+        <pv trig="true">$(PV_ROOT):A09:ACTIVE</pv>
+        <pv trig="true">$(PV_ROOT):A010:ACTIVE</pv>
       </rule>
     </rules>
     <scale_options>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm.opi
@@ -298,7 +298,7 @@
       <show_scrollbar>true</show_scrollbar>
       <tooltip></tooltip>
       <transparent>true</transparent>
-      <visible>true</visible>
+      <visible>false</visible>
       <widget_type>Grouping Container</widget_type>
       <width>792</width>
       <wuid>4fbad31a:1436c3e166f:-6faf</wuid>
@@ -1118,7 +1118,7 @@
       <show_scrollbar>true</show_scrollbar>
       <tooltip></tooltip>
       <transparent>true</transparent>
-      <visible>false</visible>
+      <visible>true</visible>
       <widget_type>Grouping Container</widget_type>
       <width>792</width>
       <wuid>-620d3863:17acd4438eb:-7b9f</wuid>
@@ -3349,7 +3349,7 @@ $(pv_value)</tooltip>
     </border_color>
     <border_style>0</border_style>
     <border_width>1</border_width>
-    <enabled>true</enabled>
+    <enabled>false</enabled>
     <font>
       <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
     </font>
@@ -3359,38 +3359,30 @@ $(pv_value)</tooltip>
     <height>37</height>
     <horizontal_alignment>1</horizontal_alignment>
     <name>Label_2</name>
-    <rules>
-      <rule name="Rule" prop_id="visible" out_exp="false">
-        <exp bool_exp="pvInt0 != 0">
-          <value>false</value>
-        </exp>
-        <exp bool_exp="pvInt1 != 0">
-          <value>false</value>
-        </exp>
-        <exp bool_exp="pvInt2 != 0">
-          <value>false</value>
-        </exp>
-        <exp bool_exp="pvInt3 != 0">
-          <value>false</value>
-        </exp>
-        <exp bool_exp="pvInt4 != 0">
-          <value>false</value>
-        </exp>
-        <exp bool_exp="pvInt5 != 0">
-          <value>false</value>
-        </exp>
-        <exp bool_exp="pvInt6 != 0">
-          <value>false</value>
-        </exp>
-        <exp bool_exp="pvInt7 != 0">
-          <value>false</value>
-        </exp>
-        <exp bool_exp="pvInt8 != 0">
-          <value>false</value>
-        </exp>
-        <exp bool_exp="pvInt9 != 0">
-          <value>false</value>
-        </exp>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts>
+      <path pathString="EmbeddedPy" checkConnect="false" sfe="false" seoe="false">
+        <scriptName>EmbeddedScript</scriptName>
+        <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+states = []
+for tab in range(10):
+    if pvArray[tab].isConnected():
+        states.append(PVUtil.getLong(pvs[tab]))
+    else:
+        # If eurotherm is entirely down then we don't want the message displayed.
+        states.append(1)
+
+if all(state == 0 for state in states):
+    widget.setPropertyValue("visible", True);
+else:
+    widget.setPropertyValue("visible", False)
+]]></scriptText>
         <pv trig="true">$(PV_ROOT):A01:ACTIVE</pv>
         <pv trig="true">$(PV_ROOT):A02:ACTIVE</pv>
         <pv trig="true">$(PV_ROOT):A03:ACTIVE</pv>
@@ -3401,20 +3393,14 @@ $(pv_value)</tooltip>
         <pv trig="true">$(PV_ROOT):A08:ACTIVE</pv>
         <pv trig="true">$(PV_ROOT):A09:ACTIVE</pv>
         <pv trig="true">$(PV_ROOT):A010:ACTIVE</pv>
-      </rule>
-    </rules>
-    <scale_options>
-      <width_scalable>true</width_scalable>
-      <height_scalable>true</height_scalable>
-      <keep_wh_ratio>false</keep_wh_ratio>
-    </scale_options>
-    <scripts />
+      </path>
+    </scripts>
     <text>IOC is not configured with any eurotherm channels, check the &#xD;
 ADDR_x IOC macros are set correctly in the configuration.</text>
     <tooltip></tooltip>
     <transparent>true</transparent>
     <vertical_alignment>1</vertical_alignment>
-    <visible>true</visible>
+    <visible>false</visible>
     <widget_type>Label</widget_type>
     <width>367</width>
     <wrap_words>false</wrap_words>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm.opi
@@ -2324,7 +2324,7 @@ $(pv_value)</tooltip>
     <vertical_alignment>1</vertical_alignment>
     <visible>true</visible>
     <widget_type>Label</widget_type>
-    <width>781</width>
+    <width>415</width>
     <wrap_words>true</wrap_words>
     <wuid>4fdc1aa2:158de06471b:-7a02</wuid>
     <x>6</x>
@@ -2410,5 +2410,77 @@ $(pv_value)</tooltip>
     <wuid>-648922a4:1624e4fa0bd:-7f69</wuid>
     <x>6</x>
     <y>42</y>
+  </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <auto_size>false</auto_size>
+    <background_color>
+      <color red="255" green="255" blue="255" />
+    </background_color>
+    <border_color>
+      <color name="Invalid" red="255" green="0" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="Major" red="255" green="0" blue="0" />
+    </foreground_color>
+    <height>37</height>
+    <horizontal_alignment>1</horizontal_alignment>
+    <name>Label_2</name>
+    <rules>
+      <rule name="Rule" prop_id="visible" out_exp="false">
+        <exp bool_exp="pvInt0 != 0">
+          <value>false</value>
+        </exp>
+        <exp bool_exp="pvInt1 != 0">
+          <value>false</value>
+        </exp>
+        <exp bool_exp="pvInt2 != 0">
+          <value>false</value>
+        </exp>
+        <exp bool_exp="pvInt3 != 0">
+          <value>false</value>
+        </exp>
+        <exp bool_exp="pvInt4 != 0">
+          <value>false</value>
+        </exp>
+        <exp bool_exp="pvInt5 != 0">
+          <value>false</value>
+        </exp>
+        <exp bool_exp="pvInt6 != 0">
+          <value>false</value>
+        </exp>
+        <pv trig="true">$(PV_ROOT):A01:ACTIVE</pv>
+        <pv trig="true">$(PV_ROOT):A02:ACTIVE</pv>
+        <pv trig="true">$(PV_ROOT):A03:ACTIVE</pv>
+        <pv trig="true">$(PV_ROOT):A04:ACTIVE</pv>
+        <pv trig="true">$(PV_ROOT):A05:ACTIVE</pv>
+        <pv trig="true">$(PV_ROOT):A06:ACTIVE</pv>
+        <pv trig="true">$(PV_ROOT):A07:ACTIVE</pv>
+      </rule>
+    </rules>
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <text>IOC is not configured with any eurotherm channels, check the &#xD;
+ADDR_x IOC macros are set correctly in the configuration.</text>
+    <tooltip></tooltip>
+    <transparent>true</transparent>
+    <vertical_alignment>1</vertical_alignment>
+    <visible>true</visible>
+    <widget_type>Label</widget_type>
+    <width>367</width>
+    <wrap_words>false</wrap_words>
+    <wuid>3d21f8eb:1818aff4c3a:-26af</wuid>
+    <x>420</x>
+    <y>6</y>
   </widget>
 </display>


### PR DESCRIPTION
### Description of work

Adds a warning on the eurotherm OPI if the IOC is started but no channels have been configured

### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/7152#issuecomment-1163038700)

### Acceptance criteria

- Start the a eurotherm IOC with no channels configured (no `ADDR_x` macros), verify warning is present
- Start a eurotherm IOC with at least one channel configured (e.g. `ADDR_1=1`), verify warning is not present

### Unit tests

n/a opi only

### System tests

n/a opi only

### Documentation
 
n/a opi only

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

