### PR TITLE
Add BUSY pv to OPI

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/PEARLPC.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/PEARLPC.opi
@@ -1522,7 +1522,7 @@ $(pv_value)</tooltip>
       <width>34</width>
       <wuid>51572fc9:180cd97d03e:-7dda</wuid>
       <x>0</x>
-      <y>36</y>
+      <y>31</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -1563,7 +1563,7 @@ $(pv_value)</tooltip>
       <wrap_words>true</wrap_words>
       <wuid>51572fc9:180cd97d03e:-7ddb</wuid>
       <x>41</x>
-      <y>36</y>
+      <y>31</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -1620,8 +1620,8 @@ $(pv_value)</tooltip>
       <widget_type>LED</widget_type>
       <width>34</width>
       <wuid>51572fc9:180cd97d03e:-7dce</wuid>
-      <x>1</x>
-      <y>72</y>
+      <x>0</x>
+      <y>62</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -1661,8 +1661,8 @@ $(pv_value)</tooltip>
       <width>90</width>
       <wrap_words>true</wrap_words>
       <wuid>51572fc9:180cd97d03e:-7dcf</wuid>
-      <x>42</x>
-      <y>72</y>
+      <x>41</x>
+      <y>62</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -1720,7 +1720,7 @@ $(pv_value)</tooltip>
       <width>34</width>
       <wuid>51572fc9:180cd97d03e:-7d93</wuid>
       <x>0</x>
-      <y>107</y>
+      <y>93</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -1761,7 +1761,106 @@ $(pv_value)</tooltip>
       <wrap_words>true</wrap_words>
       <wuid>51572fc9:180cd97d03e:-7d92</wuid>
       <x>42</x>
-      <y>111</y>
+      <y>97</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.LED" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <bit>-1</bit>
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <bulb_border>3</bulb_border>
+      <bulb_border_color>
+        <color red="150" green="150" blue="150" />
+      </bulb_border_color>
+      <data_type>0</data_type>
+      <effect_3d>true</effect_3d>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+      </foreground_color>
+      <height>32</height>
+      <name>Nominal_Pressure_Warning_LED_8</name>
+      <off_color>
+        <color name="ISIS_Red_LED_Off" red="102" green="0" blue="0" />
+      </off_color>
+      <off_label>OFF</off_label>
+      <on_color>
+        <color name="ISIS_Red_LED_On" red="255" green="100" blue="100" />
+      </on_color>
+      <on_label>ON</on_label>
+      <pv_name>$(PV_ROOT_PEARLPC):BUSY</pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>true</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_boolean_label>true</show_boolean_label>
+      <square_led>true</square_led>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>LED</widget_type>
+      <width>34</width>
+      <wuid>3d21f8eb:1818aff4c3a:105b</wuid>
+      <x>0</x>
+      <y>124</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>28</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>Nominal_Pressure_Out_of_Range_Label_6</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_scrollbar>false</show_scrollbar>
+      <text>Motors moving</text>
+      <tooltip></tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>91</width>
+      <wrap_words>true</wrap_words>
+      <wuid>3d21f8eb:1818aff4c3a:105c</wuid>
+      <x>42</x>
+      <y>128</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.tab" version="1.0.0">


### PR DESCRIPTION
### Description of work

Adds motors moving flag to OPI. PV had already been implemented as part of earlier work.

Fixes https://github.com/ISISComputingGroup/IBEX/issues/7043
Fixes https://github.com/ISISComputingGroup/IBEX/issues/6765

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6765

### Acceptance criteria
- `BUSY` pv is displayed on OPI

### Unit tests

n/a/ opi only

### System tests

n/a/ opi only

### Documentation

n/a/ opi only

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

