### PR TITLE
Use /MIR flag on client install

### DIFF
--- a/build/install_client.bat
+++ b/build/install_client.bat
@@ -16,7 +16,7 @@ REM Copy the Client files across
 set APPSDIR=C:\Instrument\Apps
 set CLIENTDIR=%APPSDIR%\Client_E4
 mkdir %CLIENTDIR%
-robocopy "%BASEDIR%Client" "%CLIENTDIR%" /E /R:2 /MT /NFL /NDL /NP /NC /NS /LOG:NUL
+robocopy "%BASEDIR%Client" "%CLIENTDIR%" /MIR /R:2 /MT /NFL /NDL /NP /NC /NS /LOG:NUL
 set errcode=%errorlevel%
 if %errcode% GEQ 4 (
     @echo ERROR %errcode% in robocopy copying ibex client
@@ -27,7 +27,7 @@ REM Copy EPICS_UTILS across
 @echo %TIME% epics utils install started
 set UTILSDIR=%APPSDIR%\EPICS_UTILS
 mkdir %UTILSDIR%
-robocopy "\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\EPICS_UTILS\EPICS_UTILS" "%UTILSDIR%" /E /R:2 /MT /NFL /NDL /NP /NC /NS /LOG:NUL
+robocopy "\\isis.cclrc.ac.uk\inst$\Kits$\CompGroup\ICP\EPICS_UTILS\EPICS_UTILS" "%UTILSDIR%" /MIR /R:2 /MT /NFL /NDL /NP /NC /NS /LOG:NUL
 set errcode=%errorlevel%
 if %errcode% GEQ 4 (
     @echo ERROR %errcode% copying EPICS UTILS

--- a/build/install_script_generator.bat
+++ b/build/install_script_generator.bat
@@ -12,7 +12,7 @@ REM Copy the script generator files across
 set APPSDIR=C:\Instrument\Apps
 set SCRIPTGENDIR=%APPSDIR%\script_generator
 mkdir %SCRIPTGENDIR%
-robocopy "%BASEDIR%script_generator" "%SCRIPTGENDIR%" /E /R:2 /MT /NFL /NDL /NP /NC /NS /LOG:NUL
+robocopy "%BASEDIR%script_generator" "%SCRIPTGENDIR%" /MIR /R:2 /MT /NFL /NDL /NP /NC /NS /LOG:NUL
 if %errorlevel% geq 4 (
     @echo ERROR copying SCRIPT GENERATOR
 )


### PR DESCRIPTION
### Description of work

Use /MIR flag on robocopy to avoid accidentally leaving stale files behind after a deploy.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/7034

### Acceptance criteria

Old files are no longer left behind when a deploy "copies over" an old tree

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

