### PR TITLE
Fix checkstyle warnings

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/DefaultNamesTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/DefaultNamesTest.java
@@ -21,7 +21,7 @@ package uk.ac.stfc.isis.ibex.configserver.tests.editing;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/server/AddressesTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/server/AddressesTest.java
@@ -20,7 +20,7 @@
 package uk.ac.stfc.isis.ibex.configserver.tests.server;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 

--- a/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/SettingPeriodSettingsFromXmlTest.java
+++ b/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/SettingPeriodSettingsFromXmlTest.java
@@ -20,7 +20,7 @@
 package uk.ac.stfc.isis.ibex.dae.tests.periods;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/WritingXmlFromPeriodSettingsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.dae.tests/src/uk/ac/stfc/isis/ibex/dae/tests/periods/WritingXmlFromPeriodSettingsTest.java
@@ -20,7 +20,8 @@
 package uk.ac.stfc.isis.ibex.dae.tests.periods;
 
 import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/detectordiagnostics/DetectorDiagnosticsModel.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/detectordiagnostics/DetectorDiagnosticsModel.java
@@ -31,7 +31,6 @@ import org.eclipse.core.runtime.jobs.Job;
 import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.Observable;
-import uk.ac.stfc.isis.ibex.epics.observing.Subscription;
 import uk.ac.stfc.isis.ibex.epics.switching.InstrumentSwitchers;
 import uk.ac.stfc.isis.ibex.epics.switching.ObservableFactory;
 import uk.ac.stfc.isis.ibex.epics.switching.OnInstrumentSwitch;

--- a/base/uk.ac.stfc.isis.ibex.devicescreens/src/uk/ac/stfc/isis/ibex/devicescreens/components/ComponentType.java
+++ b/base/uk.ac.stfc.isis.ibex.devicescreens/src/uk/ac/stfc/isis/ibex/devicescreens/components/ComponentType.java
@@ -192,7 +192,7 @@ public enum ComponentType {
     MUSR_STEERING,
     /** Delay generators. */
     DELAY_GENERATORS,
-	/** Function generators */
+	/** Function generators. */
 	FUNCTION_GENERATOR;
 
     private Target target;

--- a/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
@@ -25,18 +25,11 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -75,8 +68,6 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
 	
 	private static final String MULTIPLE_INSTANCES_CHECKING_ERROR = "Exception encountered while checking for multiple instances.";
 	private static final String ANOTHER_INSTANCE_LOG_INFO = "Another instance of IBEX found running.";
-	private static final String TEMPORARY_FILE_LOCKED_ERROR = "Could not access temporary file due to a lock. Another process is "
-			+ "refusing to release the lock.";
     
     /**
      * Setting this flag to true allows workbench to close without prompt.

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/PerspectivesVisibleModel.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/PerspectivesVisibleModel.java
@@ -9,11 +9,9 @@ import java.util.stream.Collectors;
 
 import org.eclipse.e4.ui.model.application.MApplication;
 import org.eclipse.e4.ui.model.application.ui.advanced.MPerspective;
-import org.eclipse.e4.ui.model.application.ui.advanced.MPerspectiveStack;
 import org.eclipse.e4.ui.workbench.modeling.EModelService;
 import org.eclipse.e4.ui.workbench.modeling.EPartService;
 import org.eclipse.jface.dialogs.MessageDialog;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.PlatformUI;
 
 import com.google.gson.Gson;

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/controls/Button.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/controls/Button.java
@@ -42,7 +42,6 @@ public abstract class Button extends CLabel {
      * @param model
      *            ButtonViewModel
      */
-    @SuppressWarnings("unchecked")
     public Button(Composite parent, String imageUri, String tooltip, ButtonViewModel model) {
         super(parent, SWT.SHADOW_OUT);
 

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/controls/RefreshPvConnectionButton.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/controls/RefreshPvConnectionButton.java
@@ -12,8 +12,7 @@ import uk.ac.stfc.isis.ibex.instrument.Instrument;
 public class RefreshPvConnectionButton extends Button {
 
     private static final String REFRESH_PV_CONNECTION_URI = "platform:/plugin/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/icons/resetpv.png";
-    
-    private ButtonViewModel model;
+   
     
     /**
      * Constructor.
@@ -23,7 +22,6 @@ public class RefreshPvConnectionButton extends Button {
      */
 	public RefreshPvConnectionButton(Composite parent, ButtonViewModel model) {
 		super(parent, REFRESH_PV_CONNECTION_URI, "Refresh PVs: Refreshes connection to the PVs, restoring blocked connections", model);
-		this.model = model;
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/views/PerspectiveHidingDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/views/PerspectiveHidingDialog.java
@@ -35,6 +35,7 @@ import org.eclipse.swt.widgets.Button;
  * A dialog box for selecting which perspectives to show and hide.
  *
  */
+@SuppressWarnings("magicnumber")
 public class PerspectiveHidingDialog extends TitleAreaDialog {
     private PerspectivesTable table;
     private PerspectivesVisibleModel model;

--- a/base/uk.ac.stfc.isis.ibex.e4.ui/src/org/eclipse/wb/swt/ResourceManager.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui/src/org/eclipse/wb/swt/ResourceManager.java
@@ -147,15 +147,16 @@ public class ResourceManager extends SWTResourceManager {
 			CompositeImageDescriptor compositImageDesc = new CompositeImageDescriptor() {
 				@Override
 				protected void drawCompositeImage(int width, int height) {
-					drawImage(baseImage.getImageData(), 0, 0);
+					CachedImageDataProvider  imageProvider = createCachedImageDataProvider(baseImage);
+					drawImage(imageProvider, 0, 0);
 					if (corner == TOP_LEFT) {
-						drawImage(decorator.getImageData(), 0, 0);
+						drawImage(imageProvider, 0, 0);
 					} else if (corner == TOP_RIGHT) {
-						drawImage(decorator.getImageData(), bib.width - dib.width, 0);
+						drawImage(imageProvider, bib.width - dib.width, 0);
 					} else if (corner == BOTTOM_LEFT) {
-						drawImage(decorator.getImageData(), 0, bib.height - dib.height);
+						drawImage(imageProvider, 0, bib.height - dib.height);
 					} else if (corner == BOTTOM_RIGHT) {
-						drawImage(decorator.getImageData(), bib.width - dib.width, bib.height - dib.height);
+						drawImage(imageProvider, bib.width - dib.width, bib.height - dib.height);
 					}
 				}
 				@Override

--- a/base/uk.ac.stfc.isis.ibex.epics.tests/src/uk/ac/stfc/isis/ibex/epics/tests/writing/BaseWritableTest.java
+++ b/base/uk.ac.stfc.isis.ibex.epics.tests/src/uk/ac/stfc/isis/ibex/epics/tests/writing/BaseWritableTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import uk.ac.stfc.isis.ibex.epics.writing.OnCanWriteChangeListener;
 import uk.ac.stfc.isis.ibex.epics.writing.OnErrorListener;
 
-@SuppressWarnings({ "unchecked", "checkstyle:methodname" })
+@SuppressWarnings({ "checkstyle:methodname" })
 public class BaseWritableTest {
 
     private TestableBaseWritable<String> writable;

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/conversion/ExponentialOnThresholdFormat.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/conversion/ExponentialOnThresholdFormat.java
@@ -35,6 +35,7 @@ import java.text.ParsePosition;
  * format for doubles accounts for the number of fractional digits specified in
  * the default format.
  */
+@SuppressWarnings("serial")
 public class ExponentialOnThresholdFormat extends NumberFormat {
 
     private static final String EXPONENTIAL_PATTERN = "0.####E0";

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/writing/OnCanWriteChangeListener.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/writing/OnCanWriteChangeListener.java
@@ -8,5 +8,5 @@ public interface OnCanWriteChangeListener {
      * Called when the Writable becomes (un)available.
      * @param canWrite Whether the Writable can be written to. 
      */
-    public void onCanWriteChanged(boolean canWrite);
+    void onCanWriteChanged(boolean canWrite);
 }

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/writing/OnErrorListener.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/writing/OnErrorListener.java
@@ -8,5 +8,5 @@ public interface OnErrorListener {
      * Called when the Writable is in error.
      * @param e The error of the Writable.
      */
-    public void onError(Exception e);
+    void onError(Exception e);
 }

--- a/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/internal/ExperimentDetailsVariables.java
+++ b/base/uk.ac.stfc.isis.ibex.experimentdetails/src/uk/ac/stfc/isis/ibex/experimentdetails/internal/ExperimentDetailsVariables.java
@@ -63,7 +63,7 @@ public class ExperimentDetailsVariables {
     /** The writable for setting the current user details. **/
     public final Writable<UserDetails[]> userDetailsSetter;
 
-    private JsonSerialisingConverter<UserDetails[]> userDetailsSerialiser = new JsonSerialisingConverter(UserDetails[].class);
+    private JsonSerialisingConverter<UserDetails[]> userDetailsSerialiser = new JsonSerialisingConverter<UserDetails[]>(UserDetails[].class);
     
     public ExperimentDetailsVariables() {
         availableSampleParameters =

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/list/InstrumentListObservable.java
@@ -28,7 +28,6 @@ import java.util.function.Function;
 
 import org.apache.logging.log4j.Logger;
 
-import uk.ac.stfc.isis.ibex.epics.conversion.Convert;
 import uk.ac.stfc.isis.ibex.epics.conversion.json.JsonDeserialisingConverter;
 import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
 import uk.ac.stfc.isis.ibex.epics.observing.ConvertingObservable;

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalField.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalField.java
@@ -189,11 +189,11 @@ public enum JournalField {
     private final IJournalFormatter formatter;
     private final JournalSortDirection sortDirection;
 
-    private JournalField(String friendlyName, String sqlFieldName, JournalSortDirection sortDirection) {
+    JournalField(String friendlyName, String sqlFieldName, JournalSortDirection sortDirection) {
         this(friendlyName, sqlFieldName, new NoopJournalFormatter(), sortDirection);
     }
     
-    private JournalField(String friendlyName, String sqlFieldName, IJournalFormatter formatter, JournalSortDirection sortDirection) {
+    JournalField(String friendlyName, String sqlFieldName, IJournalFormatter formatter, JournalSortDirection sortDirection) {
         this.friendlyName = friendlyName;
         this.sqlFieldName = sqlFieldName;
         this.formatter = formatter;

--- a/base/uk.ac.stfc.isis.ibex.model/src/uk/ac/stfc/isis/ibex/model/HasStatus.java
+++ b/base/uk.ac.stfc.isis.ibex.model/src/uk/ac/stfc/isis/ibex/model/HasStatus.java
@@ -12,6 +12,6 @@ public interface HasStatus<T> {
 	 * 
 	 * @return the status.
 	 */
-	public T getStatus();
+	T getStatus();
 
 }

--- a/base/uk.ac.stfc.isis.ibex.nicos.tests/src/uk/ac/stfc/isis/ibex/nicos/NicosModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos.tests/src/uk/ac/stfc/isis/ibex/nicos/NicosModelTest.java
@@ -22,8 +22,8 @@
 package uk.ac.stfc.isis.ibex.nicos;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;

--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/NICOSMessage.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/messages/NICOSMessage.java
@@ -68,8 +68,7 @@ public abstract class NICOSMessage<TSEND, TRESP> {
      *             thrown when the conversion cannot take place.
      */
     public List<String> getMulti() throws ConversionException {
-        @SuppressWarnings("rawtypes")
-		JsonSerialisingConverter<List<TSEND>> serialiser = new JsonSerialisingConverter(List.class);
+		JsonSerialisingConverter<List<TSEND>> serialiser = new JsonSerialisingConverter<List<TSEND>>(List.class);
         return Arrays.asList(command, "", serialiser.apply(parameters));
     }
 

--- a/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlTest.java
+++ b/base/uk.ac.stfc.isis.ibex.opis.tests/src/uk/ac/stfc/isis/ibex/opis/tests/desc/XmlTest.java
@@ -9,8 +9,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.JAXBException;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXException;

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ActionsTableTest.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/ActionsTableTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.awt.Container;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,7 +19,6 @@ import org.junit.Test;
 
 import uk.ac.stfc.isis.ibex.scriptgenerator.JavaActionParameter;
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ActionsTable;
-import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
 
 /**
  * 

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/utils/StatusSwitchCounter.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator.tests/src/uk/ac/stfc/isis/ibex/scriptgenerator/tests/utils/StatusSwitchCounter.java
@@ -26,6 +26,7 @@ public class StatusSwitchCounter<T extends HasStatus<K>, K> implements PropertyC
 	 * Tally up a new property changed from one status to another.
 	 * {@inheritdoc}
 	 */
+	@SuppressWarnings("unchecked")
 	@Override
 	public void propertyChange(PropertyChangeEvent evt) {
 		T oldVal = (T) evt.getOldValue();

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorProperties.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorProperties.java
@@ -3,7 +3,7 @@ package uk.ac.stfc.isis.ibex.scriptgenerator;
 public class ScriptGeneratorProperties {
 	
 	 /**
-     * A property that denotes whether the language to generate and check validity errors in is supported,
+     * A property that denotes whether the language to generate and check validity errors in is supported.
      */
     public static final String LANGUAGE_SUPPORT_PROPERTY = "language_supported";
 

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorProperties.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorProperties.java
@@ -1,6 +1,11 @@
 package uk.ac.stfc.isis.ibex.scriptgenerator;
 
-public class ScriptGeneratorProperties {
+/**
+ * Contains properties used in the script generator.
+ */
+public final class ScriptGeneratorProperties {
+	private ScriptGeneratorProperties() {
+	}
 	
 	 /**
      * A property that denotes whether the language to generate and check validity errors in is supported.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/ScriptGeneratorSingleton.java
@@ -481,7 +481,7 @@ public class ScriptGeneratorSingleton extends ModelObject {
 	
 	/**
 	 * Get the action at the corresponding index or an empty optional.
-	 * 
+	 * @param actionIndex - The index of the action to get.
 	 * @return the action at the corresponding index or an empty optional.
 	 */
 	public Optional<ScriptGeneratorAction> getAction(Integer actionIndex) {

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScript.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScript.java
@@ -34,7 +34,7 @@ public class DynamicScript {
 			String id = idWithWhitespace.strip();
 			try {
 				return Integer.parseInt(id);
-			} catch(NumberFormatException e) {
+			} catch (NumberFormatException e) {
 				throw new DynamicScriptNameFormatException("Format should be like 'Script Generator: <Integer ID>'");
 			}
 		} else {

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScriptName.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScriptName.java
@@ -13,6 +13,7 @@ public class DynamicScriptName implements HasStatus<Optional<String>> {
 	
 	/**
 	 * Create a dynamic script name with the given optional name.
+	 * @param name - An optional string containing the name to set.
 	 */
 	public DynamicScriptName(Optional<String> name) {
 		this.name = name;

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScriptNameFormatException.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScriptNameFormatException.java
@@ -3,6 +3,7 @@ package uk.ac.stfc.isis.ibex.scriptgenerator.dynamicscripting;
 /**
  * An exception to throw when the format of a dynamic script is incorrect.
  */
+@SuppressWarnings("serial")
 public class DynamicScriptNameFormatException extends Exception {
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScriptingException.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScriptingException.java
@@ -3,6 +3,7 @@ package uk.ac.stfc.isis.ibex.scriptgenerator.dynamicscripting;
 /**
  * An exception that may occur when executing a script dynamically.
  */
+@SuppressWarnings("serial")
 public class DynamicScriptingException extends Exception {
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScriptingProperties.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/DynamicScriptingProperties.java
@@ -3,7 +3,9 @@ package uk.ac.stfc.isis.ibex.scriptgenerator.dynamicscripting;
 /**
  * Contains the properties used in dynamic scripting.
  */
-public class DynamicScriptingProperties {
+public final class DynamicScriptingProperties {
+	private DynamicScriptingProperties() {
+	}
 	
 	/**
 	 * A property to listen for when the status of the script in nicos has changed.

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/PausedState.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/PausedState.java
@@ -97,6 +97,8 @@ public class PausedState extends DynamicScriptingState {
 			case DynamicScriptingProperties.SCRIPT_PAUSED_PROPERTY:
 				handlePaused();
 				break;
+			default: // do nothing;
+				break;
 		}
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/PlayingState.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/dynamicscripting/PlayingState.java
@@ -113,6 +113,8 @@ public class PlayingState extends DynamicScriptingState {
 			case DynamicScriptingProperties.SCRIPT_PAUSED_PROPERTY:
 				handlePaused();
 				break;
+			default: // do nothing;
+				break;
 		}
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorContext.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/generation/GeneratorContext.java
@@ -170,7 +170,7 @@ public class GeneratorContext extends ModelObject {
      * @throws ExecutionException A failure to execute the call to generate.
      * @throws InterruptedException The call to generate was interrupted.
      */
-    public void refreshTimeEstimation(List<ScriptGeneratorAction> actions, ScriptDefinitionWrapper scriptDefinition,List<String> globalParams)
+    public void refreshTimeEstimation(List<ScriptGeneratorAction> actions, ScriptDefinitionWrapper scriptDefinition, List<String> globalParams)
             throws UnsupportedLanguageException, InterruptedException, ExecutionException {
         refreshTimeEstimation(actions, scriptDefinition, GeneratedLanguage.PYTHON, globalParams);
     }

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionWrapper.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/ScriptDefinitionWrapper.java
@@ -43,6 +43,7 @@ public interface ScriptDefinitionWrapper {
 	 * @param global_params The global parameters to check validity with.
 	 * @return The error if the arguments are not valid.
 	 */
+    @SuppressWarnings("checkstyle:parametername")
 	String parametersValid(Map<String, String> action, List<String> global_params);
 	
     /**
@@ -52,6 +53,7 @@ public interface ScriptDefinitionWrapper {
      * @param global_params The global parameters to refresh the time estimation with.
      * @return An estimate in seconds
      */
+    @SuppressWarnings("checkstyle:parametername")
     Number estimateTime(Map<String, String> action, List<String> global_params);
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/table/ActionsTable.java
@@ -45,7 +45,7 @@ public class ActionsTable extends ModelObject {
 	
 	/**
 	 * Get the action at the corresponding index or an empty optional.
-	 * 
+	 * @param actionIndex - The index of action to get.
 	 * @return the action at the corresponding index or an empty optional.
 	 */
 	public Optional<ScriptGeneratorAction> getAction(Integer actionIndex) {

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/VariablesTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/internal/VariablesTest.java
@@ -29,14 +29,12 @@ import java.util.Collection;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.stubbing.OngoingStubbing;
 import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.epics.switching.ObservableFactory;
 import uk.ac.stfc.isis.ibex.epics.switching.SwitchableObservable;
 import uk.ac.stfc.isis.ibex.epics.switching.WritableFactory;
 import uk.ac.stfc.isis.ibex.epics.writing.Writable;
 import uk.ac.stfc.isis.ibex.instrument.channels.ChannelType;
-import uk.ac.stfc.isis.ibex.instrument.channels.DefaultChannel;
 import uk.ac.stfc.isis.ibex.instrument.channels.DefaultChannelWithoutUnits;
 import uk.ac.stfc.isis.ibex.instrument.channels.StringChannel;
 import uk.ac.stfc.isis.ibex.synoptic.SynopticInfo;

--- a/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/xml/SynopticWrittenToXmlTest.java
+++ b/base/uk.ac.stfc.isis.ibex.synoptic.tests/src/uk/ac/stfc/isis/ibex/synoptic/tests/xml/SynopticWrittenToXmlTest.java
@@ -20,7 +20,8 @@
 package uk.ac.stfc.isis.ibex.synoptic.tests.xml;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.net.MalformedURLException;

--- a/base/uk.ac.stfc.isis.ibex.ui.about/src/uk/ac/stfc/isis/ibex/ui/about/AboutDialogBox.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.about/src/uk/ac/stfc/isis/ibex/ui/about/AboutDialogBox.java
@@ -19,17 +19,9 @@
 
 package uk.ac.stfc.isis.ibex.ui.about;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-
-import javax.imageio.ImageIO;
-import javax.swing.ImageIcon;
-
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -49,7 +41,6 @@ public class AboutDialogBox extends TitleAreaDialog {
 	private static final int HEIGHT = 400;
 	/** Name of the application */
 	private String applicationName;
-	private Image image;
 
 	/**
 	 * Construct a new about Ibex dialog box.

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteComponentsHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteComponentsHandler.java
@@ -65,8 +65,7 @@ public class DeleteComponentsHandler extends DisablingConfigHandler<Collection<S
         if (dialog.open() == Window.OK) {
             Collection<String> toDelete = dialog.selectedConfigs();
             DeleteItemsDialogHelper helper = new DeleteItemsDialogHelper();
-            if(helper.deleteItemsConfirmDialog(toDelete, "Components"))
-            {
+            if (helper.deleteItemsConfirmDialog(toDelete, "Components")) {
                 Map<String, Collection<String>> selectedDependencies = viewModel.filterSelected(toDelete);
                 try {
                     if (selectedDependencies.isEmpty()) {

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteConfigsHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/DeleteConfigsHandler.java
@@ -59,8 +59,7 @@ public class DeleteConfigsHandler extends DisablingConfigHandler<Collection<Stri
                 SERVER.configsInfo().getValue(), configNamesWithFlags, false, false);
 		if (dialog.open() == Window.OK) {
 	        DeleteItemsDialogHelper helper = new DeleteItemsDialogHelper();
-	    	if(helper.deleteItemsConfirmDialog(dialog.selectedConfigs(), "Configurations"))
-	    	{
+	    	if (helper.deleteItemsConfirmDialog(dialog.selectedConfigs(), "Configurations")) {
 			    try {		        
 			        configService.write(dialog.selectedConfigs());
 		            boolean noError = true;

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/DeleteItemsDialogHelper.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/helpers/DeleteItemsDialogHelper.java
@@ -7,10 +7,10 @@ import org.eclipse.ui.PlatformUI;
 
 public class DeleteItemsDialogHelper {
 	/**
-	 * Opens dialog to confirm deleting items
+	 * Opens dialog to confirm deleting items.
 	 * @param selectedItems Items that will be displayed in confirmation
 	 * @param itemsType The type of items (eg. Configurations) to be deleted
-	 * @return
+	 * @return The open dialog.
 	 */
     public boolean deleteItemsConfirmDialog(Collection<String> selectedItems, String itemsType) {
         return MessageDialog.openQuestion(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), "Confirm Delete " + itemsType,

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/DecoratedCellLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/DecoratedCellLabelProvider.java
@@ -28,12 +28,24 @@ import org.eclipse.jface.viewers.ViewerCell;
 
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
 
+/**
+ * Provides decorated Cell Labels.
+ *
+ * @param <TRow> the type of the row data
+ */
 public abstract class DecoratedCellLabelProvider<TRow> extends DataboundCellLabelProvider<TRow> {
 
 	private final List<CellDecorator<TRow>> decorators = new ArrayList<>();
 			
+	 /**
+     * Instantiates a new decorated cell label provider that tracks changes to
+     * one attribute.
+     *
+     * @param attributeMap the attribute map
+     * @param decorators - decorators to add to the cell
+     */
 	public DecoratedCellLabelProvider(
-			IObservableMap attributeMap, 
+			IObservableMap<TRow, ?> attributeMap, 
 			Collection<? extends CellDecorator<TRow>> decorators) {
 		super(attributeMap);
 		

--- a/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosControlButtonPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosControlButtonPanel.java
@@ -81,7 +81,6 @@ public class NicosControlButtonPanel extends Composite {
         bind();
     }
 
-    @SuppressWarnings("unchecked")
     private void bind() {
         bindingContext.bindValue(WidgetProperties.text().observe(btnTogglePause),
                 BeanProperties.value("toggleButtonText").observe(statusModel));

--- a/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosCurrentScriptContainer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosCurrentScriptContainer.java
@@ -29,7 +29,6 @@ import uk.ac.stfc.isis.ibex.ui.widgets.NumberedStyledText;
 @SuppressWarnings("checkstyle:magicnumber")
 public class NicosCurrentScriptContainer {
 
-    private Label lblCurrentScriptStatus;
     private StyledText txtCurrentScript;
     private final NicosModel model;
     private final DataBindingContext bindingContext;
@@ -71,7 +70,6 @@ public class NicosCurrentScriptContainer {
      * @param parent injected by eclipse
      */
 	@PostConstruct
-	@SuppressWarnings("unchecked")
     public void createCurrentScriptContainer(Composite parent) {
         parent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
         parent.setLayout(new GridLayout(1, false));

--- a/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosOutputContainer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosOutputContainer.java
@@ -27,7 +27,6 @@ public class NicosOutputContainer {
 	 * @param parent the parent injected by eclipse
 	 */
 	@PostConstruct
-	@SuppressWarnings("unchecked")
 	public void createOutputContainer(Composite parent) {
 		parent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 		parent.setLayout(new GridLayout(1, false));

--- a/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosQueueContainer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosQueueContainer.java
@@ -110,7 +110,6 @@ public class NicosQueueContainer {
 	 * @param parent the parent (injected by eclipse)
 	 */
 	@PostConstruct
-	@SuppressWarnings("unchecked")
 	public void createQueueContainer(Composite parent) {
 		GridData gdQueueContainer = new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1);
 		gdQueueContainer.heightHint = 300;

--- a/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosStatusContainer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/NicosStatusContainer.java
@@ -29,7 +29,6 @@ public class NicosStatusContainer {
 	 * @param parent injected by eclipse
 	 */
 	@PostConstruct
-	@SuppressWarnings("unchecked")
 	public void createStatusContainer(Composite parent) {
 		parent.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1));
 		parent.setLayout(new GridLayout(1, false));

--- a/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/dialogs/ScriptContentPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.nicos/src/uk/ac/stfc/isis/ibex/ui/nicos/dialogs/ScriptContentPanel.java
@@ -53,7 +53,6 @@ public class ScriptContentPanel extends Composite {
      * @param editableName
      *            whether the name of this script is editable
      */
-    @SuppressWarnings("unchecked")
     public ScriptContentPanel(Composite parent, int style, QueuedScript script, boolean editableName) {
 		super(parent, style);
         GridLayout gridLayout = new GridLayout(2, false);

--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/EditRunControlDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/EditRunControlDialog.java
@@ -35,7 +35,6 @@ import uk.ac.stfc.isis.ibex.configserver.ConfigServer;
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
 import uk.ac.stfc.isis.ibex.runcontrol.RunControlServer;
 import uk.ac.stfc.isis.ibex.ui.runcontrol.RunControlViewModel;
-import uk.ac.stfc.isis.ibex.ui.runcontrol.commands.RunControlHandler;
 import uk.ac.stfc.isis.ibex.validators.ErrorMessage;
 
 /**
@@ -49,7 +48,6 @@ public class EditRunControlDialog extends TitleAreaDialog {
 	private final RunControlServer runControlServer;
 	private RunControlSettingsPanel editor;
 	private final RunControlViewModel viewModel;
-	private RunControlHandler handler;
 	
 	/**
 	 * Creates a dialog for configuring the run-control settings.

--- a/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlSettingsPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.runcontrol/src/uk/ac/stfc/isis/ibex/ui/runcontrol/dialogs/RunControlSettingsPanel.java
@@ -39,7 +39,6 @@ import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 import uk.ac.stfc.isis.ibex.runcontrol.RunControlServer;
 import uk.ac.stfc.isis.ibex.ui.runcontrol.RunControlViewModel;
-import uk.ac.stfc.isis.ibex.ui.runcontrol.commands.RunControlHandler;
 
 /**
  * UI elements for editing run control settings, as used by run control dialog.

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ExecutingStatusDisplay.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ExecutingStatusDisplay.java
@@ -8,11 +8,28 @@ import org.eclipse.wb.swt.ResourceManager;
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ActionDynamicScriptingStatus;
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
 
-public class ExecutingStatusDisplay {
-	
+/**
+ * Class to handle displaying images for execution status.
+ *
+ */
+public final class ExecutingStatusDisplay {
+	private ExecutingStatusDisplay() {
+	}
+	/**
+	 * Image to use to show that a script is executing.
+	 */
     public static final Image EXECUTING_IMAGE = ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui.scriptgenerator", "icons/play.png");
+    /**
+     * Image to use to show pausing.
+     */
     public static final Image PAUSED_BEFORE_IMAGE = ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui.scriptgenerator", "icons/pause.png");
+    /**
+     * Image to use to show resuming.
+     */
     public static final Image PAUSED_DURING_IMAGE = ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui.scriptgenerator", "icons/resume.png");
+    /**
+     * Null image for not executing.
+     */
     public static final Image NOT_EXECUTING_IMAGE = null;
 	
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ExecutingStatusDisplay.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ExecutingStatusDisplay.java
@@ -16,6 +16,7 @@ public class ExecutingStatusDisplay {
     public static final Image NOT_EXECUTING_IMAGE = null;
 	
     /**
+     * @param status The scripting status.
      * @return The mark to display whether executing or not.
      */
 	public static Image getImage(ActionDynamicScriptingStatus status) {
@@ -34,7 +35,7 @@ public class ExecutingStatusDisplay {
 	/**
 	 * Get the ValidityDisplay from it's displayed text.
 	 * 
-	 * @param text The string to generate a Validity display element from.
+	 * @param optionalImage an image to generate a Validity display element from.
 	 * @return A ValidityDisplay element generated from the given string.
 	 */
 	public static ActionDynamicScriptingStatus fromImage(Optional<Image> optionalImage) {
@@ -59,6 +60,7 @@ public class ExecutingStatusDisplay {
 	 * Whether the actions executing status equals this enum.
 	 * 
 	 * @param action The action to check the executing status of.
+	 * @param status The status to check against.
 	 * @return True if the action and this enum have the same executing status or false if not.
 	 */
 	public static boolean equalsAction(ActionDynamicScriptingStatus status, ScriptGeneratorAction action) {

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorNicosViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorNicosViewModel.java
@@ -39,6 +39,10 @@ public class ScriptGeneratorNicosViewModel implements PropertyChangeListener {
 	private static final String RUN_BUTTON_TEXT = "Run";
 	private static final String RESUME_BUTTON_TEXT = "Resume";
 	
+	/**
+	 *  Constructor to create a view model using a scriptgeneratorsingleton as the model.
+	 * @param scriptGeneratorModel - The script generator singleton to be used as the model.
+	 */
 	public ScriptGeneratorNicosViewModel(ScriptGeneratorSingleton scriptGeneratorModel) {
 		var nicosAdapter = new DynamicScriptingNicosAdapter(nicosModel);
 		nicosModel.addPropertyChangeListener(nicosAdapter);
@@ -139,6 +143,8 @@ public class ScriptGeneratorNicosViewModel implements PropertyChangeListener {
 				break;
 			case ERROR:
 				formatButtonsWhenError();
+				break;
+			default: // do nothing;
 				break;
 		}
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -53,7 +53,6 @@ import org.eclipse.wb.swt.ResourceManager;
 
 import uk.ac.stfc.isis.ibex.preferences.PreferenceSupplier;
 import uk.ac.stfc.isis.ibex.scriptgenerator.ScriptGeneratorProperties;
-import uk.ac.stfc.isis.ibex.scriptgenerator.dynamicscripting.DynamicScriptingProperties;
 
 /**
  * Provides the UI to control the script generator.

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -26,7 +26,6 @@ import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.CellLabelProvider;
 import org.eclipse.jface.viewers.ColumnViewerToolTipSupport;
 import org.eclipse.jface.viewers.ComboViewer;
-import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -50,15 +49,18 @@ import org.eclipse.swt.widgets.Text;
 import org.apache.logging.log4j.Logger;
 import static java.lang.Math.min;
 
-import uk.ac.stfc.isis.ibex.scriptgenerator.*;
-import uk.ac.stfc.isis.ibex.scriptgenerator.dynamicscripting.DynamicScriptingProperties;
+import uk.ac.stfc.isis.ibex.scriptgenerator.Activator;
+import uk.ac.stfc.isis.ibex.scriptgenerator.JavaActionParameter;
+import uk.ac.stfc.isis.ibex.scriptgenerator.NoScriptDefinitionSelectedException;
+import uk.ac.stfc.isis.ibex.scriptgenerator.ScriptDefinitionNotMatched;
+import uk.ac.stfc.isis.ibex.scriptgenerator.ScriptGeneratorProperties;
+import uk.ac.stfc.isis.ibex.scriptgenerator.ScriptGeneratorSingleton;
 import uk.ac.stfc.isis.ibex.scriptgenerator.generation.InvalidParamsException;
 import uk.ac.stfc.isis.ibex.scriptgenerator.generation.UnsupportedLanguageException;
 import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ActionParameter;
 import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ScriptDefinitionWrapper;
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
 import uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs.SaveScriptGeneratorFileMessageDialog;
-import uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs.QueueScriptPreviewDialog;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
 import uk.ac.stfc.isis.ibex.ui.widgets.StringEditingSupport;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -105,6 +107,9 @@ public class ScriptGeneratorViewModel extends ModelObject {
      */
     public static final String VALIDITY_COLUMN_HEADER = "Validity";
     
+    /**
+     * The header of the action column.
+     */
     public static final String ACTION_NUMBER_COLUMN_HEADER = "Action";
     
     /**
@@ -256,17 +261,6 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	        });
 	    });
 	    return scriptGeneratorModel;
-    }
-    
-    private void previewScriptOrQueueDirectly(String generatedScript) {
-		QueueScriptPreviewDialog scriptPreview = new QueueScriptPreviewDialog(Display.getDefault().getActiveShell(), generatedScript);
-		if (scriptPreview.askIfPreviewScript()) {
-			if (scriptPreview.open() == IDialogConstants.OK_ID) {
-				firePropertyChange(DynamicScriptingProperties.NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
-			}
-		} else {
-			firePropertyChange(DynamicScriptingProperties.NICOS_SCRIPT_GENERATED_PROPERTY, null, generatedScript);
-		}
     }
     
     private void saveScriptToCurrentFilepath(String generatedScript) {

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -863,7 +863,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
      */
     protected void updateValidityChecks(ActionsViewTable viewTable) {
 	    Map<Integer, String> globals = scriptGeneratorModel.getGlobalParamErrors();
-	    for (int i = 0; i< this.globalParamText.size(); i++) {
+	    for (int i = 0; i < this.globalParamText.size(); i++) {
 	    	if (globals.containsKey(i)) {
 	    		globalParamText.get(i).setBackground(INVALID_LIGHT_COLOR);
 	    		globalParamText.get(i).setBackground(INVALID_DARK_COLOR);

--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PyDevAdditionalInterpreterSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/PyDevAdditionalInterpreterSettings.java
@@ -101,7 +101,7 @@ public class PyDevAdditionalInterpreterSettings extends InterpreterNewCustomEntr
 	}
 
 	private String geniePythonDir() {
-		return toOSPath(new File(preferenceSupplier.getPythonPath()).getParent());
+		return toOSPath(new File(PreferenceSupplier.getPythonPath()).getParent());
 	}
 	
 	private void addEpicsEnvironment(List<String> entries) {

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/SynopticEditorHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/commands/SynopticEditorHandler.java
@@ -55,7 +55,10 @@ public abstract class SynopticEditorHandler {
     private boolean canExecute;
 
     
-    
+    /**
+     * Sets whether the handler can be executed.
+     * @param canExecute - The boolean to set.
+     */
     protected void setCanExecute(boolean canExecute) {
     	this.canExecute = canExecute;
     }
@@ -67,7 +70,8 @@ public abstract class SynopticEditorHandler {
 	SYNOPTIC.delete().addOnCanWriteChangeListener(canWriteListener);
     }
     
-    private OnCanWriteChangeListener canWriteListener = canWrite -> {canExecute = canWrite;};
+    private OnCanWriteChangeListener canWriteListener = canWrite -> {
+    	canExecute = canWrite; };
 
     /**
      * 

--- a/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/ViewSynopticDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.synoptic.editor/src/uk/ac/stfc/isis/ibex/ui/synoptic/editor/dialogs/ViewSynopticDialog.java
@@ -19,8 +19,8 @@ import uk.ac.stfc.isis.ibex.ui.synoptic.editor.instrument.SynopticPreview;
 import uk.ac.stfc.isis.ibex.ui.synoptic.editor.model.SynopticViewModel;
 import uk.ac.stfc.isis.ibex.ui.synoptic.editor.validators.SynopticValidator;
 import uk.ac.stfc.isis.ibex.validators.ErrorMessage;
-
-public class ViewSynopticDialog extends TitleAreaDialog{
+@SuppressWarnings("magicnumber")
+public class ViewSynopticDialog extends TitleAreaDialog {
 	private static final Point INITIAL_SIZE = new Point(950, 800);
 	    private final String title;
 	    private final String subtitle;

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/ControlCellLabelProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/ControlCellLabelProvider.java
@@ -80,6 +80,12 @@ public abstract class ControlCellLabelProvider<T extends Control, TRow> extends 
 		cellControls.clear();
 	}
 	
+	/**
+	 * Creates  the control for a cell.
+	 * @param cell The cell to add the control to
+	 * @param style The style to create the new control with
+	 * @return The control created
+	 */
     protected abstract T createControl(ViewerCell cell, int style);
 	
 	private T create(final ViewerCell cell, int style) {
@@ -91,10 +97,20 @@ public abstract class ControlCellLabelProvider<T extends Control, TRow> extends 
 		return control;
 	}
 	
+	/**
+	 * Get the control from a cell as a composite.
+	 * @param cell - The cell to get the control of
+	 * @return The control as a composite.
+	 */
 	protected Composite composite(ViewerCell cell) {
 		return (Composite) cell.getControl();
 	}
 	
+	/**
+	 * Set the editor for a cell.
+	 * @param cell - The cell to edit.
+	 * @param control - The control for the cell.
+	 */
 	protected void setEditor(ViewerCell cell, Control control) {
 		TableItem item = (TableItem) cell.getItem();
 		TableEditor editor = new TableEditor(item.getParent());

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/StringUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/StringUtils.java
@@ -10,7 +10,7 @@ public final class StringUtils {
 	/**
 	 * Private constructor for utility class.
 	 */
-	private StringUtils() {}
+	private StringUtils() { }
 	
 	/**
 	 * If a string is too long, truncate it and add an ellipsis to the end.

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/tables/DataboundTable.java
@@ -185,6 +185,7 @@ public abstract class DataboundTable<TRow> extends Composite {
      * Sets the selected rows based on multiple rows.
      *
      * @param selected the newly selected rows
+     * @param reveal whether or not the row is revealed
      */
     public void setSelected(List<TRow> selected, boolean reveal) {
        viewer.setSelection(new StructuredSelection(selected), reveal);

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorAggregator.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorAggregator.java
@@ -32,8 +32,14 @@ import java.util.Map;
  * Aggregates a number of error message providers into one.
  */
 public abstract class ErrorAggregator extends ErrorMessageProvider {
+	/**
+	 * Map of error providers to error messages.
+	 */
     protected Map<ErrorMessageProvider, ErrorMessage> childErrors = new HashMap<>();
 
+    /**
+     * Property change listener to add provider to child errors.
+     */
     protected PropertyChangeListener errorListener = new PropertyChangeListener() {
         @Override
         public void propertyChange(PropertyChangeEvent evt) {

--- a/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorMessageProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.validators/src/uk/ac/stfc/isis/ibex/validators/ErrorMessageProvider.java
@@ -25,7 +25,14 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
  *
  */
 public abstract class ErrorMessageProvider extends ModelObject {
+	/**
+	 * The error.
+	 */
     protected ErrorMessage error = new ErrorMessage();
+    
+    /**
+     * The warning.
+     */
     protected WarningMessage warning = new WarningMessage();
     
     /**


### PR DESCRIPTION
### Description of work
Fixed chunk of checkstyle warnings:
 - Replaced uses of Deprecated assertThat
 - Removed unused Imports
 - Removed unused Parameters
 - Removed unused Functions
 - Corrected whitespace Issues
 - Fixed and added some javadoc comments
 - Added magic number warning suppression to GUI files
 - Removed warning supressions  where it was not used
 - added default cases to switch statements
 - removed unnesecary keywords from declarations
 - added final declarations that should be final
 - Fixed some uses of Raw generics
 - Fixed use of deprecated function drawImage

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/7200

### Acceptance criteria

Number of checkstylewarnings is reduced, code still functions.

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

