### PR TITLE
Set names for most threads created by IBEX code, for easier debugging

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/MQConnection.java
+++ b/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/MQConnection.java
@@ -86,7 +86,7 @@ public class MQConnection extends ModelObject implements Runnable {
         setCredentials(username, password);
         updateURL(initialHost);
 
-        thread = new Thread(this);
+        thread = new Thread(this, "ActiveMQ Connection");
         thread.start();
     }
 

--- a/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
+++ b/base/uk.ac.stfc.isis.ibex.activemq/src/uk/ac/stfc/isis/ibex/activemq/message/MessageParser.java
@@ -58,7 +58,7 @@ public abstract class MessageParser<T extends IMessage> implements Runnable {
     	}
         running = run;
         if (running && (thread == null || !thread.isAlive())) {
-        	thread = new Thread(this);
+        	thread = new Thread(this, "ActiveMQ MessageParser");
             thread.start();
         }
     }

--- a/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmReloadManager.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmReloadManager.java
@@ -99,7 +99,7 @@ public final class AlarmReloadManager implements PropertyChangeListener {
             thread.interrupt();
         }
 
-        thread = new Thread(reloadRunnable);
+        thread = new Thread(reloadRunnable, "AlarmReloadManager");
         thread.start();
     }
 

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/CopyPerspectiveSnippetProcessor.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/CopyPerspectiveSnippetProcessor.java
@@ -254,7 +254,7 @@ public class CopyPerspectiveSnippetProcessor {
      * @param time Time in milliseconds of how long to wait before enabling PV connection check.
      */
     private void setupConnectionCheckTimeout(long time) {
-        Thread connectionTimeoutThread = new Thread() {
+        Thread connectionTimeoutThread = new Thread("CopyPerspectiveSnippetProcessor timeout thread") {
         	public void run() {
         		try {
 					Thread.sleep(time);

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/controls/FlashingButton.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/controls/FlashingButton.java
@@ -59,7 +59,7 @@ public class FlashingButton implements Runnable, DisposeListener {
      */
     public void start() {
         if (null == flashThread) {
-            flashThread = new Thread(this);
+            flashThread = new Thread(this, "FlashingButton thread");
             flashThread.start();
         }
     }

--- a/base/uk.ac.stfc.isis.ibex.epics.switching/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.epics.switching/META-INF/MANIFEST.MF
@@ -8,7 +8,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench,
  uk.ac.stfc.isis.ibex.instrument;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.epics,
- uk.ac.stfc.isis.ibex.logger;bundle-version="1.0.0"
+ uk.ac.stfc.isis.ibex.logger;bundle-version="1.0.0",
+ com.google.guava
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: uk.ac.stfc.isis.ibex.epics.switching
 Bundle-ActivationPolicy: lazy

--- a/base/uk.ac.stfc.isis.ibex.epics.switching/src/uk/ac/stfc/isis/ibex/epics/switching/InstrumentSwitchers.java
+++ b/base/uk.ac.stfc.isis.ibex.epics.switching/src/uk/ac/stfc/isis/ibex/epics/switching/InstrumentSwitchers.java
@@ -7,6 +7,8 @@ import java.util.concurrent.TimeUnit;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 
 /**
@@ -22,6 +24,9 @@ public class InstrumentSwitchers implements BundleActivator {
     private ClosingSwitcher closingSwitcher = new ClosingSwitcher();
     private ObservablePrefixChangingSwitcher observablePrefixChangingSwitcher = new ObservablePrefixChangingSwitcher();
     private WritablePrefixChangingSwitcher writablePrefixChangingSwitcher = new WritablePrefixChangingSwitcher();
+    
+    private static final ScheduledExecutorService SWITCHER_EXECUTOR = Executors.newSingleThreadScheduledExecutor(
+			new ThreadFactoryBuilder().setNameFormat("InstrumentSwitcher-%d").build());
     
     /**
      * Indicates if the singleton instance of switchers is currently in the process of switching
@@ -104,8 +109,7 @@ public class InstrumentSwitchers implements BundleActivator {
         instance.observablePrefixChangingSwitcher.switchInstrument(instrument);
         instance.writablePrefixChangingSwitcher.switchInstrument(instrument);
         // This is to prevent instrument from being switched too often
-        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-        executorService.schedule(new Runnable() {
+        SWITCHER_EXECUTOR.schedule(new Runnable() {
 			@Override
 			public void run() {
 		        switching = false;

--- a/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerObservable.java
+++ b/base/uk.ac.stfc.isis.ibex.epics/src/uk/ac/stfc/isis/ibex/epics/pvmanager/PVManagerObservable.java
@@ -35,6 +35,8 @@ import org.diirt.datasource.PVReaderEvent;
 import org.diirt.datasource.PVReaderListener;
 import org.diirt.vtype.VType;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import uk.ac.stfc.isis.ibex.epics.pv.ObservablePV;
 import uk.ac.stfc.isis.ibex.epics.pv.PVInfo;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -63,7 +65,8 @@ public class PVManagerObservable<R extends VType> extends ObservablePV<R> {
 	 */
 	private PVReaderListener<R> observingListener;
 	
-	private static final ExecutorService UPDATE_THREADPOOL = Executors.newCachedThreadPool();
+	private static final ExecutorService UPDATE_THREADPOOL = Executors.newCachedThreadPool(
+			new ThreadFactoryBuilder().setNameFormat("PVManagerObservable-threadpool-%d").build());
 	
     /**
      * Create a new PV manager observable.

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
@@ -271,7 +271,7 @@ public class Instrument implements BundleActivator {
             public void run() {
                 updateExtendingPlugins(finalSelectedInstrument);
             }
-        }).start();
+        }, "SetInstrument thread").start();
 
         logNumberOfChannels();
     }

--- a/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.journal/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.databinding.observable,
  uk.ac.stfc.isis.ibex.logger,
  org.csstudio.platform.libs.jdbc,
- com.ibm.icu
+ com.ibm.icu,
+ com.google.guava
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.journal

--- a/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
+++ b/base/uk.ac.stfc.isis.ibex.journal/src/uk/ac/stfc/isis/ibex/journal/JournalModel.java
@@ -34,6 +34,8 @@ import java.util.concurrent.Executors;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.jface.preference.IPreferenceStore;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import uk.ac.stfc.isis.ibex.databases.Rdb;
 import uk.ac.stfc.isis.ibex.journal.preferences.PreferenceConstants;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
@@ -63,7 +65,8 @@ public class JournalModel extends ModelObject {
     // Exact choice of number is arbitrary.
     private static final int QUERY_DURATION_WARNING_LEVEL = 2000;
     
-    private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(1);
+    private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(1, 
+			new ThreadFactoryBuilder().setNameFormat("JournalModel-threadpool-%d").build());
 
     private static final String NO_RESULTS_FOUND = "No results found with current search parameters";
     

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/src/uk/ac/stfc/isis/ibex/scriptgenerator/pythoninterface/PythonInterface.java
@@ -299,7 +299,7 @@ public class PythonInterface extends ModelObject {
 		firePropertyChange(ScriptGeneratorProperties.PYTHON_READINESS_PROPERTY, null, pythonReady);
 		clientServer = createClientServer();
 		pythonProcess = startPythonProcess(clientServer, python3InterpreterPath(), scriptDefinitionLoaderScript);
-		new Thread(listenToErrors).start();
+		new Thread(listenToErrors, "ScriptGenerator error listener").start();
 		
 		this.scriptDefinitionsWrapper = (ScriptDefinitionsWrapper) clientServer
 				.getPythonServerEntryPoint(new Class[] {ScriptDefinitionsWrapper.class});

--- a/base/uk.ac.stfc.isis.ibex.ui.log/src/uk/ac/stfc/isis/ibex/ui/log/widgets/SearchControl.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.log/src/uk/ac/stfc/isis/ibex/ui/log/widgets/SearchControl.java
@@ -344,7 +344,7 @@ public class SearchControl extends Canvas {
             }
         };
 
-        Thread searchJobThread = new Thread(searchJob);
+        Thread searchJobThread = new Thread(searchJob, "Log search thread");
 
         searchJobThread.start();
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/META-INF/MANIFEST.MF
@@ -20,7 +20,8 @@ Require-Bundle: uk.ac.stfc.isis.ibex.scriptgenerator,
  uk.ac.stfc.isis.ibex.logger;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.preferences;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.ui.about;bundle-version="1.0.0",
- uk.ac.stfc.isis.ibex.nicos;bundle-version="1.0.0"
+ uk.ac.stfc.isis.ibex.nicos;bundle-version="1.0.0",
+ com.google.guava
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.ui.scriptgenerator
 Import-Package: uk.ac.stfc.isis.ibex.ui.widgets
 Bundle-ActivationPolicy: lazy

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -46,6 +46,9 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import org.apache.logging.log4j.Logger;
 import static java.lang.Math.min;
 
@@ -816,7 +819,8 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	    this.mainParent = mainParent;
 	    this.currentGlobals = new ArrayList<String>();
 	    this.finishTimer = new ScriptGeneratorExpectedFinishTimer();
-	    this.scheduler = Executors.newScheduledThreadPool(1);
+	    this.scheduler = Executors.newScheduledThreadPool(1, 
+				new ThreadFactoryBuilder().setNameFormat("ScriptGeneratorViewModel-threadpool-%d").build());
 	    this.scheduler.scheduleWithFixedDelay(finishTimer, 0, 1, TimeUnit.SECONDS);
 	    scriptGeneratorModel.getScriptDefinitionLoader().addPropertyChangeListener(ScriptGeneratorProperties.SCRIPT_DEFINITION_SWITCH_PROPERTY, scriptDefinitionSwitchHelpListener);
     }


### PR DESCRIPTION
### Description of work

Set names for most threads in IBEX. This helps debugging as we can more easily tell which thread an update has come in on, or which threads are using excessive resources for example.

### Ticket

none

### Acceptance criteria

Most threads created by ibex have sensible names.

Note: some threads/threadpools are created by CSS/py4j etc and we cannot change the names of these.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

