### PR TITLE
Ticket1357

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ build/maven
 build/ICP_Binaries_maven.log
 base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/ScriptDefinitions_repo.bundle
 base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/git
+*.log

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/ConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/ConfigurationTest.java
@@ -21,12 +21,8 @@ package uk.ac.stfc.isis.ibex.configserver.tests.editing;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.Test;
 
-import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.internal.ConfigEditing;

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/ConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/ConfigurationTest.java
@@ -21,8 +21,12 @@ package uk.ac.stfc.isis.ibex.configserver.tests.editing;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Test;
 
+import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
 import uk.ac.stfc.isis.ibex.configserver.internal.ConfigEditing;

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/EditableConfigurationTest.java
@@ -211,4 +211,26 @@ public class EditableConfigurationTest {
 		config.setIsProtected(false);
 		assertFalse(config.getIsProtected());
 	}
+	
+	@Test
+	public void GIVEN_configuration_WHEN_component_added_THEN_blocks_from_component_available() {
+
+		var component = new Configuration("comp", "desc", "", Collections.emptyList(), 
+				List.of(new Block("comp_blockname", "", false, false)), 
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), false, true, false);
+		
+		var config = new Configuration("name", "description", "", iocs, blocks, groups, components, history, false, true, false);
+		var editable = new EditableConfiguration(config, Collections.emptyList(), List.of(component), Collections.emptyList());
+		
+		assertEquals(editable.getAllBlocks().size(), 0);
+		
+		editable.getEditableComponents().toggleSelection(List.of(component));
+		
+		assertEquals(editable.getAllBlocks().size(), 1);
+		assertEquals(editable.getAllBlocks().toArray(new Block[0])[0].getName(), "comp_blockname");
+		
+		editable.getEditableComponents().toggleSelection(List.of(component));
+		
+		assertEquals(editable.getAllBlocks().size(), 0);
+	}
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/GroupsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/editing/GroupsTest.java
@@ -93,7 +93,7 @@ public class GroupsTest extends EditableConfigurationTest {
 		groups.add(JAWS);
 		EditableConfiguration edited = edit(config());
 		
-		List<EditableBlock> availableBlocks = (List<EditableBlock>) edited.getOtherBlocks();
+		List<EditableBlock> availableBlocks = (List<EditableBlock>) edited.getBlocksOutsideGroup();
 
 		assertEquals(availableBlocks.size(), 1);
 		assertEquals(availableBlocks.get(0).getName(), "GAPY");

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Block.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Block.java
@@ -43,7 +43,7 @@ public class Block extends ModelObject implements IRuncontrol, INamedInComponent
 	private String pv;
 	private boolean visible;
 	private boolean local;
-	private String component;
+	protected String component;
 
     private boolean runcontrol;
     private double lowlimit;

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableBlock.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableBlock.java
@@ -33,6 +33,14 @@ public class EditableBlock extends Block {
 	public EditableBlock(Block other) {
 		super(other);
 	}
+	
+	/**
+	 * Create a block that may be editable from a read-only one which is part of a component.
+	 */
+	public EditableBlock(Block other, String componentName) {
+		super(other);
+		this.component = componentName;
+	}
 
 	/**
 	 * Get whether the block is editable.

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableConfiguration.java
@@ -531,7 +531,7 @@ public class EditableConfiguration extends ModelObject implements GroupNamesProv
     	final Set<String> blockNamesInGroups = getEditableGroups().stream()
     			.map(EditableGroup::getBlocks)
     			.flatMap(Collection::stream)
-    			.collect(Collectors.toSet());
+    			.collect(Collectors.toUnmodifiableSet());
     	
 	    return allBlocks.stream()
 	    		.filter(b -> !blockNamesInGroups.contains(b.getName()))

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableGroup.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableGroup.java
@@ -28,10 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-
 import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
 import uk.ac.stfc.isis.ibex.configserver.configuration.Group;
 import uk.ac.stfc.isis.ibex.configserver.internal.DisplayUtils;

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableGroup.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/editing/EditableGroup.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -57,12 +58,6 @@ public class EditableGroup extends Group {
 
 		config = configuration;
 		blocksInGroup = lookupBlocksByName(config.getAllBlocks(), group.getBlocks());
-
-		for (EditableBlock block : blocksInGroup) {
-			if (!group.getName().equals("NONE")) {
-				config.makeBlockUnavailable(block);
-			}
-		}
 
 		config.addPropertyChangeListener(new PropertyChangeListener() {
 			@Override
@@ -99,7 +94,7 @@ public class EditableGroup extends Group {
 	 *         A collection of blocks that are unselected.
 	 */
 	public Collection<EditableBlock> getUnselectedBlocks() {
-		return new ArrayList<>(config.getOtherBlocks());
+		return new ArrayList<>(config.getBlocksOutsideGroup());
 	}
 
 	/**
@@ -124,10 +119,8 @@ public class EditableGroup extends Group {
 		for (EditableBlock block : blocksToToggle) {
 			if (blocksInGroup.contains(block)) {
 				blocksInGroup.remove(block);
-				config.makeBlockAvailable(block);
 			} else {
 				blocksInGroup.add(block);
-				config.makeBlockUnavailable(block);
 			}
 		}
 
@@ -203,12 +196,9 @@ public class EditableGroup extends Group {
 	}
 
 	private List<String> blockNames(Collection<? extends Block> blocks) {
-		return Lists.newArrayList(Iterables.transform(blocks, new Function<Block, String>() {
-			@Override
-			public String apply(Block block) {
-				return block.getName();
-			}
-		}));
+	    return blocks.stream()
+	    		.map(Block::getName)
+	    		.collect(Collectors.toList());
 	}
 
 	private List<EditableBlock> lookupBlocksByName(Collection<EditableBlock> blocks, final Collection<String> names) {

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/DisplayUtils.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/DisplayUtils.java
@@ -20,10 +20,7 @@
 package uk.ac.stfc.isis.ibex.configserver.internal;
 
 import java.util.Collection;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
+import java.util.stream.Collectors;
 
 import uk.ac.stfc.isis.ibex.configserver.configuration.Group;
 
@@ -40,11 +37,8 @@ public final class DisplayUtils {
 	}
 	
 	public static <T extends Group> Collection<T> removeOtherGroup(Collection<T> groups) {
-		return Lists.newArrayList(Iterables.filter(groups, new Predicate<T>() {
-			@Override
-			public boolean apply(T group) {
-				return !group.getName().equals(OTHER);
-			}
-		}));
+		return groups.stream()
+				.filter(g -> !g.getName().equals(OTHER))
+				.collect(Collectors.toList());
 	}
 }


### PR DESCRIPTION
### Description of work

Preview blocks in config dialog before the config is saved

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/1357

### Acceptance criteria

- Create a config and a component with a block in it
- Add the component to the config, don't save yet
- Verify block is in config dialog
- Save the config
- Verify component block does not get saved in config's `blocks.xml`

### Unit tests

Yes

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

