### PR TITLE
Ensure exception stack traces are logged

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
@@ -125,8 +125,7 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
     			writeTempFile(new String[] {Long.toString(ProcessHandle.current().pid())}, true);
     		}
 		} catch (Exception e) {
-			LOG.error(MULTIPLE_INSTANCES_CHECKING_ERROR);
-			e.printStackTrace();
+			LoggerUtils.logErrorWithStackTrace(LOG, MULTIPLE_INSTANCES_CHECKING_ERROR, e);
 		}
     }
     

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoMenu.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoMenu.java
@@ -3,6 +3,7 @@ package uk.ac.stfc.isis.ibex.ui.beamstatus.views;
 import java.io.IOException;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jface.action.Action;
 
 import org.eclipse.jface.action.MenuManager;
@@ -12,6 +13,8 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 
 import uk.ac.stfc.isis.ibex.beamstatus.FacilityPV;
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
 import uk.ac.stfc.isis.ibex.ui.blocks.groups.BlocksMenu;
 import uk.ac.stfc.isis.ibex.ui.blocks.presentation.Presenter;
 import uk.ac.stfc.isis.ibex.ui.configserver.commands.NewBlockHandler;
@@ -24,6 +27,7 @@ public class BeamInfoMenu extends MenuManager {
 
 	FacilityPV facilityPV;
 	private static final String LOG_PLOTTER_PERSPECTIVE_ID = "uk.ac.stfc.isis.ibex.client.e4.product.perspective.logplotter";
+	private static final Logger LOG = IsisLog.getLogger(BeamInfoMenu.class);
 
 	/**
 	 * The constructor, creates the menu for when the specific facility PV is
@@ -44,11 +48,9 @@ public class BeamInfoMenu extends MenuManager {
 					new NewBlockHandler().createDialog(facilityPV.pv);
 
 				} catch (TimeoutException e) {
-
-					e.printStackTrace();
+					LoggerUtils.logErrorWithStackTrace(LOG, e.getMessage(), e);
 				} catch (IOException e) {
-
-					e.printStackTrace();
+					LoggerUtils.logErrorWithStackTrace(LOG, e.getMessage(), e);
 				}
 				super.run();
 			}

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/ManualHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/ManualHandler.java
@@ -28,6 +28,9 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.browser.IWebBrowser;
 
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
+
 /**
  * The handler for opening the user manual via the menu.
  */
@@ -45,14 +48,14 @@ public class ManualHandler {
         try {
             url = new URL(USER_MANUAL_ADDRESS);
         } catch (MalformedURLException ex) {
-            ex.printStackTrace();
+            LoggerUtils.logErrorWithStackTrace(IsisLog.getLogger(getClass()), ex.getMessage(), ex);
         }
 
         try {
             IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser();
             browser.openURL(url);
         } catch (PartInitException ex) {
-            ex.printStackTrace();
+        	LoggerUtils.logErrorWithStackTrace(IsisLog.getLogger(getClass()), ex.getMessage(), ex);
         }              
 	}
 	


### PR DESCRIPTION
I noticed a couple of instances where we were only printing, but not logging, exceptions. Exceptions should go to the log file so that any future issues can be debugged more easily.