### PR TITLE
Ticket 6309

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/AddBlockToComponentHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/AddBlockToComponentHandler.java
@@ -57,6 +57,14 @@ public class AddBlockToComponentHandler extends AbstractHandler {
 
 		return null;
 	}
+	
+	/**
+	 * Prevent adding block without permission
+	 */
+	@Override
+	public boolean isEnabled() {
+		return SERVER.setCurrentConfig().canWrite();
+	}
 
 	/**
 	 * Create dialog to select component, open edit component and add new block

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewBlockHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewBlockHandler.java
@@ -74,9 +74,13 @@ public class NewBlockHandler extends AbstractHandler {
 	    return null;
     }
 	
+	
+	/**
+	 * Prevent adding block without permission
+	 */
 	@Override
 	public boolean isEnabled() {
-		return false;
+		return SERVER.setCurrentConfig().canWrite();
 	}
 	
     /**

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewBlockHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/commands/NewBlockHandler.java
@@ -74,6 +74,11 @@ public class NewBlockHandler extends AbstractHandler {
 	    return null;
     }
 	
+	@Override
+	public boolean isEnabled() {
+		return false;
+	}
+	
     /**
      * Create the dialog for creating the new block.
      * 


### PR DESCRIPTION
### Description of work

Have added restriction so user is prevented from adding a block from the OPI IFF they have write permission on the current server config (button handler is not enabled otherwise).

Decided restriction over block addition given a user is not in manager mode but in a protected configuration was out of scope for this training ticket.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6309

### Acceptance criteria

The add block option in the OPI menu is greyed out if it is not allowed.

### Unit tests

No unit tests. Changes mostly GUI based so would be potentially out of scope of training ticket to implement.

### System tests

No system tests. Potential for squish testing, but potentially out of scope and changes are relatively low risk.

### Documentation
n/a

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

