### PR TITLE
Ticket 4735

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
@@ -10,7 +10,7 @@
   <background_color>
     <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
   </background_color>
-  <boy_version>5.1.0.201707071649</boy_version>
+  <boy_version>5.1.0</boy_version>
   <foreground_color>
     <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
   </foreground_color>
@@ -1836,7 +1836,7 @@ $(pv_value)</tooltip>
         <color name="Major" red="255" green="0" blue="0" />
       </foreground_color>
       <format_type>4</format_type>
-      <height>61</height>
+      <height>49</height>
       <horizontal_alignment>0</horizontal_alignment>
       <name>Calib_error_text_$(PV_ROOT_EURO)</name>
       <precision>3</precision>
@@ -1871,6 +1871,66 @@ $(pv_value)</tooltip>
       <wuid>-58ade2e9:16b50410d43:-72b9</wuid>
       <x>0</x>
       <y>72</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <auto_size>false</auto_size>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="Minor" red="255" green="128" blue="0" />
+      </foreground_color>
+      <format_type>4</format_type>
+      <height>37</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>Lookup_warning_text_$(PV_ROOT_EURO)</name>
+      <precision>3</precision>
+      <precision_from_pv>false</precision_from_pv>
+      <pv_name></pv_name>
+      <pv_value />
+      <rotation_angle>0.0</rotation_angle>
+      <rules>
+        <rule name="Visible" prop_id="visible" out_exp="false">
+          <exp bool_exp="pv0 != 1 &amp;&amp; pv1 == 1">
+            <value>true</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT_EURO):LUTON</pv>
+          <pv trig="true">$(PV_ROOT_EURO):RAMP_FILE_CHANGED</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_units>false</show_units>
+      <text>Default file changed but lookup not on.</text>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <transparent>false</transparent>
+      <vertical_alignment>0</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Text Update</widget_type>
+      <width>219</width>
+      <wrap_words>true</wrap_words>
+      <wuid>64b3cffe:18235a4905a:-6ebf</wuid>
+      <x>0</x>
+      <y>114</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Eurotherm_single.opi
@@ -1909,7 +1909,7 @@ $(pv_value)</tooltip>
             <value>true</value>
           </exp>
           <pv trig="true">$(PV_ROOT_EURO):LUTON</pv>
-          <pv trig="true">$(PV_ROOT_EURO):RAMP_FILE_CHANGED</pv>
+          <pv trig="true">$(PV_ROOT_EURO):RAMP_FILE_NOT_DEFAULT</pv>
         </rule>
       </rules>
       <scale_options>


### PR DESCRIPTION
### Description of work

Added minor warning label to 'DIP and max output lookup' in the Eurotherm OPI -  warns when DIP and max output lookup file is **not** the **default** and lookup **not on.**

### Ticket

[*Link to Ticket #4735*](https://github.com/ISISComputingGroup/IBEX/issues/4735)

### Acceptance criteria

- A message to remind the user when they change the default file but have not yet to turned lookup on

### Unit tests

See: https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/compare/Ticket_4735?expand=1

### System tests

n/a


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

