### PR TITLE
Use https for links to user manual

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
@@ -7,7 +7,7 @@ uk.ac.stfc.isis.ibex.preferences/show_values_of_invalid_blocks=false
 uk.ac.stfc.isis.ibex.preferences/script_definitions_folder=C:/Instrument/Settings/ibex_script_generator/scriptdefinitions
 uk.ac.stfc.isis.ibex.preferences/script_generation_folder=C:/Scripts/
 uk.ac.stfc.isis.ibex.preferences/hide_script_definition_error_table=false
-uk.ac.stfc.isis.ibex.preferences/script_generator_manual_url=http://shadow.nd.rl.ac.uk/ibex_user_manual/script_generator/Script-Generator,https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Script-Generator
+uk.ac.stfc.isis.ibex.preferences/script_generator_manual_url=https://shadow.nd.rl.ac.uk/ibex_user_manual/script_generator/Script-Generator,https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Script-Generator
 
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = false
 org.eclipse.ui/LOCK_TRIM = true

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/fermi_chopper.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/fermi_chopper.opi
@@ -4162,7 +4162,7 @@ $(pv_value)</tooltip>
               <path/>
               <scriptText>import webbrowser
 
-webbrowser.open("http://shadow.nd.rl.ac.uk/ibex_user_manual/FZJ-Fermi-Chopper")
+webbrowser.open("https://shadow.nd.rl.ac.uk/ibex_user_manual/FZJ-Fermi-Chopper")
 </scriptText>
               <embedded>true</embedded>
               <description/>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/kepco.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/kepco.opi
@@ -499,7 +499,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="true" hook_all="false">
         <action type="OPEN_WEBPAGE">
-          <hyperlink>http://shadow.nd.rl.ac.uk/ibex_user_manual/Kepco-Power-Supply</hyperlink>
+          <hyperlink>https://shadow.nd.rl.ac.uk/ibex_user_manual/Kepco-Power-Supply</hyperlink>
           <description>Kepco IOC specific information</description>
         </action>
       </actions>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/matplotlib.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/matplotlib.opi
@@ -241,7 +241,7 @@ $(pv_value)</tooltip>
           <path/>
           <scriptText>import webbrowser
 
-webbrowser.open("http://shadow.nd.rl.ac.uk/ibex_user_manual/Matplotlib")
+webbrowser.open("https://shadow.nd.rl.ac.uk/ibex_user_manual/Matplotlib")
 </scriptText>
           <embedded>true</embedded>
           <description/>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/template.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/template.opi
@@ -4049,7 +4049,7 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="true" hook_all="false">
         <action type="OPEN_WEBPAGE">
-          <hyperlink>http://shadow.nd.rl.ac.uk/ibex_user_manual/Kepco-Power-Supply</hyperlink>
+          <hyperlink>https://shadow.nd.rl.ac.uk/ibex_user_manual/Kepco-Power-Supply</hyperlink>
           <description>Kepco IOC specific information</description>
         </action>
       </actions>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/weblinks.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/weblinks.opi
@@ -52,7 +52,7 @@
       <color red="192" green="192" blue="192"/>
     </border_color>
     <widget_type>Web Browser</widget_type>
-    <url>http://dataweb.isis.rl.ac.uk/IbexLinks/default.htm?&amp;instrument=$(INST)</url>
+    <url>https://dataweb.isis.rl.ac.uk/IbexLinks/default.htm?&amp;instrument=$(INST)</url>
     <background_color>
       <color red="240" green="240" blue="240"/>
     </background_color>

--- a/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
+++ b/base/uk.ac.stfc.isis.ibex.preferences/src/uk/ac/stfc/isis/ibex/preferences/PreferenceSupplier.java
@@ -198,7 +198,7 @@ public class PreferenceSupplier {
     /**
      * The default URL for the Script Generator manual page
      */
-    private static final String DEFAULT_SCRIPT_GENERATOR_MANUAL_URL = "http://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator";
+    private static final String DEFAULT_SCRIPT_GENERATOR_MANUAL_URL = "https://shadow.nd.rl.ac.uk/ibex_user_manual/Using-the-Script-Generator";
     
     /**
      * Defines the URL of the Script Generator page on the user manual

--- a/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/ManualHandler.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.help/src/uk/ac/stfc/isis/ibex/ui/help/ManualHandler.java
@@ -36,7 +36,7 @@ import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
  */
 public class ManualHandler {
 
-    private static final String USER_MANUAL_ADDRESS = "http://shadow.nd.rl.ac.uk/ibex_user_manual/Home";
+    private static final String USER_MANUAL_ADDRESS = "https://shadow.nd.rl.ac.uk/ibex_user_manual/Home";
 
     /**
      * Opens the 'User Manual' URL in help menu.

--- a/base/uk.ac.stfc.isis.scriptgenerator.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.scriptgenerator.client/plugin_customization.ini
@@ -4,7 +4,7 @@
 uk.ac.stfc.isis.ibex.preferences/script_definitions_folder=C:/Instrument/Settings/ibex_script_generator/scriptdefinitions
 uk.ac.stfc.isis.ibex.preferences/script_generation_folder=C:/Scripts/
 uk.ac.stfc.isis.ibex.preferences/hide_script_definition_error_table=false
-uk.ac.stfc.isis.ibex.preferences/script_generator_manual_url=http://shadow.nd.rl.ac.uk/ibex_user_manual/script_generator/Script-Generator,https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Script-Generator
+uk.ac.stfc.isis.ibex.preferences/script_generator_manual_url=https://shadow.nd.rl.ac.uk/ibex_user_manual/script_generator/Script-Generator,https://github.com/ISISComputingGroup/ibex_user_manual/wiki/Script-Generator
 
 # Eclipse
 org.eclipse.ui/SHOW_MEMORY_MONITOR=false


### PR DESCRIPTION
### Description of work

Change links to https

### Ticket

See ISISComputingGroup/IBEX#7229

### Acceptance criteria

* links to help pages on user manual still work e.g. on kepco OPI and general ibex help link
---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

