### PR TITLE
fixing 'edit host configuration' menu item 

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/BlocksMenu.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/BlocksMenu.java
@@ -57,7 +57,6 @@ public class BlocksMenu extends MenuManager {
 	
 	private static boolean canWrite = false;
 
-	private IAction editBlockAction;
 	private MenuManager logSubMenu;
 	private MenuManager noLogPlotterSubMenu;
 	
@@ -141,7 +140,7 @@ public class BlocksMenu extends MenuManager {
 
         appendToGroup(BLOCK_MENU_GROUP, logSubMenu);
         
-        createEditBlockLabelAndAction();
+        final var editBlockAction = createEditBlockLabelAndAction();
         
         appendToGroup(BLOCK_MENU_GROUP, editBlockAction);
         
@@ -159,11 +158,9 @@ public class BlocksMenu extends MenuManager {
 				updateAll(true);
 			}
         });
-
-
 	}
 
-	private void createEditBlockLabelAndAction() {
+	private IAction createEditBlockLabelAndAction() {
 		String editBlockLabel = EDIT_BLOCK_PREFIX;
         if (this.block.inComponent()) {
             editBlockLabel += COMPONENT_SUFFIX;
@@ -171,7 +168,7 @@ public class BlocksMenu extends MenuManager {
             editBlockLabel += CONFIGURATION_SUFFIX;
         }
         
-        editBlockAction = new Action(editBlockLabel) {
+        return new Action(editBlockLabel) {
             @Override
             public void run() {
                 new EditBlockHandler(block.getName()).execute(null); //TODO e4 migrate: This will be added as a command which includes a shell at that time make this correct

--- a/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/BlocksMenu.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/BlocksMenu.java
@@ -61,8 +61,8 @@ public class BlocksMenu extends MenuManager {
 	private MenuManager logSubMenu;
 	private MenuManager noLogPlotterSubMenu;
 	
-	
 	static {
+		// Set a listener for the edit host configuration/component menu item based on server write access status.
 		Configurations.getInstance().server().setCurrentConfig().addOnCanWriteChangeListener(canWrite -> BlocksMenu.canWrite = canWrite);
 	}
 	
@@ -141,19 +141,7 @@ public class BlocksMenu extends MenuManager {
 
         appendToGroup(BLOCK_MENU_GROUP, logSubMenu);
         
-        String editBlockLabel = EDIT_BLOCK_PREFIX;
-        if (this.block.inComponent()) {
-            editBlockLabel += COMPONENT_SUFFIX;
-        } else {
-            editBlockLabel += CONFIGURATION_SUFFIX;
-        }
-        
-        editBlockAction = new Action(editBlockLabel) {
-            @Override
-            public void run() {
-                new EditBlockHandler(block.getName()).execute(null); //TODO e4 migrate: This will be added as a command which includes a shell at that time make this correct
-            }
-        };
+        createEditBlockLabelAndAction();
         
         appendToGroup(BLOCK_MENU_GROUP, editBlockAction);
         
@@ -173,6 +161,22 @@ public class BlocksMenu extends MenuManager {
         });
 
 
+	}
+
+	private void createEditBlockLabelAndAction() {
+		String editBlockLabel = EDIT_BLOCK_PREFIX;
+        if (this.block.inComponent()) {
+            editBlockLabel += COMPONENT_SUFFIX;
+        } else {
+            editBlockLabel += CONFIGURATION_SUFFIX;
+        }
+        
+        editBlockAction = new Action(editBlockLabel) {
+            @Override
+            public void run() {
+                new EditBlockHandler(block.getName()).execute(null); //TODO e4 migrate: This will be added as a command which includes a shell at that time make this correct
+            }
+        };
 	}
     
     /**


### PR DESCRIPTION
The exceptions occurred due to the finalizer method of the BlocksMenu class trying to remove a listener which had already been disposed of if the menu was not open. 

There is a slight difference in the way that the 'edit host configuration/component' menu item is now greyed out instead of invisible when a user does not have write access to a block, though I think this is more clear. 
