### PR TITLE
Add % of Volt Limit to Pressure and Temp Cards on Mercury Cryostat GUI

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/mercuryiTC/mercuryiTC_single_pressure.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/mercuryiTC/mercuryiTC_single_pressure.opi
@@ -10,7 +10,7 @@
   <background_color>
     <color red="240" green="240" blue="240" />
   </background_color>
-  <boy_version>5.1.0.201707071649</boy_version>
+  <boy_version>5.1.0</boy_version>
   <foreground_color>
     <color red="192" green="192" blue="192" />
   </foreground_color>
@@ -1812,8 +1812,8 @@ $(pv_value)</tooltip>
           <width>73</width>
           <wrap_words>true</wrap_words>
           <wuid>42a2523d:1674fc14987:-7f5a</wuid>
-          <x>29</x>
-          <y>102</y>
+          <x>26</x>
+          <y>83</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -1865,7 +1865,7 @@ $(pv_value)</tooltip>
           <wrap_words>false</wrap_words>
           <wuid>42a2523d:1674fc14987:-7f59</wuid>
           <x>114</x>
-          <y>102</y>
+          <y>83</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -1906,7 +1906,7 @@ $(pv_value)</tooltip>
           <wrap_words>true</wrap_words>
           <wuid>42a2523d:1674fc14987:-7f58</wuid>
           <x>48</x>
-          <y>132</y>
+          <y>120</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -1958,7 +1958,7 @@ $(pv_value)</tooltip>
           <wrap_words>false</wrap_words>
           <wuid>42a2523d:1674fc14987:-7f57</wuid>
           <x>114</x>
-          <y>132</y>
+          <y>120</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -2258,7 +2258,7 @@ $(pv_value)</tooltip>
           <width>91</width>
           <wuid>-7d8c0c3:160fede6a8a:-7f98</wuid>
           <x>174</x>
-          <y>162</y>
+          <y>139</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -2310,7 +2310,7 @@ $(pv_value)</tooltip>
           <wrap_words>false</wrap_words>
           <wuid>-7d8c0c3:160fede6a8a:-7f99</wuid>
           <x>114</x>
-          <y>162</y>
+          <y>139</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -2351,7 +2351,7 @@ $(pv_value)</tooltip>
           <wrap_words>true</wrap_words>
           <wuid>-7d8c0c3:160fede6a8a:-7f97</wuid>
           <x>24</x>
-          <y>162</y>
+          <y>139</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -2491,6 +2491,99 @@ $(pv_value)</tooltip>
           <wuid>42a2523d:1674fc14987:-7e4e</wuid>
           <x>170</x>
           <y>6</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <auto_size>false</auto_size>
+          <background_color>
+            <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color name="ISIS_Border" red="0" green="0" blue="0" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+          </font>
+          <foreground_color>
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+          </foreground_color>
+          <height>20</height>
+          <horizontal_alignment>2</horizontal_alignment>
+          <name>Voltage_limit_percent_label</name>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <show_scrollbar>false</show_scrollbar>
+          <text>% of voltage limit:</text>
+          <tooltip></tooltip>
+          <transparent>false</transparent>
+          <vertical_alignment>1</vertical_alignment>
+          <visible>true</visible>
+          <widget_type>Label</widget_type>
+          <width>102</width>
+          <wrap_words>true</wrap_words>
+          <wuid>-1d6ae919:18234675882:-7780</wuid>
+          <x>0</x>
+          <y>158</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <alarm_pulsing>false</alarm_pulsing>
+          <auto_size>false</auto_size>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <background_color>
+            <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+          </background_color>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
+          <border_color>
+            <color name="ISIS_Border" red="0" green="0" blue="0" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
+          </font>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <foreground_color>
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+          </foreground_color>
+          <format_type>0</format_type>
+          <height>19</height>
+          <horizontal_alignment>0</horizontal_alignment>
+          <name>Voltage_limit_text</name>
+          <precision>3</precision>
+          <precision_from_pv>true</precision_from_pv>
+          <pv_name>$(PV_ROOT):HEATER:VOLT_PRCNT</pv_name>
+          <pv_value />
+          <rotation_angle>0.0</rotation_angle>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <show_units>true</show_units>
+          <text>######</text>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <transparent>false</transparent>
+          <vertical_alignment>1</vertical_alignment>
+          <visible>true</visible>
+          <widget_type>Text Update</widget_type>
+          <width>57</width>
+          <wrap_words>false</wrap_words>
+          <wuid>-1d6ae919:18234675882:-7778</wuid>
+          <x>114</x>
+          <y>158</y>
         </widget>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/mercuryiTC/mercuryiTC_single_temp.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/mercuryiTC/mercuryiTC_single_temp.opi
@@ -10,7 +10,7 @@
   <background_color>
     <color red="240" green="240" blue="240" />
   </background_color>
-  <boy_version>5.1.0.201707071649</boy_version>
+  <boy_version>5.1.0</boy_version>
   <foreground_color>
     <color red="192" green="192" blue="192" />
   </foreground_color>
@@ -1722,9 +1722,9 @@ $(pv_value)</tooltip>
         <transparent>false</transparent>
         <visible>true</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>319</width>
+        <width>327</width>
         <wuid>42a2523d:1674fc14987:-7f63</wuid>
-        <x>318</x>
+        <x>310</x>
         <y>6</y>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -1761,10 +1761,10 @@ $(pv_value)</tooltip>
           <vertical_alignment>1</vertical_alignment>
           <visible>true</visible>
           <widget_type>Label</widget_type>
-          <width>73</width>
+          <width>55</width>
           <wrap_words>true</wrap_words>
           <wuid>42a2523d:1674fc14987:-7f5a</wuid>
-          <x>29</x>
+          <x>53</x>
           <y>88</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -1816,101 +1816,8 @@ $(pv_value)</tooltip>
           <width>57</width>
           <wrap_words>false</wrap_words>
           <wuid>42a2523d:1674fc14987:-7f59</wuid>
-          <x>114</x>
+          <x>120</x>
           <y>88</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <auto_size>false</auto_size>
-          <background_color>
-            <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-          </background_color>
-          <border_color>
-            <color name="ISIS_Border" red="0" green="0" blue="0" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
-          </font>
-          <foreground_color>
-            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-          </foreground_color>
-          <height>20</height>
-          <horizontal_alignment>2</horizontal_alignment>
-          <name>Resistance_label_2</name>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <show_scrollbar>false</show_scrollbar>
-          <text>Voltage:</text>
-          <tooltip></tooltip>
-          <transparent>false</transparent>
-          <vertical_alignment>1</vertical_alignment>
-          <visible>true</visible>
-          <widget_type>Label</widget_type>
-          <width>54</width>
-          <wrap_words>true</wrap_words>
-          <wuid>42a2523d:1674fc14987:-7f58</wuid>
-          <x>48</x>
-          <y>118</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <alarm_pulsing>false</alarm_pulsing>
-          <auto_size>false</auto_size>
-          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-          <background_color>
-            <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
-          </background_color>
-          <border_alarm_sensitive>true</border_alarm_sensitive>
-          <border_color>
-            <color name="ISIS_Border" red="0" green="0" blue="0" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
-          </font>
-          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-          <foreground_color>
-            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-          </foreground_color>
-          <format_type>0</format_type>
-          <height>19</height>
-          <horizontal_alignment>0</horizontal_alignment>
-          <name>Temperature_text_3</name>
-          <precision>3</precision>
-          <precision_from_pv>true</precision_from_pv>
-          <pv_name>$(PV_ROOT):HEATER:VOLT</pv_name>
-          <pv_value />
-          <rotation_angle>0.0</rotation_angle>
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <show_units>true</show_units>
-          <text>######</text>
-          <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-          <transparent>false</transparent>
-          <vertical_alignment>1</vertical_alignment>
-          <visible>true</visible>
-          <widget_type>Text Update</widget_type>
-          <width>57</width>
-          <wrap_words>false</wrap_words>
-          <wuid>42a2523d:1674fc14987:-7f57</wuid>
-          <x>114</x>
-          <y>118</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -1950,7 +1857,7 @@ $(pv_value)</tooltip>
           <width>54</width>
           <wrap_words>true</wrap_words>
           <wuid>42a2523d:1674fc14987:-7f56</wuid>
-          <x>48</x>
+          <x>54</x>
           <y>178</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -2002,7 +1909,7 @@ $(pv_value)</tooltip>
           <width>57</width>
           <wrap_words>false</wrap_words>
           <wuid>42a2523d:1674fc14987:-7f55</wuid>
-          <x>114</x>
+          <x>120</x>
           <y>178</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -2040,10 +1947,10 @@ $(pv_value)</tooltip>
           <vertical_alignment>1</vertical_alignment>
           <visible>true</visible>
           <widget_type>Label</widget_type>
-          <width>102</width>
+          <width>55</width>
           <wrap_words>true</wrap_words>
           <wuid>-7d8c0c3:160fede6a8a:-7e2e</wuid>
-          <x>0</x>
+          <x>53</x>
           <y>42</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -2095,7 +2002,7 @@ $(pv_value)</tooltip>
           <width>57</width>
           <wrap_words>false</wrap_words>
           <wuid>-7d8c0c3:160fede6a8a:-7e30</wuid>
-          <x>114</x>
+          <x>120</x>
           <y>41</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
@@ -2152,8 +2059,240 @@ $(pv_value)</tooltip>
           <widget_type>Text Input</widget_type>
           <width>91</width>
           <wuid>-7d8c0c3:160fede6a8a:-7e2f</wuid>
-          <x>174</x>
+          <x>180</x>
           <y>42</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <auto_size>false</auto_size>
+          <background_color>
+            <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color name="ISIS_Border" red="0" green="0" blue="0" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+          </font>
+          <foreground_color>
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+          </foreground_color>
+          <height>20</height>
+          <horizontal_alignment>2</horizontal_alignment>
+          <name>Output_label_2</name>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <show_scrollbar>false</show_scrollbar>
+          <text>Heater control:</text>
+          <tooltip></tooltip>
+          <transparent>false</transparent>
+          <vertical_alignment>1</vertical_alignment>
+          <visible>true</visible>
+          <widget_type>Label</widget_type>
+          <width>96</width>
+          <wrap_words>true</wrap_words>
+          <wuid>42a2523d:1674fc14987:-7e54</wuid>
+          <x>12</x>
+          <y>6</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <alarm_pulsing>false</alarm_pulsing>
+          <auto_size>false</auto_size>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <background_color>
+            <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+          </background_color>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
+          <border_color>
+            <color name="ISIS_Border" red="0" green="0" blue="0" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
+          </font>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <foreground_color>
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+          </foreground_color>
+          <format_type>0</format_type>
+          <height>21</height>
+          <horizontal_alignment>0</horizontal_alignment>
+          <name>Output_text_2</name>
+          <precision>3</precision>
+          <precision_from_pv>true</precision_from_pv>
+          <pv_name>$(PV_ROOT):HEATER:MODE</pv_name>
+          <pv_value />
+          <rotation_angle>0.0</rotation_angle>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <show_units>true</show_units>
+          <text>######</text>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <transparent>false</transparent>
+          <vertical_alignment>1</vertical_alignment>
+          <visible>true</visible>
+          <widget_type>Text Update</widget_type>
+          <width>57</width>
+          <wrap_words>false</wrap_words>
+          <wuid>42a2523d:1674fc14987:-7e46</wuid>
+          <x>120</x>
+          <y>5</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <alarm_pulsing>false</alarm_pulsing>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <background_color>
+            <color red="240" green="240" blue="240" />
+          </background_color>
+          <border_alarm_sensitive>false</border_alarm_sensitive>
+          <border_color>
+            <color red="0" green="128" blue="255" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+          </font>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <foreground_color>
+            <color red="0" green="0" blue="0" />
+          </foreground_color>
+          <height>25</height>
+          <horizontal>true</horizontal>
+          <items_from_pv>true</items_from_pv>
+          <name>Choice Button_1</name>
+          <pv_name>$(PV_ROOT):HEATER:MODE:SP</pv_name>
+          <pv_value />
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <selected_color>
+            <color red="255" green="255" blue="255" />
+          </selected_color>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <visible>true</visible>
+          <widget_type>Choice Button</widget_type>
+          <width>100</width>
+          <wuid>42a2523d:1674fc14987:-7e4e</wuid>
+          <x>180</x>
+          <y>6</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <auto_size>false</auto_size>
+          <background_color>
+            <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+          </background_color>
+          <border_color>
+            <color name="ISIS_Border" red="0" green="0" blue="0" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+          </font>
+          <foreground_color>
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+          </foreground_color>
+          <height>20</height>
+          <horizontal_alignment>2</horizontal_alignment>
+          <name>Resistance_label_2</name>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <show_scrollbar>false</show_scrollbar>
+          <text>Voltage:</text>
+          <tooltip></tooltip>
+          <transparent>false</transparent>
+          <vertical_alignment>1</vertical_alignment>
+          <visible>true</visible>
+          <widget_type>Label</widget_type>
+          <width>54</width>
+          <wrap_words>true</wrap_words>
+          <wuid>-1d6ae919:18234675882:-75f5</wuid>
+          <x>54</x>
+          <y>113</y>
+        </widget>
+        <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+          <actions hook="false" hook_all="false" />
+          <alarm_pulsing>false</alarm_pulsing>
+          <auto_size>false</auto_size>
+          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+          <background_color>
+            <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+          </background_color>
+          <border_alarm_sensitive>true</border_alarm_sensitive>
+          <border_color>
+            <color name="ISIS_Border" red="0" green="0" blue="0" />
+          </border_color>
+          <border_style>0</border_style>
+          <border_width>1</border_width>
+          <enabled>true</enabled>
+          <font>
+            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
+          </font>
+          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+          <foreground_color>
+            <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+          </foreground_color>
+          <format_type>0</format_type>
+          <height>19</height>
+          <horizontal_alignment>0</horizontal_alignment>
+          <name>Temperature_text_3</name>
+          <precision>3</precision>
+          <precision_from_pv>true</precision_from_pv>
+          <pv_name>$(PV_ROOT):HEATER:VOLT</pv_name>
+          <pv_value />
+          <rotation_angle>0.0</rotation_angle>
+          <rules />
+          <scale_options>
+            <width_scalable>true</width_scalable>
+            <height_scalable>true</height_scalable>
+            <keep_wh_ratio>false</keep_wh_ratio>
+          </scale_options>
+          <scripts />
+          <show_units>true</show_units>
+          <text>######</text>
+          <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+          <transparent>false</transparent>
+          <vertical_alignment>1</vertical_alignment>
+          <visible>true</visible>
+          <widget_type>Text Update</widget_type>
+          <width>57</width>
+          <wrap_words>false</wrap_words>
+          <wuid>-1d6ae919:18234675882:-75f4</wuid>
+          <x>120</x>
+          <y>113</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
           <actions hook="false" hook_all="false" />
@@ -2208,9 +2347,9 @@ $(pv_value)</tooltip>
           <visible>true</visible>
           <widget_type>Text Input</widget_type>
           <width>91</width>
-          <wuid>-7d8c0c3:160fede6a8a:-7f98</wuid>
-          <x>174</x>
-          <y>148</y>
+          <wuid>-1d6ae919:18234675882:-75f3</wuid>
+          <x>180</x>
+          <y>132</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -2260,9 +2399,9 @@ $(pv_value)</tooltip>
           <widget_type>Text Update</widget_type>
           <width>57</width>
           <wrap_words>false</wrap_words>
-          <wuid>-7d8c0c3:160fede6a8a:-7f99</wuid>
-          <x>114</x>
-          <y>148</y>
+          <wuid>-1d6ae919:18234675882:-75f2</wuid>
+          <x>120</x>
+          <y>132</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -2301,9 +2440,9 @@ $(pv_value)</tooltip>
           <widget_type>Label</widget_type>
           <width>78</width>
           <wrap_words>true</wrap_words>
-          <wuid>-7d8c0c3:160fede6a8a:-7f97</wuid>
-          <x>24</x>
-          <y>148</y>
+          <wuid>-1d6ae919:18234675882:-75f1</wuid>
+          <x>30</x>
+          <y>132</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -2325,7 +2464,7 @@ $(pv_value)</tooltip>
           </foreground_color>
           <height>20</height>
           <horizontal_alignment>2</horizontal_alignment>
-          <name>Output_label_2</name>
+          <name>Voltage_limit_percent_label</name>
           <rules />
           <scale_options>
             <width_scalable>true</width_scalable>
@@ -2334,17 +2473,17 @@ $(pv_value)</tooltip>
           </scale_options>
           <scripts />
           <show_scrollbar>false</show_scrollbar>
-          <text>Heater control:</text>
+          <text>% of voltage limit:</text>
           <tooltip></tooltip>
           <transparent>false</transparent>
           <vertical_alignment>1</vertical_alignment>
           <visible>true</visible>
           <widget_type>Label</widget_type>
-          <width>96</width>
+          <width>102</width>
           <wrap_words>true</wrap_words>
-          <wuid>42a2523d:1674fc14987:-7e54</wuid>
-          <x>2</x>
-          <y>6</y>
+          <wuid>-1d6ae919:18234675882:-75f0</wuid>
+          <x>6</x>
+          <y>151</y>
         </widget>
         <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
           <actions hook="false" hook_all="false" />
@@ -2369,12 +2508,12 @@ $(pv_value)</tooltip>
             <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
           </foreground_color>
           <format_type>0</format_type>
-          <height>21</height>
+          <height>19</height>
           <horizontal_alignment>0</horizontal_alignment>
-          <name>Output_text_2</name>
+          <name>Voltage_limit_text_1</name>
           <precision>3</precision>
           <precision_from_pv>true</precision_from_pv>
-          <pv_name>$(PV_ROOT):HEATER:MODE</pv_name>
+          <pv_name>$(PV_ROOT):HEATER:VOLT_PRCNT</pv_name>
           <pv_value />
           <rotation_angle>0.0</rotation_angle>
           <rules />
@@ -2394,55 +2533,9 @@ $(pv_value)</tooltip>
           <widget_type>Text Update</widget_type>
           <width>57</width>
           <wrap_words>false</wrap_words>
-          <wuid>42a2523d:1674fc14987:-7e46</wuid>
-          <x>110</x>
-          <y>5</y>
-        </widget>
-        <widget typeId="org.csstudio.opibuilder.widgets.choiceButton" version="1.0.0">
-          <actions hook="false" hook_all="false" />
-          <alarm_pulsing>false</alarm_pulsing>
-          <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
-          <background_color>
-            <color red="240" green="240" blue="240" />
-          </background_color>
-          <border_alarm_sensitive>false</border_alarm_sensitive>
-          <border_color>
-            <color red="0" green="128" blue="255" />
-          </border_color>
-          <border_style>0</border_style>
-          <border_width>1</border_width>
-          <enabled>true</enabled>
-          <font>
-            <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-          </font>
-          <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-          <foreground_color>
-            <color red="0" green="0" blue="0" />
-          </foreground_color>
-          <height>25</height>
-          <horizontal>true</horizontal>
-          <items_from_pv>true</items_from_pv>
-          <name>Choice Button_1</name>
-          <pv_name>$(PV_ROOT):HEATER:MODE:SP</pv_name>
-          <pv_value />
-          <rules />
-          <scale_options>
-            <width_scalable>true</width_scalable>
-            <height_scalable>true</height_scalable>
-            <keep_wh_ratio>false</keep_wh_ratio>
-          </scale_options>
-          <scripts />
-          <selected_color>
-            <color red="255" green="255" blue="255" />
-          </selected_color>
-          <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-          <visible>true</visible>
-          <widget_type>Choice Button</widget_type>
-          <width>100</width>
-          <wuid>42a2523d:1674fc14987:-7e4e</wuid>
-          <x>170</x>
-          <y>6</y>
+          <wuid>-1d6ae919:18234675882:-75ef</wuid>
+          <x>120</x>
+          <y>151</y>
         </widget>
       </widget>
       <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
@@ -3392,9 +3485,9 @@ $(pv_value)</tooltip>
         <transparent>false</transparent>
         <visible>true</visible>
         <widget_type>Grouping Container</widget_type>
-        <width>319</width>
+        <width>327</width>
         <wuid>8c31286:174e9b3a29e:-7e6e</wuid>
-        <x>318</x>
+        <x>310</x>
         <y>234</y>
         <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
           <actions hook="false" hook_all="false" />


### PR DESCRIPTION
### Description of work
Added a percentage readout to show what % of the voltage limit is being used by the heaters on the pressure and temperature cards. This was requested by scientists that were mistakenly reading the "Power" value as a percent of the limit. 

### Ticket

Partially Fixes ISISComputingGroup/IBEX#6283

### Acceptance criteria
1. The percentage appears correctly on the settings screen of the temp and pressure cards. 
2. The readout style should match the other readouts related to voltage
3. The style matches the usual IBEX style guide. 

### Unit tests

Added unit tests to check that the calculation is occuring correctly. 

### System tests
N/A

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

