### PR TITLE
Ticket7133 log plotter disabled notification

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoMenu.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoMenu.java
@@ -66,7 +66,7 @@ public class BeamInfoMenu extends MenuManager {
 				} else {
 					Shell shell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
 					MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.OK);
-					messageBox.setText(String.format("Failed to Open \"%s\" in Log Plotter", facilityPV.pv));
+					messageBox.setText("Failed to open in Log Plotter");
 					messageBox.setMessage("Make the Log Plotter perspective visible.");
 					messageBox.open();
 				}

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoMenu.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoMenu.java
@@ -7,6 +7,9 @@ import org.apache.logging.log4j.Logger;
 import org.eclipse.jface.action.Action;
 
 import org.eclipse.jface.action.MenuManager;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IPerspectiveRegistry;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
@@ -60,6 +63,12 @@ public class BeamInfoMenu extends MenuManager {
 				if (BlocksMenu.canAddPlot()) {
 					switchToLogPlotter();
 					Presenter.pvHistoryPresenter().newDisplay(facilityPV.pv, facilityPV.pv);
+				} else {
+					Shell shell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
+					MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.OK);
+					messageBox.setText(String.format("Failed to Open \"%s\" in Log Plotter", facilityPV.pv));
+					messageBox.setMessage("Make the Log Plotter perspective visible.");
+					messageBox.open();
 				}
 			}
 		});

--- a/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.logplotter/src/uk/ac/stfc/isis/ibex/ui/logplotter/OpenLogPlotterPopup.java
@@ -28,6 +28,9 @@ import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IPerspectiveRegistry;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
@@ -114,6 +117,12 @@ public class OpenLogPlotterPopup extends AbstractHandler {
                 MessageDialog.openError(editor.getSite().getShell(),
                         "Error", ex.getMessage());
             }
+    	} else {
+    		Shell shell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
+			MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.OK);
+			messageBox.setText("Failed to open in Log Plotter");
+			messageBox.setMessage("Make the Log Plotter perspective visible.");
+			messageBox.open();
     	}
         return null;
     }


### PR DESCRIPTION
### Description of work

Added message boxes to Beam Info and OPIs that warn when adding a PV to the Log Plotter if the Log Plotter perspective is disabled.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/7133

### Acceptance criteria

See ticket.


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

