### PR TITLE
Use local .m2 location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ build/Output
 .vscode
 __pycache__
 build/maven
+build/.m2
 build/ICP_Binaries_maven.log
 base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/ScriptDefinitions_repo.bundle
 base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/git

--- a/build/build.bat
+++ b/build/build.bat
@@ -38,7 +38,7 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 if "%BUILD_NUMBER%" == "" SET BUILD_NUMBER=SNAPSHOT
 
 set mvnErr=
-call mvn --settings=%~dp0..\mvn_user_settings.xml -f %~dp0..\base\uk.ac.stfc.isis.ibex.client.tycho.parent\pom.xml -DforceContextQualifier=%BUILD_NUMBER% clean verify || set mvnErr=1
+call mvn --settings=%~dp0..\mvn_user_settings.xml -f %~dp0..\base\uk.ac.stfc.isis.ibex.client.tycho.parent\pom.xml -DforceContextQualifier=%BUILD_NUMBER% -Dmaven.repo.local=%~dp0\.m2 clean verify || set mvnErr=1
 if defined mvnErr exit /b 1
 
 REM Copy built client into a sensible directory to run it

--- a/build/build_script_generator.bat
+++ b/build/build_script_generator.bat
@@ -60,7 +60,7 @@ if %errorlevel% geq 4 (
 
 
 set mvnErr=
-call mvn --settings=%~dp0..\mvn_user_settings.xml -f %~dp0..\base\uk.ac.stfc.isis.scriptgenerator.tycho.parent\pom.xml -DforceContextQualifier=%BUILD_NUMBER% clean verify || set mvnErr=1
+call mvn --settings=%~dp0..\mvn_user_settings.xml -f %~dp0..\base\uk.ac.stfc.isis.scriptgenerator.tycho.parent\pom.xml -DforceContextQualifier=%BUILD_NUMBER% -Dmaven.repo.local=%~dp0\.m2 clean verify || set mvnErr=1
 if defined mvnErr exit /b 1
 
 REM Copy built client into a sensible clean directory to run it


### PR DESCRIPTION
Use local `.m2` cache directory.

This prevents conflicts if maven is updated in one project/branch but not another, and the `.m2` repo structure changes incompatibly between versions.