### PR TITLE
Depend on tyrus via maven rather than via custom P2 site

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.feature.base/feature.xml
+++ b/base/uk.ac.stfc.isis.ibex.feature.base/feature.xml
@@ -1556,11 +1556,12 @@
          install-size="0"
          version="0.0.0"
          unpack="false"/>
-    <plugin
-         id="org.glassfish.tyrus.bundles.tyrus-standalone-client"
+
+   <plugin
+         id="wrapped.org.glassfish.tyrus.bundles.tyrus-standalone-client"
          download-size="0"
          install-size="0"
-         version="2.0.4"
+         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/base/uk.ac.stfc.isis.ibex.targetplatform/targetplatform.target
+++ b/base/uk.ac.stfc.isis.ibex.targetplatform/targetplatform.target
@@ -219,9 +219,15 @@
 			</dependency>
 		</dependencies>
 	</location>
-    <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="http://shadow.nd.rl.ac.uk/ICP_P2/Tyrus_P2_2.0.4/target/repository/"/>
-		<unit id="org.glassfish.tyrus.bundles.tyrus-standalone-client" version="2.0.4"/>
+	<location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">
+		<dependencies>
+			<dependency>
+				<groupId>org.glassfish.tyrus.bundles</groupId>
+				<artifactId>tyrus-standalone-client</artifactId>
+				<version>2.1.0</version>
+				<type>jar</type>
+			</dependency>
+		</dependencies>
 	</location>
 </locations>
 <environment>

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/META-INF/MANIFEST.MF
@@ -18,10 +18,10 @@ Require-Bundle: org.eclipse.ui,
  com.google.guava,
  javax.annotation;bundle-version="1.3.5",
  org.eclipse.e4.ui.model.workbench;bundle-version="2.1.1000",
- org.glassfish.tyrus.bundles.tyrus-standalone-client;bundle-version="2.0.4",
  org.eclipse.e4.ui.workbench,
  org.eclipse.e4.core.contexts;bundle-version="1.8.400",
- wrapped.net.sf.py4j.py4j;bundle-version="0.10.9"
+ wrapped.net.sf.py4j.py4j;bundle-version="0.10.9",
+ wrapped.org.glassfish.tyrus.bundles.tyrus-standalone-client;bundle-version="2.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Export-Package: uk.ac.stfc.isis.ibex.ui.graphing


### PR DESCRIPTION
Depend on `tyrus` directly via maven, rather than via a custom P2 site.

This was missed from dependency updates because the plotting ticket (which tyrus was added in) happened in parallel with dep updates.

Both methods *work*, but depending via maven is significantly nicer and makes it much easier to update dependencies etc later as we don't have to mess around with rebuilding custom P2 sites.