### PR TITLE
#5470 adds mocked observable and writable for new checkbox in experim…

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.experimentdetails.tests/src/uk/ac/stfc/isis/ibex/ui/experimentdetails/tests/ExperimentDetailsViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.experimentdetails.tests/src/uk/ac/stfc/isis/ibex/ui/experimentdetails/tests/ExperimentDetailsViewModelTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import uk.ac.stfc.isis.ibex.epics.observing.ClosableObservable;
+import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.epics.writing.Writable;
 import uk.ac.stfc.isis.ibex.experimentdetails.ObservableExperimentDetailsModel;
 import uk.ac.stfc.isis.ibex.ui.experimentdetails.ExperimentDetailsViewModel;
@@ -49,6 +50,8 @@ public class ExperimentDetailsViewModelTest {
         
         when(model.rbNumber()).thenReturn(mock(ClosableObservable.class));
         when(model.rbNumberSetter()).thenReturn(mock(Writable.class));
+        when(model.displayTitle()).thenReturn(mock(ForwardingObservable.class));
+        when(model.displayTitleSetter()).thenReturn(mock(Writable.class));
         
         viewModel = new ExperimentDetailsViewModel(model);
     }


### PR DESCRIPTION
### Description of work

i forgor :skull: to add mocks of the observable and writable for `displayTitle`, added in https://github.com/ISISComputingGroup/genie_python/pull/368

### Acceptance criteria

`uk.ac.stfc.isis.ibex.ui.experimentdetails.tests.ExperimentDetailsViewModelTest` passes

### Unit tests

`uk.ac.stfc.isis.ibex.ui.experimentdetails.tests.ExperimentDetailsViewModelTest`

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

