### PR TITLE
Ticket7483

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/comms/RepeatingJob.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/comms/RepeatingJob.java
@@ -63,11 +63,9 @@ public abstract class RepeatingJob extends Job {
                 return doTask(monitor);
             } catch (RuntimeException e) {
             	LoggerUtils.logErrorWithStackTrace(LOG, "Exception in repeating job " + this + ": " + e.getMessage(), e);
-            	throw e;
             }
-        } else {
-            return Status.CANCEL_STATUS;
         }
+        return Status.CANCEL_STATUS;
     }
 
     /**


### PR DESCRIPTION
### Description of work

When the Script Server stops or crashes the `RepeatingJob` tries to send a message to a socket that is null and throws an `IllegalStateException`, this exception is caught inside the `run` method of the `RepeatingJob` but then gets rethrown. That exception seems to never be caught.

To reproduce:
- Start NICOS.
- Stop NICOS.
- There should be an uncaught exception stack trace in the console.

All relevant info is already logged or shown in the GUI, so the rethrow can safely be removed.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/7483

### Acceptance criteria

I don't think adding any tests is necessary.

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

