### PR TITLE
Ticket7461

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.graphing.tests/src/uk/ac/stfc/isis/ibex/ui/graphing/tests/MatplotlibModelTests.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing.tests/src/uk/ac/stfc/isis/ibex/ui/graphing/tests/MatplotlibModelTests.java
@@ -107,7 +107,8 @@ public class MatplotlibModelTests {
     
     @Test
     public void WHEN_refresh_requested_THEN_refresh_queued() {
-    	model.forceServerRefresh();;
+    	model.setImageData(new ByteArrayInputStream(FAKE_IMAGE_BYTES));
+    	model.forceServerRefresh();
     	Mockito.verify(workerThread, Mockito.times(1)).submit(runnableCaptor.capture());
     	
     	runnableCaptor.getValue().run();

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing.tests/src/uk/ac/stfc/isis/ibex/ui/graphing/tests/MatplotlibViewModelTests.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing.tests/src/uk/ac/stfc/isis/ibex/ui/graphing/tests/MatplotlibViewModelTests.java
@@ -39,6 +39,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.ac.stfc.isis.ibex.ui.graphing.websocketview.MatplotlibButtonState;
 import uk.ac.stfc.isis.ibex.ui.graphing.websocketview.MatplotlibButtonType;
 import uk.ac.stfc.isis.ibex.ui.graphing.websocketview.MatplotlibCursorPosition;
+import uk.ac.stfc.isis.ibex.ui.graphing.websocketview.MatplotlibCursorType;
 import uk.ac.stfc.isis.ibex.ui.graphing.websocketview.MatplotlibFigureViewModel;
 import uk.ac.stfc.isis.ibex.ui.graphing.websocketview.MatplotlibNavigationType;
 import uk.ac.stfc.isis.ibex.ui.graphing.websocketview.MatplotlibPressType;
@@ -144,6 +145,21 @@ public class MatplotlibViewModelTests {
     	assertEquals(viewModel.getForwardButtonState().getValue(), MatplotlibButtonState.DISABLED);
     }
     
+   @Test 
+   public void WHEN_server_connected_and_cursor_style_received_THEN_cursor_updated() {
+	   Mockito.when(model.getCursorType()).thenReturn(MatplotlibCursorType.CROSSHAIR);
+	   Mockito.when(model.isConnected()).thenReturn(true);
+	   viewModel.updateCursorType();
+	   assertEquals(viewModel.getCursorType().getValue(), MatplotlibCursorType.CROSSHAIR);
+   }
+   
+   @Test
+   public void WHEN_server_disconnected_then_cursor_style_default() {
+	   Mockito.when(model.isConnected()).thenReturn(false);
+	   viewModel.updateCursorType();
+	   assertEquals(viewModel.getCursorType().getValue(), MatplotlibCursorType.DEFAULT);
+   }
+    
     @Test
     public void WHEN_canvas_resized_THEN_resize_request_sent_to_model() {
     	Mockito.verify(workerThread, Mockito.times(4)).scheduleWithFixedDelay(runnableCaptor.capture(), Mockito.anyLong(), Mockito.anyLong(), Mockito.any());
@@ -226,6 +242,48 @@ public class MatplotlibViewModelTests {
     	viewModel.navigatePlot(navType);
     	
     	Mockito.verify(model, Mockito.times(1)).navigatePlot(navType);
+    }
+    
+    @Test
+    public void WHEN_zoom_enabled_and_button_press_THEN_drag_status_true() {
+    	Mockito.when(model.getNavMode()).thenReturn(MatplotlibNavigationType.ZOOM);
+    	Mockito.when(model.isConnected()).thenReturn(true);
+    	viewModel.updateNavMode();
+    	
+    	viewModel.notifyButtonPressed(new MatplotlibCursorPosition(0, 0, true), MatplotlibPressType.BUTTON_PRESS);
+    	assertEquals(viewModel.getDragState().getValue(), true);
+    }
+    
+    @Test
+    public void WHEN_zoom_enabled_and_button_up_THEN_drag_status_false() {
+    	Mockito.when(model.getNavMode()).thenReturn(MatplotlibNavigationType.ZOOM);
+    	Mockito.when(model.isConnected()).thenReturn(true);
+    	viewModel.updateNavMode();
+    	
+    	viewModel.notifyButtonPressed(new MatplotlibCursorPosition(0, 0, true), MatplotlibPressType.BUTTON_RELEASE);
+    	assertEquals(viewModel.getDragState().getValue(), false);
+    }
+    
+    @Test
+    public void WHEN_zoom_enabled_and_mouse_moves_THEN_drag_status_true() {
+    	Mockito.when(model.getNavMode()).thenReturn(MatplotlibNavigationType.ZOOM);
+    	Mockito.when(model.isConnected()).thenReturn(true);
+    	viewModel.updateNavMode();
+    	
+    	viewModel.notifyButtonPressed(new MatplotlibCursorPosition(0, 0, true), MatplotlibPressType.BUTTON_PRESS);
+    	
+    	viewModel.setCursorPosition(new MatplotlibCursorPosition(0, 0, true));
+    	assertEquals(viewModel.getDragState().getValue(), true);
+    }
+    
+    @Test
+    public void WHEN_zoom_not_active_and_mouse_moves_THEN_drag_status_false() {
+    	Mockito.when(model.getNavMode()).thenReturn(MatplotlibNavigationType.ZOOM);
+    	Mockito.when(model.isConnected()).thenReturn(true);
+    	viewModel.updateNavMode();
+    	
+    	viewModel.setCursorPosition(new MatplotlibCursorPosition(0, 0, true));
+    	assertEquals(viewModel.getDragState().getValue(), false);
     }
     
     @Test

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing.tests/src/uk/ac/stfc/isis/ibex/ui/graphing/tests/MatplotlibViewModelTests.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing.tests/src/uk/ac/stfc/isis/ibex/ui/graphing/tests/MatplotlibViewModelTests.java
@@ -185,7 +185,7 @@ public class MatplotlibViewModelTests {
     			Optional.of(new ImageData(new ByteArrayInputStream(MatplotlibModelTests.FAKE_IMAGE_BYTES))));
     	
     	var mockListener = Mockito.mock(PropertyChangeListener.class);
-    	viewModel.getImage().addPropertyChangeListener(mockListener);
+    	viewModel.getCanvasData().addPropertyChangeListener(mockListener);
     	viewModel.imageUpdated();
     	
     	// index 0 = redraw, 1 = canvas size, 2 = cursor position, 3 = force refresh

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibCanvasData.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibCanvasData.java
@@ -1,0 +1,19 @@
+package uk.ac.stfc.isis.ibex.ui.graphing.websocketview;
+import java.util.Map;
+import org.eclipse.swt.graphics.ImageData;
+import uk.ac.stfc.isis.ibex.model.SettableUpdatedValue;
+
+/**
+ * Record to encapsulate all the data belonging to the matplotlib plot canvas.
+ */
+public record MatplotlibCanvasData(ImageData image, Map<String, Integer> zoomSelectionArea) {
+	/**
+	 * Constructor for MatplotlibCanvasData.
+	 * @param image
+	 * @param zoomSelectionArea
+	 */
+	public MatplotlibCanvasData(ImageData image, Map<String, Integer> zoomSelectionArea) {
+		this.image = image;
+		this.zoomSelectionArea = zoomSelectionArea;
+	}
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibCanvasData.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibCanvasData.java
@@ -1,7 +1,6 @@
 package uk.ac.stfc.isis.ibex.ui.graphing.websocketview;
 import java.util.Map;
 import org.eclipse.swt.graphics.ImageData;
-import uk.ac.stfc.isis.ibex.model.SettableUpdatedValue;
 
 /**
  * Record to encapsulate all the data belonging to the matplotlib plot canvas.

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibCanvasData.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibCanvasData.java
@@ -2,17 +2,8 @@ package uk.ac.stfc.isis.ibex.ui.graphing.websocketview;
 import java.util.Map;
 import org.eclipse.swt.graphics.ImageData;
 
+
 /**
- * Record to encapsulate all the data belonging to the matplotlib plot canvas.
+ * Encapsulates all the data belonging to a matplotlib plot canvas.
  */
-public record MatplotlibCanvasData(ImageData image, Map<String, Integer> zoomSelectionArea) {
-	/**
-	 * Constructor for MatplotlibCanvasData.
-	 * @param image
-	 * @param zoomSelectionArea
-	 */
-	public MatplotlibCanvasData(ImageData image, Map<String, Integer> zoomSelectionArea) {
-		this.image = image;
-		this.zoomSelectionArea = zoomSelectionArea;
-	}
-}
+public record MatplotlibCanvasData(ImageData image, Map<String, Integer> zoomSelectionArea) { }

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibCursorType.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibCursorType.java
@@ -1,0 +1,22 @@
+package uk.ac.stfc.isis.ibex.ui.graphing.websocketview;
+
+/**
+ * Describes the types of cursors which can be used.
+ */
+public enum MatplotlibCursorType {
+	/**
+	 * Normal cursor type.
+	 */
+	DEFAULT,
+	
+	/**
+	 * 'Crosshair' cursor type (for zooming).
+	 */
+	CROSSHAIR,
+	
+	/**
+	 * Grabbing hand cursor type (for panning).
+	 */
+	HAND;
+	
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibDragSelectionType.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibDragSelectionType.java
@@ -1,0 +1,19 @@
+package uk.ac.stfc.isis.ibex.ui.graphing.websocketview;
+
+/**
+ * Describes the state of a zoom drag selection.
+ */
+public enum MatplotlibDragSelectionType {
+	/**
+	 * Drag selection begins.
+	 */
+	DRAG_START,
+	/**
+	 * Drag selection area is changing.
+	 */
+	DRAG_UPDATE,
+	/**
+	 * Drag selection has ended.
+	 */
+	DRAG_END;
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
@@ -110,6 +110,17 @@ public class MatplotlibFigure extends Composite {
 				viewModel.canvasResized(bounds.width, bounds.height);
 			}
 		});
+
+		plotCanvas.addPaintListener(e -> {
+			e.gc.drawImage(plotImage, 0, 0);
+			
+            if (viewModel.getDragState().getValue()) {
+                Map<String, Integer> bounds = viewModel.getCanvasData().getValue().zoomSelectionArea();
+                
+                e.gc.setLineStyle(SWT.LINE_DASH);
+                e.gc.drawRectangle(bounds.get("minX"), bounds.get("minY"), bounds.get("width"), bounds.get("height"));
+            }
+        });
 		
 		viewModel.canvasResized(plotCanvas.getBounds().width, plotCanvas.getBounds().height);
 		
@@ -155,17 +166,6 @@ public class MatplotlibFigure extends Composite {
 		plotCanvas.addMouseTrackListener(mouseTrackListener);
 		plotCanvas.addMouseMoveListener(mouseMoveListener);
 		plotCanvas.addMouseListener(mouseListener);
-		
-		plotCanvas.addPaintListener(e -> {
-			e.gc.drawImage(plotImage, 0, 0);
-			
-            if (viewModel.getDragState().getValue()) {
-                Map<String, Integer> bounds = viewModel.getCanvasData().getValue().zoomSelectionArea();
-                
-                e.gc.setLineStyle(SWT.LINE_DASH);
-                e.gc.drawRectangle(bounds.get("minX"), bounds.get("minY"), bounds.get("width"), bounds.get("height"));
-            }
-        });
 		
 		connectionNameListener = viewModel.getPlotName()
 				.addUiThreadPropertyChangeListener(e -> {

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
@@ -182,9 +182,9 @@ public class MatplotlibFigure extends Composite {
 		cursorTypeListener = viewModel.getCursorType()
 				.addUiThreadPropertyChangeListener(e -> {
 					if (!container.isDisposed()) {
-					    if (viewModel.getCursorType().getValue().equals(MatplotlibCursorType.CROSSHAIR)) {
+					    if (MatplotlibCursorType.CROSSHAIR.equals(viewModel.getCursorType().getValue())) {
 					    	container.setCursor(zoomCursor);
-					    } else if (viewModel.getCursorType().getValue().equals(MatplotlibCursorType.HAND)) {
+					    } else if (MatplotlibCursorType.HAND.equals(viewModel.getCursorType().getValue())) {
 					    	container.setCursor(panCursor);
 					    } else {
 					    	container.setCursor(defaultCursor);

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
@@ -13,11 +13,9 @@ import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseMoveListener;
 import org.eclipse.swt.events.MouseTrackAdapter;
 import org.eclipse.swt.events.MouseTrackListener;
-import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.ImageData;
-import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -25,8 +23,6 @@ import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.Tracker;
 
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.logger.LoggerUtils;
@@ -156,13 +152,10 @@ public class MatplotlibFigure extends Composite {
 		plotCanvas.addListener(SWT.Paint, e -> {
             if (viewModel.getDragState().getValue()) {
                 GC gc = e.gc;
-                gc.setLineStyle(SWT.LINE_DASH);
-
-                //gc.setBackground(Display.getDefault().getSystemColor(SWT.COLOR_BLACK));
-                gc.setAlpha(128);
-
+                
                 Map<String, Integer> bounds = viewModel.getSelectionBounds();
                 
+                gc.setLineStyle(SWT.LINE_DASH);
                 gc.drawRectangle(bounds.get("minX"), bounds.get("minY"), bounds.get("width"), bounds.get("height"));
             }
         });

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
@@ -193,7 +193,9 @@ public class MatplotlibFigure extends Composite {
 					}
 				});
 		canvasListener = viewModel.getCanvasData()
-				.addUiThreadPropertyChangeListener(e -> drawImage(viewModel.getImage().getValue()));
+				.addUiThreadPropertyChangeListener(e -> {
+					drawImage(viewModel.getCanvasData().getValue().image());
+				});
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
@@ -102,7 +102,7 @@ public class MatplotlibFigure extends Composite {
 			}
 		});
 		
-		plotCanvas.addPaintListener(event -> event.gc.drawImage(plotImage, 0, 0));
+		//plotCanvas.addPaintListener(event -> event.gc.drawImage(plotImage, 0, 0));
 		
 		viewModel.canvasResized(plotCanvas.getBounds().width, plotCanvas.getBounds().height);
 		
@@ -149,7 +149,9 @@ public class MatplotlibFigure extends Composite {
 		plotCanvas.addMouseMoveListener(mouseMoveListener);
 		plotCanvas.addMouseListener(mouseListener);
 		
-		plotCanvas.addListener(SWT.Paint, e -> {
+		plotCanvas.addPaintListener(e -> {
+			e.gc.drawImage(plotImage, 0, 0);
+			
             if (viewModel.getDragState().getValue()) {
                 GC gc = e.gc;
                 

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigure.java
@@ -181,10 +181,10 @@ public class MatplotlibFigure extends Composite {
 				});
 		cursorTypeListener = viewModel.getCursorType()
 				.addUiThreadPropertyChangeListener(e -> {
-					if (!plotMessage.isDisposed()) {
-					    if (viewModel.getCursorType().getValue() == MatplotlibCursorType.CROSSHAIR) {
+					if (!container.isDisposed()) {
+					    if (viewModel.getCursorType().getValue().equals(MatplotlibCursorType.CROSSHAIR)) {
 					    	container.setCursor(zoomCursor);
-					    } else if (viewModel.getCursorType().getValue() == MatplotlibCursorType.HAND) {
+					    } else if (viewModel.getCursorType().getValue().equals(MatplotlibCursorType.HAND)) {
 					    	container.setCursor(panCursor);
 					    } else {
 					    	container.setCursor(defaultCursor);
@@ -247,6 +247,10 @@ public class MatplotlibFigure extends Composite {
 			plotCanvas.dispose();
 		}
 		labelConnectionStatus.dispose();
+		
+		defaultCursor.dispose();
+		zoomCursor.dispose();
+		panCursor.dispose();
 		
 		toolBar.dispose();
 		

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
@@ -525,7 +525,7 @@ public class MatplotlibFigureViewModel implements Closeable {
 	
 	/**
 	 * Gets the bounds of the zoom selection box.
-	 * @return map of: min x and y distances, width, height
+	 * @return map of: min x and y distances, width & height
 	 */
 	private Map<String, Integer> calculateZoomSelectionBounds() {
 		 int minX = Math.min(dragStartPos.getValue().x(), dragEndPos.getValue().x());

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
@@ -32,6 +32,7 @@ public class MatplotlibFigureViewModel implements Closeable {
 	private final SettableUpdatedValue<String> plotName;
 	private final SettableUpdatedValue<String> plotMessage;
 	private final SettableUpdatedValue<ImageData> image;
+	private final SettableUpdatedValue<MatplotlibCursorType> cursorType;
 	
 	private final SettableUpdatedValue<MatplotlibButtonState> homeState;
 	private final SettableUpdatedValue<MatplotlibButtonState> backState;
@@ -117,6 +118,7 @@ public class MatplotlibFigureViewModel implements Closeable {
 				String.format("[Disconnected] %s", model.getPlotName(), figureNumber));
 		image = new SettableUpdatedValue<ImageData>(generateBlankImage());
 		plotMessage = new SettableUpdatedValue<String>("");
+		cursorType = new SettableUpdatedValue<MatplotlibCursorType>(MatplotlibCursorType.DEFAULT);
 		
 		backState = new SettableUpdatedValue<MatplotlibButtonState>(MatplotlibButtonState.DISABLED);
 		forwardState = new SettableUpdatedValue<MatplotlibButtonState>(MatplotlibButtonState.DISABLED);
@@ -153,6 +155,8 @@ public class MatplotlibFigureViewModel implements Closeable {
 				String.format("[Disconnected] %s", model.getPlotName(), figureNumber));
 		image = new SettableUpdatedValue<ImageData>(generateBlankImage());
 		plotMessage = new SettableUpdatedValue<String>("");
+		cursorType = new SettableUpdatedValue<MatplotlibCursorType>(MatplotlibCursorType.DEFAULT);
+		
 		backState = new SettableUpdatedValue<MatplotlibButtonState>(MatplotlibButtonState.DISABLED);
 		forwardState = new SettableUpdatedValue<MatplotlibButtonState>(MatplotlibButtonState.DISABLED);
 		homeState = new SettableUpdatedValue<MatplotlibButtonState>(MatplotlibButtonState.DISABLED);
@@ -303,6 +307,21 @@ public class MatplotlibFigureViewModel implements Closeable {
 	}
 	
 	/**
+	 * Updates the cursor appearance from the model. 
+	 */
+	public void updateCursorType() {
+		if (model.isConnected()) { 
+			cursorType.setValue(model.getCursorType());
+		} else { 
+			cursorType.setValue(MatplotlibCursorType.DEFAULT);
+		}
+	}
+	
+	public SettableUpdatedValue<MatplotlibCursorType> getCursorType() {
+		return cursorType;
+	}
+	
+	/**
 	 * @return pan enabled state
 	 */
 	public UpdatedValue<MatplotlibButtonState> getPanButtonState() {
@@ -422,6 +441,7 @@ public class MatplotlibFigureViewModel implements Closeable {
 	public void onConnectionStatus(boolean isConnected) {
 		updatePlotName();
 		updatePlotMessage();
+		updateCursorType();
 		updateForwardState();
 		updateBackState();
 		updateNavMode();

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
@@ -465,7 +465,7 @@ public class MatplotlibFigureViewModel implements Closeable {
 		cursorPositionChanged.set(true);
 		
 		// if zoom and drag are enabled manage drag selection
-		if (zoomState.getValue().equals(MatplotlibButtonState.ENABLED_ACTIVE) && dragState.getValue()) {
+		if (MatplotlibButtonState.ENABLED_ACTIVE.equals(zoomState.getValue()) && dragState.getValue()) {
 			setSelectionBounds(MatplotlibDragSelectionType.DRAG_UPDATE, cursorPosition);
 		}
 	}
@@ -480,7 +480,7 @@ public class MatplotlibFigureViewModel implements Closeable {
 		model.notifyButtonPress(cursorPosition, pressType);
 		
 		// if zoom is enabled manage drag selection
-		if (zoomState.getValue().equals(MatplotlibButtonState.ENABLED_ACTIVE)) {
+		if (MatplotlibButtonState.ENABLED_ACTIVE.equals(zoomState.getValue())) {
 			switch (pressType) {
 				case BUTTON_PRESS:
 					setSelectionBounds(MatplotlibDragSelectionType.DRAG_START, cursorPosition);
@@ -510,11 +510,11 @@ public class MatplotlibFigureViewModel implements Closeable {
 	 * @param cursorPosition
 	 */
 	public void setSelectionBounds(MatplotlibDragSelectionType dragType, MatplotlibCursorPosition cursorPosition) {
-		if (dragType.equals(MatplotlibDragSelectionType.DRAG_START)) {
+		if (MatplotlibDragSelectionType.DRAG_START.equals(dragType)) {
 			dragStartPos.setValue(cursorPosition);
 			dragEndPos.setValue(cursorPosition);
 			dragState.setValue(true);
-		} else if (dragType.equals(MatplotlibDragSelectionType.DRAG_UPDATE)) {
+		} else if (MatplotlibDragSelectionType.DRAG_UPDATE.equals(dragType)) {
 			dragEndPos.setValue(cursorPosition);
 			dragState.setValue(true);
 		} else {

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
@@ -465,7 +465,7 @@ public class MatplotlibFigureViewModel implements Closeable {
 		cursorPositionChanged.set(true);
 		
 		// if zoom and drag are enabled manage drag selection
-		if (zoomState.getValue() == MatplotlibButtonState.ENABLED_ACTIVE && dragState.getValue()) {
+		if (zoomState.getValue().equals(MatplotlibButtonState.ENABLED_ACTIVE) && dragState.getValue()) {
 			setSelectionBounds(MatplotlibDragSelectionType.DRAG_UPDATE, cursorPosition);
 		}
 	}
@@ -480,7 +480,7 @@ public class MatplotlibFigureViewModel implements Closeable {
 		model.notifyButtonPress(cursorPosition, pressType);
 		
 		// if zoom is enabled manage drag selection
-		if (zoomState.getValue() == MatplotlibButtonState.ENABLED_ACTIVE) {
+		if (zoomState.getValue().equals(MatplotlibButtonState.ENABLED_ACTIVE)) {
 			switch (pressType) {
 				case BUTTON_PRESS:
 					setSelectionBounds(MatplotlibDragSelectionType.DRAG_START, cursorPosition);
@@ -510,11 +510,11 @@ public class MatplotlibFigureViewModel implements Closeable {
 	 * @param cursorPosition
 	 */
 	public void setSelectionBounds(MatplotlibDragSelectionType dragType, MatplotlibCursorPosition cursorPosition) {
-		if (dragType == MatplotlibDragSelectionType.DRAG_START) {
+		if (dragType.equals(MatplotlibDragSelectionType.DRAG_START)) {
 			dragStartPos.setValue(cursorPosition);
 			dragEndPos.setValue(cursorPosition);
 			dragState.setValue(true);
-		} else if (dragType == MatplotlibDragSelectionType.DRAG_UPDATE) {
+		} else if (dragType.equals(MatplotlibDragSelectionType.DRAG_UPDATE)) {
 			dragEndPos.setValue(cursorPosition);
 			dragState.setValue(true);
 		} else {

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibFigureViewModel.java
@@ -10,7 +10,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.logging.log4j.Logger;
-import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.RGB;
@@ -41,8 +40,8 @@ public class MatplotlibFigureViewModel implements Closeable {
 	private final SettableUpdatedValue<MatplotlibButtonState> panState;
 	private final SettableUpdatedValue<MatplotlibNavigationType> navMode;
 	
-	private final SettableUpdatedValue<MatplotlibCursorPosition> startPos;
-	private final SettableUpdatedValue<MatplotlibCursorPosition> endPos;
+	private final SettableUpdatedValue<MatplotlibCursorPosition> dragStartPos;
+	private final SettableUpdatedValue<MatplotlibCursorPosition> dragEndPos;
 	private final SettableUpdatedValue<Boolean> dragState;
 	
 	
@@ -125,8 +124,8 @@ public class MatplotlibFigureViewModel implements Closeable {
 		panState = new SettableUpdatedValue<MatplotlibButtonState>(MatplotlibButtonState.DISABLED);
 		navMode = new SettableUpdatedValue<MatplotlibNavigationType>(MatplotlibNavigationType.NONE);
 		
-		startPos = new SettableUpdatedValue<MatplotlibCursorPosition>(new MatplotlibCursorPosition(0, 0, true));
-		endPos = new SettableUpdatedValue<MatplotlibCursorPosition>(new MatplotlibCursorPosition(0, 0, true));
+		dragStartPos = new SettableUpdatedValue<MatplotlibCursorPosition>(new MatplotlibCursorPosition(0, 0, true));
+		dragEndPos = new SettableUpdatedValue<MatplotlibCursorPosition>(new MatplotlibCursorPosition(0, 0, true));
 		dragState = new SettableUpdatedValue<Boolean>(false);
 		
 		updateExecutor  = 
@@ -159,8 +158,8 @@ public class MatplotlibFigureViewModel implements Closeable {
 		panState = new SettableUpdatedValue<MatplotlibButtonState>(MatplotlibButtonState.DISABLED);
 		navMode = new SettableUpdatedValue<MatplotlibNavigationType>(MatplotlibNavigationType.NONE);
 
-		startPos = new SettableUpdatedValue<MatplotlibCursorPosition>(new MatplotlibCursorPosition(0, 0, true));
-		endPos = new SettableUpdatedValue<MatplotlibCursorPosition>(new MatplotlibCursorPosition(0, 0, true));
+		dragStartPos = new SettableUpdatedValue<MatplotlibCursorPosition>(new MatplotlibCursorPosition(0, 0, true));
+		dragEndPos = new SettableUpdatedValue<MatplotlibCursorPosition>(new MatplotlibCursorPosition(0, 0, true));
 		dragState = new SettableUpdatedValue<Boolean>(false);
 		
 		updateExecutor  = executor;
@@ -481,14 +480,14 @@ public class MatplotlibFigureViewModel implements Closeable {
 	 */
 	public void setSelectionBounds(MatplotlibDragSelectionType dragType, MatplotlibCursorPosition cursorPosition) {
 		if (dragType == MatplotlibDragSelectionType.DRAG_START) {
-			startPos.setValue(cursorPosition);
-			endPos.setValue(cursorPosition);
+			dragStartPos.setValue(cursorPosition);
+			dragEndPos.setValue(cursorPosition);
 			dragState.setValue(true);
 		} else if (dragType == MatplotlibDragSelectionType.DRAG_UPDATE) {
-			endPos.setValue(cursorPosition);
+			dragEndPos.setValue(cursorPosition);
 			dragState.setValue(true);
 		} else {
-			endPos.setValue(cursorPosition);
+			dragEndPos.setValue(cursorPosition);
 			dragState.setValue(false);
 		}
 	}
@@ -498,11 +497,11 @@ public class MatplotlibFigureViewModel implements Closeable {
 	 * @return map of: min x and y distances, width, height
 	 */
 	public Map<String, Integer> getSelectionBounds() {
-		 int minX = Math.min(startPos.getValue().x(), endPos.getValue().x());
-         int minY = Math.min(startPos.getValue().y(), endPos.getValue().y());
+		 int minX = Math.min(dragStartPos.getValue().x(), dragEndPos.getValue().x());
+         int minY = Math.min(dragStartPos.getValue().y(), dragEndPos.getValue().y());
 
-         int maxX = Math.max(startPos.getValue().x(), endPos.getValue().x());
-         int maxY = Math.max(startPos.getValue().y(), endPos.getValue().y());
+         int maxX = Math.max(dragStartPos.getValue().x(), dragEndPos.getValue().x());
+         int maxY = Math.max(dragStartPos.getValue().y(), dragEndPos.getValue().y());
 
          int width = maxX - minX;
          int height = maxY - minY;

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibToolbar.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibToolbar.java
@@ -4,6 +4,9 @@ import java.beans.PropertyChangeListener;
 import java.util.Objects;
 
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.MouseTrackAdapter;
+import org.eclipse.swt.events.MouseTrackListener;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
@@ -53,23 +56,24 @@ public class MatplotlibToolbar {
 		
 		
 		homeButton = new MatplotlibButton(viewModel.getHomeButtonState(), toolBar, 
-				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.HOME)), HOME_ICON);
+				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.HOME)), HOME_ICON, "Reset original view");
 
 		backButton = new MatplotlibButton(viewModel.getBackButtonState(), toolBar, 
-				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.BACK)), BACK_ICON);
+				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.BACK)), BACK_ICON, "Back to previous view");
 		
 		forwardButton = new MatplotlibButton(viewModel.getForwardButtonState(), toolBar, 
-				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.FORWARD)), FORWARD_ICON);
+				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.FORWARD)), FORWARD_ICON, "Forward to next view");
 		
 		// This is used, but only to be added to the toolbar.
 		@SuppressWarnings("unused")
 		var separator = new ToolItem(toolBar, SWT.SEPARATOR);
 		
 		panButton = new MatplotlibButton(viewModel.getPanButtonState(), toolBar, 
-				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.PAN)), PAN_ACTIVE, PAN_INACTIVE);
+				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.PAN)), PAN_ACTIVE, PAN_INACTIVE, "Pan");
 		
 		zoomButton = new MatplotlibButton(viewModel.getZoomButtonState(), toolBar, 
-				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.ZOOM)), ZOOM_ACTIVE, ZOOM_INACTIVE);
+				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.ZOOM)), ZOOM_ACTIVE, ZOOM_INACTIVE, "Zoom");
+
 	}
 	
 	/**
@@ -94,6 +98,7 @@ public class MatplotlibToolbar {
 		private ToolItem button;
 		private Image activeIcon;
 		private Image inactiveIcon;
+		private String description;
 		
 		private final PropertyChangeListener buttonListener;
 		
@@ -107,8 +112,8 @@ public class MatplotlibToolbar {
 		 * @param selectionListener
 		 * @param iconFilePath
 		 */
-		MatplotlibButton(UpdatedValue<MatplotlibButtonState> state, ToolBar toolBar, SelectionListener selectionListener, String iconFilePath) {
-			this(state, toolBar, selectionListener, iconFilePath, iconFilePath);
+		MatplotlibButton(UpdatedValue<MatplotlibButtonState> state, ToolBar toolBar, SelectionListener selectionListener, String iconFilePath, String description) {
+			this(state, toolBar, selectionListener, iconFilePath, iconFilePath, description);
 		}
 		
 		/**
@@ -119,10 +124,11 @@ public class MatplotlibToolbar {
 		 * @param activeIconFilePath
 		 * @param inactiveIconFilePath
 		 */
-		MatplotlibButton(UpdatedValue<MatplotlibButtonState> viewModelState, ToolBar toolBar, SelectionListener selectionListener, String activeIconFilePath, String inactiveIconFilePath) {
+		MatplotlibButton(UpdatedValue<MatplotlibButtonState> viewModelState, ToolBar toolBar, SelectionListener selectionListener, String activeIconFilePath, String inactiveIconFilePath, String description) {
 			this.activeIcon = ResourceManager.getPluginImage(SYMBOLIC_PATH, activeIconFilePath);
 			this.inactiveIcon = ResourceManager.getPluginImage(SYMBOLIC_PATH, inactiveIconFilePath);
 			this.viewModelState = viewModelState;
+			this.description = description;
 			
 			this.buttonState.setValue(viewModelState.getValue());
 			button = new ToolItem(toolBar, SWT.PUSH);
@@ -136,6 +142,12 @@ public class MatplotlibToolbar {
 							this.setState((MatplotlibButtonState) e.getNewValue());
 						}
 					});
+			/*
+			 * button.addListener(SWT.MouseHover, new Listener() {
+			 * 
+			 * @Override public void handleEvent(Event e) { // why isn't this working? :(
+			 * viewModel.getModel().setPlotMessage(description); } });
+			 */
 		}
 		
 		/**

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibToolbar.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibToolbar.java
@@ -4,9 +4,6 @@ import java.beans.PropertyChangeListener;
 import java.util.Objects;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.MouseEvent;
-import org.eclipse.swt.events.MouseTrackAdapter;
-import org.eclipse.swt.events.MouseTrackListener;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
@@ -53,16 +50,17 @@ public class MatplotlibToolbar {
 		
 		this.viewModel = viewModel;
 		
-		
-		
 		homeButton = new MatplotlibButton(viewModel.getHomeButtonState(), toolBar, 
 				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.HOME)), HOME_ICON, "Reset original view");
-
+		homeButton.getButton().setToolTipText(homeButton.getDescription());
+		
 		backButton = new MatplotlibButton(viewModel.getBackButtonState(), toolBar, 
 				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.BACK)), BACK_ICON, "Back to previous view");
+		backButton.getButton().setToolTipText(backButton.getDescription());
 		
 		forwardButton = new MatplotlibButton(viewModel.getForwardButtonState(), toolBar, 
 				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.FORWARD)), FORWARD_ICON, "Forward to next view");
+		forwardButton.getButton().setToolTipText(forwardButton.getDescription());
 		
 		// This is used, but only to be added to the toolbar.
 		@SuppressWarnings("unused")
@@ -70,10 +68,11 @@ public class MatplotlibToolbar {
 		
 		panButton = new MatplotlibButton(viewModel.getPanButtonState(), toolBar, 
 				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.PAN)), PAN_ACTIVE, PAN_INACTIVE, "Pan");
+		panButton.getButton().setToolTipText(panButton.getDescription());
 		
 		zoomButton = new MatplotlibButton(viewModel.getZoomButtonState(), toolBar, 
 				SelectionListener.widgetSelectedAdapter(e -> viewModel.navigatePlot(MatplotlibButtonType.ZOOM)), ZOOM_ACTIVE, ZOOM_INACTIVE, "Zoom");
-
+		zoomButton.getButton().setToolTipText(zoomButton.getDescription());
 	}
 	
 	/**
@@ -142,12 +141,20 @@ public class MatplotlibToolbar {
 							this.setState((MatplotlibButtonState) e.getNewValue());
 						}
 					});
-			/*
-			 * button.addListener(SWT.MouseHover, new Listener() {
-			 * 
-			 * @Override public void handleEvent(Event e) { // why isn't this working? :(
-			 * viewModel.getModel().setPlotMessage(description); } });
-			 */
+		}
+		
+		/**
+		 * @return the button's embedded ToolItem object
+		 */
+		public ToolItem getButton() {
+			return button;
+		}
+		
+		/**
+		 * @return the button's description
+		 */
+		public String getDescription() {
+			return description;
 		}
 		
 		/**

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibWebsocketEndpoint.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibWebsocketEndpoint.java
@@ -119,6 +119,7 @@ public class MatplotlibWebsocketEndpoint extends Endpoint implements Closeable {
 			@Override
 			public void onMessage(String message) {
 				LoggerUtils.logIfExtraDebug(LOG, String.format("string message from %s: %s", getUrl(), message));
+				System.out.println(message);
 				try {
 					// Can't deserialize to Map<String, String> because some messages are of type Map<String, List>
 					// So have to deserialize to Object initially and then cast later.
@@ -190,8 +191,10 @@ public class MatplotlibWebsocketEndpoint extends Endpoint implements Closeable {
 		    propertiesToSend.put("type", type);
 		    propertiesToSend.put("figure_id", Integer.toString(figNum));
 		    
+		    
 			remote.sendText(GSON.toJson(propertiesToSend));
 			LoggerUtils.logIfExtraDebug(LOG, String.format("sent %s to %s", propertiesToSend, getUrl()));
+			System.out.println(String.format("sent %s to %s", propertiesToSend, getUrl()));
 		} catch (RuntimeException e) {
 			LoggerUtils.logErrorWithStackTrace(LOG, "Failed to send property to websocket: " + e.getMessage(), e);
 		}

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibWebsocketEndpoint.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibWebsocketEndpoint.java
@@ -119,7 +119,6 @@ public class MatplotlibWebsocketEndpoint extends Endpoint implements Closeable {
 			@Override
 			public void onMessage(String message) {
 				LoggerUtils.logIfExtraDebug(LOG, String.format("string message from %s: %s", getUrl(), message));
-				System.out.println(message);
 				try {
 					// Can't deserialize to Map<String, String> because some messages are of type Map<String, List>
 					// So have to deserialize to Object initially and then cast later.
@@ -197,7 +196,6 @@ public class MatplotlibWebsocketEndpoint extends Endpoint implements Closeable {
 		    
 			remote.sendText(GSON.toJson(propertiesToSend));
 			LoggerUtils.logIfExtraDebug(LOG, String.format("sent %s to %s", propertiesToSend, getUrl()));
-			System.out.println(String.format("sent %s to %s", propertiesToSend, getUrl()));
 		} catch (RuntimeException e) {
 			LoggerUtils.logErrorWithStackTrace(LOG, "Failed to send property to websocket: " + e.getMessage(), e);
 		}

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibWebsocketEndpoint.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibWebsocketEndpoint.java
@@ -152,6 +152,9 @@ public class MatplotlibWebsocketEndpoint extends Endpoint implements Closeable {
 		    case "navigate_mode":
 		    	model.toggleZoomAndPan((String) content.getOrDefault("mode", ""));
 		    	break;
+		    case "cursor":
+		    	model.setCursor((String) content.getOrDefault("cursor", "default"));
+		    	break;
 		    default:
 		    	// No action required
 		    	break;

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibWebsocketModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/src/uk/ac/stfc/isis/ibex/ui/graphing/websocketview/MatplotlibWebsocketModel.java
@@ -33,6 +33,8 @@ public class MatplotlibWebsocketModel implements Closeable, AutoCloseable {
 	private boolean backState;
 	private boolean forwardState;
 	
+	private MatplotlibCursorType cursorType;
+	
 	private Optional<ImageData> imageData = Optional.empty();
 	
 	private boolean isConnected = false;
@@ -309,6 +311,34 @@ public class MatplotlibWebsocketModel implements Closeable, AutoCloseable {
 	 */
 	public MatplotlibNavigationType getNavMode() {
 		return navMode;
+	}
+	
+	/**
+	 * Sets the cursor appearance.
+	 * @param cursorType
+	 */
+	public void setCursor(String cursorType) {
+		switch (cursorType) {
+			case "default":
+				this.cursorType = MatplotlibCursorType.DEFAULT;
+				break;
+			case "crosshair":
+				this.cursorType = MatplotlibCursorType.CROSSHAIR;
+				break;
+			case "move":
+				this.cursorType = MatplotlibCursorType.HAND;
+				break;
+			default:
+				break;
+		}
+		viewModel.updateCursorType();
+	}
+	
+	/**
+	 * @return the current cursor type
+	 */
+	public MatplotlibCursorType getCursorType() {
+		return cursorType;
 	}
 	
 	/**


### PR DESCRIPTION
### Description of work

- Added zoom selection box
- Added different cursor styles for appropriate nav styles
- Added tooltips for each button on the toolbar 

Implemented tooltips rather than using the plot message as:
 -  It responds quicker than setting the plot message via the websocket (e.g. `model.setPlotMessage()`) and then waiting for the `viewModel` to update it
 -  Was more concise approach

Kept `MAX_DRAW_RATE_MS` at 100 instead of 50; does mean slightly slower response on faster machines for panning/drawing zoom selection box but gives a slightly more acceptable performance on the slower ones.

### Ticket

[Ticket #7461](https://github.com/ISISComputingGroup/IBEX/issues/7461)

### Acceptance criteria

- [ ] There is a selection box when selecting zoom area
- [ ] There is a crosshair cursor when selecting zoom area 
- [ ] Plot message box describes buttons when hovering over them

### Unit tests

See `.../graphing/tests/MatplotlibViewModelTests.java`

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

