### PR TITLE
Link matplotlib toolbar icons to maven build

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/META-INF/MANIFEST.MF
@@ -1,4 +1,5 @@
 Manifest-Version: 1.0
+Eclipse-BundleShape: dir
 Bundle-ManifestVersion: 2
 Bundle-Name: Graphing
 Bundle-SymbolicName: uk.ac.stfc.isis.ibex.ui.graphing;singleton:=true

--- a/base/uk.ac.stfc.isis.ibex.ui.graphing/build.properties
+++ b/base/uk.ac.stfc.isis.ibex.ui.graphing/build.properties
@@ -3,4 +3,6 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               icons/
+               icons/,\
+               resources/
+src.includes = resources/


### PR DESCRIPTION
### Description of work
Icons for [#7461](https://github.com/ISISComputingGroup/IBEX/issues/7461) were not linked to maven build so were not visible/behaving correctly.
