### PR TITLE
Ticket7542

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
@@ -6904,7 +6904,7 @@ $(pv_value)</tooltip>
       <format_type>0</format_type>
       <height>20</height>
       <horizontal_alignment>0</horizontal_alignment>
-      <name>Text Update_10</name>
+      <name>IocNameUpdate</name>
       <precision>0</precision>
       <precision_from_pv>true</precision_from_pv>
       <pv_name>$(M)_IOCNAME</pv_name>
@@ -7753,12 +7753,12 @@ $(pv_value)</tooltip>
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>85</height>
+    <height>133</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
-    <name>Error</name>
+    <name>Info</name>
     <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -7784,7 +7784,7 @@ if ioc_name in ["GALIL", "GALILMUL", "TC"]:
     <visible>false</visible>
     <widget_type>Grouping Container</widget_type>
     <width>265</width>
-    <wuid>1d8e216:185c4fc9f25:-7bea</wuid>
+    <wuid>7ba3ff1f:1865539e452:-7f40</wuid>
     <x>474</x>
     <y>816</y>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -7809,7 +7809,7 @@ if ioc_name in ["GALIL", "GALILMUL", "TC"]:
       <foreground_color>
         <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
       </foreground_color>
-      <format_type>4</format_type>
+      <format_type>0</format_type>
       <height>20</height>
       <horizontal_alignment>0</horizontal_alignment>
       <name>ErrorTextUpdate</name>
@@ -7840,11 +7840,24 @@ if motor_name == "GALIL" or motor_name == "GALILMUL":
     pv = p + "MOT:DMC" + motor_controller_num + ":ERROR_MON"
     widget.setPropertyValue("pv_name", pv)
 elif motor_name == "TC":
-    axis = m[-2:].lstrip("0")
+    axis = PVUtil.getString(display.getWidget("AxisUpdate").getPV())
     pv = p + ioc_name + ":ASTAXES_" + axis + ":STSTATUS-NERRORID"
     widget.setPropertyValue("pv_name", pv)
 else:
     widget.setPropertyValue("text", "UNKNOWN")
+]]></scriptText>
+          <pv trig="true">$(M)_IOCNAME</pv>
+        </path>
+        <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
+          <scriptName>FormatType</scriptName>
+          <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+ioc_name = PVUtil.getString(pvs[0]).split("_")[0]
+
+if ioc_name == "TC":
+    widget.setPropertyValue("format_type", 0)
+else:
+    widget.setPropertyValue("format_type", 4)
 ]]></scriptText>
           <pv trig="true">$(M)_IOCNAME</pv>
         </path>
@@ -7857,11 +7870,11 @@ $(pv_value)</tooltip>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Text Update</widget_type>
-      <width>139</width>
+      <width>92</width>
       <wrap_words>false</wrap_words>
-      <wuid>1d8e216:185c4fc9f25:-7bdf</wuid>
-      <x>0</x>
-      <y>3</y>
+      <wuid>7ba3ff1f:1865539e452:-7f3f</wuid>
+      <x>142</x>
+      <y>0</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">
@@ -7919,9 +7932,9 @@ $(pv_value)</tooltip>
       <visible>true</visible>
       <widget_type>Action Button</widget_type>
       <width>90</width>
-      <wuid>1d8e216:185c4fc9f25:-7c00</wuid>
-      <x>144</x>
-      <y>0</y>
+      <wuid>7ba3ff1f:1865539e452:-7f3e</wuid>
+      <x>143</x>
+      <y>48</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">
@@ -7933,7 +7946,7 @@ ioc_name = PVUtil.getString(widget.getPV())
 motor_name = ioc_name.split("_")[0]
 macros = display.getPropertyValue("macros").getMacrosMap()
 p = macros.get("P")
-axis = macros.get("M")[-2:].lstrip("0")
+axis = PVUtil.getString(display.getWidget("AxisUpdate").getPV())
 
 pv = p + ioc_name + ":ASTAXES_" + axis + ":STCONTROL-BENABLE"
 PVUtil.writePV(pv, 1)
@@ -7989,9 +8002,167 @@ $(pv_value)</tooltip>
       <visible>false</visible>
       <widget_type>Action Button</widget_type>
       <width>79</width>
-      <wuid>-770158af:1864a131213:-7f46</wuid>
+      <wuid>7ba3ff1f:1865539e452:-7f3d</wuid>
       <x>0</x>
-      <y>30</y>
+      <y>73</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>Label_20</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_scrollbar>false</show_scrollbar>
+      <text>Error:</text>
+      <tooltip></tooltip>
+      <transparent>false</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>43</width>
+      <wrap_words>true</wrap_words>
+      <wuid>7ba3ff1f:1865539e452:-7f3c</wuid>
+      <x>0</x>
+      <y>0</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <auto_size>false</auto_size>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <format_type>0</format_type>
+      <height>20</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>AxisUpdate</name>
+      <precision>0</precision>
+      <precision_from_pv>false</precision_from_pv>
+      <pv_name>$(M)_AXIS_NUM</pv_name>
+      <pv_value />
+      <rotation_angle>0.0</rotation_angle>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts>
+        <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
+          <scriptName>VisibleScript</scriptName>
+          <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+ioc_name = PVUtil.getString(pvs[0]).split("_")[0]
+
+if ioc_name == "TC":
+    widget.setPropertyValue("visible", True)
+]]></scriptText>
+          <pv trig="true">$(M)_IOCNAME</pv>
+        </path>
+      </scripts>
+      <show_units>false</show_units>
+      <text>######</text>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Text Update</widget_type>
+      <width>92</width>
+      <wrap_words>false</wrap_words>
+      <wuid>7ba3ff1f:1865539e452:-7f3b</wuid>
+      <x>142</x>
+      <y>19</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>Label_20</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts>
+        <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
+          <scriptName>VisibleScript</scriptName>
+          <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+ioc_name = PVUtil.getString(pvs[0]).split("_")[0]
+
+if ioc_name == "TC":
+    widget.setPropertyValue("visible", True)
+]]></scriptText>
+          <pv trig="true">$(M)_IOCNAME</pv>
+        </path>
+      </scripts>
+      <show_scrollbar>false</show_scrollbar>
+      <text>Axis:</text>
+      <tooltip></tooltip>
+      <transparent>false</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>false</visible>
+      <widget_type>Label</widget_type>
+      <width>43</width>
+      <wrap_words>true</wrap_words>
+      <wuid>7ba3ff1f:1865539e452:-7f3a</wuid>
+      <x>0</x>
+      <y>19</y>
     </widget>
   </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
@@ -7735,4 +7735,261 @@ $(pv_value)</tooltip>
     <x>12</x>
     <y>1</y>
   </widget>
+  <widget typeId="org.csstudio.opibuilder.widgets.groupingContainer" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <background_color>
+      <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color name="ISIS_GroupBox_Border_NEW" red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>13</border_style>
+    <border_width>1</border_width>
+    <enabled>true</enabled>
+    <fc>false</fc>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_GroupBox_NEW</opifont.name>
+    </font>
+    <foreground_color>
+      <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
+    </foreground_color>
+    <height>85</height>
+    <lock_children>false</lock_children>
+    <macros>
+      <include_parent_macros>true</include_parent_macros>
+    </macros>
+    <name>Error</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts>
+      <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
+        <scriptName>HasEngineeringView</scriptName>
+        <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+ioc_name = PVUtil.getString(pvs[0]).split("_")[0]
+
+if ioc_name in ["GALIL", "GALILMUL", "TC"]:
+    widget.setPropertyValue("visible", True)
+]]></scriptText>
+        <pv trig="true">$(M)_IOCNAME</pv>
+      </path>
+    </scripts>
+    <show_scrollbar>true</show_scrollbar>
+    <tooltip></tooltip>
+    <transparent>false</transparent>
+    <visible>false</visible>
+    <widget_type>Grouping Container</widget_type>
+    <width>265</width>
+    <wuid>1d8e216:185c4fc9f25:-7bea</wuid>
+    <x>474</x>
+    <y>816</y>
+    <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <alarm_pulsing>false</alarm_pulsing>
+      <auto_size>false</auto_size>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Label_Background" red="240" green="240" blue="240" />
+      </background_color>
+      <border_alarm_sensitive>true</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Value_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>true</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <format_type>4</format_type>
+      <height>20</height>
+      <horizontal_alignment>0</horizontal_alignment>
+      <name>ErrorTextUpdate</name>
+      <precision>0</precision>
+      <precision_from_pv>false</precision_from_pv>
+      <pv_name>$(M)_IOCNAME</pv_name>
+      <pv_value />
+      <rotation_angle>0.0</rotation_angle>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts>
+        <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
+          <scriptName>GetError</scriptName>
+          <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+ioc_name = PVUtil.getString(pvs[0])
+motor_name = ioc_name.split("_")[0]
+macros = display.getPropertyValue("macros").getMacrosMap()
+p = macros.get("P")
+motor_controller_num = macros.get("M")[-4:-2]
+
+if motor_name == "GALIL" or motor_name == "GALILMUL":
+    pv = p + "MOT:DMC" + motor_controller_num + ":ERROR_MON"
+    widget.setPropertyValue("pv_name", pv)
+elif motor_name == "TC":
+    pv = p + ioc_name + ":ASTAXES_" + motor_controller_num[1:] + ":STSTATUS-NERRORID"
+    widget.setPropertyValue("pv_name", pv)
+else:
+    widget.setPropertyValue("text", "UNKNOWN")
+]]></scriptText>
+          <pv trig="true">$(M)_IOCNAME</pv>
+        </path>
+      </scripts>
+      <show_units>false</show_units>
+      <text>######</text>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Text Update</widget_type>
+      <width>139</width>
+      <wrap_words>false</wrap_words>
+      <wuid>1d8e216:185c4fc9f25:-7bdf</wuid>
+      <x>0</x>
+      <y>3</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+      <actions hook="false" hook_all="false">
+        <action type="EXECUTE_PYTHONSCRIPT">
+          <path>openEngineeringView.py</path>
+          <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil, ScriptUtil, DataUtil
+
+ioc_name = PVUtil.getString(widget.getPV()).split("_")[0]
+new_macros = DataUtil.createMacrosInput(True)
+
+if ioc_name == "GALIL" or ioc_name == "GALILMUL":
+    macros = display.getPropertyValue("macros").getMacrosMap()
+    motor_controller_num = macros.get("M")[-4:-2]
+    new_macros.put("M", motor_controller_num)
+    ScriptUtil.openOPI(widget, "../galil/galil.opi", 1, new_macros)
+elif ioc_name == "TC":
+    ScriptUtil.openOPI(widget, "../twincat/twincat_engineering.opi", 1, new_macros)
+]]></scriptText>
+          <embedded>true</embedded>
+          <description></description>
+        </action>
+      </actions>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>50</height>
+      <image></image>
+      <name>OpenEngineeringViewButton</name>
+      <push_action_index>0</push_action_index>
+      <pv_name>$(M)_IOCNAME</pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <style>1</style>
+      <text>Open Engineering View</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>90</width>
+      <wuid>1d8e216:185c4fc9f25:-7c00</wuid>
+      <x>144</x>
+      <y>0</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+      <actions hook="false" hook_all="false">
+        <action type="EXECUTE_PYTHONSCRIPT">
+          <path></path>
+          <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+ioc_name = PVUtil.getString(widget.getPV())
+motor_name = ioc_name.split("_")[0]
+macros = display.getPropertyValue("macros").getMacrosMap()
+p = macros.get("P")
+motor_controller_num = macros.get("M")[-4:-2]
+
+pv = p + ioc_name + ":ASTAXES_" + motor_controller_num[1:] + ":STCONTROL-BENABLE"
+PVUtil.writePV(pv, 1)
+]]></scriptText>
+          <embedded>true</embedded>
+          <description></description>
+        </action>
+      </actions>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>25</height>
+      <image></image>
+      <name>ResetErrorButton</name>
+      <push_action_index>0</push_action_index>
+      <pv_name>$(M)_IOCNAME</pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts>
+        <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
+          <scriptName>VisibleScript</scriptName>
+          <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+ioc_name = PVUtil.getString(pvs[0]).split("_")[0]
+
+if ioc_name == "TC":
+    widget.setPropertyValue("visible", True)
+]]></scriptText>
+          <pv trig="true">$(M)_IOCNAME</pv>
+        </path>
+      </scripts>
+      <style>1</style>
+      <text>Reset Error</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>false</visible>
+      <widget_type>Action Button</widget_type>
+      <width>79</width>
+      <wuid>-770158af:1864a131213:-7f46</wuid>
+      <x>0</x>
+      <y>30</y>
+    </widget>
+  </widget>
 </display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Motor/details.opi
@@ -7833,13 +7833,15 @@ ioc_name = PVUtil.getString(pvs[0])
 motor_name = ioc_name.split("_")[0]
 macros = display.getPropertyValue("macros").getMacrosMap()
 p = macros.get("P")
-motor_controller_num = macros.get("M")[-4:-2]
+m = macros.get("M")
 
 if motor_name == "GALIL" or motor_name == "GALILMUL":
+    motor_controller_num = m[-4:-2]
     pv = p + "MOT:DMC" + motor_controller_num + ":ERROR_MON"
     widget.setPropertyValue("pv_name", pv)
 elif motor_name == "TC":
-    pv = p + ioc_name + ":ASTAXES_" + motor_controller_num[1:] + ":STSTATUS-NERRORID"
+    axis = m[-2:].lstrip("0")
+    pv = p + ioc_name + ":ASTAXES_" + axis + ":STSTATUS-NERRORID"
     widget.setPropertyValue("pv_name", pv)
 else:
     widget.setPropertyValue("text", "UNKNOWN")
@@ -7931,9 +7933,9 @@ ioc_name = PVUtil.getString(widget.getPV())
 motor_name = ioc_name.split("_")[0]
 macros = display.getPropertyValue("macros").getMacrosMap()
 p = macros.get("P")
-motor_controller_num = macros.get("M")[-4:-2]
+axis = macros.get("M")[-2:].lstrip("0")
 
-pv = p + ioc_name + ":ASTAXES_" + motor_controller_num[1:] + ":STCONTROL-BENABLE"
+pv = p + ioc_name + ":ASTAXES_" + axis + ":STCONTROL-BENABLE"
 PVUtil.writePV(pv, 1)
 ]]></scriptText>
           <embedded>true</embedded>


### PR DESCRIPTION
### Description of work

Added a new grouping container to the motor details for Galils and Beckhoffs that shows the current error and has a button to open the engineering view. For Beckhoff there is a reset error button as well.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/7542

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

