### PR TITLE
Fix script_definitions submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "script_definitions"]
+    path = "script_definitions"
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "script_definitions"]
     path = "script_definitions"
     url = https://github.com/ISISComputingGroup/ScriptDefinitions.git
+    branch = master
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "script_definitions"]
     path = "script_definitions"
+    url = https://github.com/ISISComputingGroup/ScriptDefinitions.git
 


### PR DESCRIPTION
Adds `.gitmodules` metadata - not sure why this was missing? https://stackoverflow.com/questions/59633536/git-submodules-without-gitmodules-file#:~:text=If%20the%20.,half%2Dformed%20submodule%20is%20easier suggests taht a submodule without a `.gitmodules` file is broken.

This was causing git diff to always report a change.