### PR TITLE
Ticket6922 script generator read only when excuting step

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorEditingSupport.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorEditingSupport.java
@@ -6,17 +6,33 @@ import uk.ac.stfc.isis.ibex.scriptgenerator.table.ActionDynamicScriptingStatus;
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
 import uk.ac.stfc.isis.ibex.ui.widgets.StringEditingSupport;
 
+/**
+ * Editing support for the scriptgenerator.
+ *
+ */
 public class ScriptGeneratorEditingSupport extends StringEditingSupport<ScriptGeneratorAction> {
 	private JavaActionParameter actionParameter;
+	
+	/**
+	 * Create this editing support.
+	 * @param viewer the column viewer
+	 * @param rowType the row type
+	 * @param actionParameter the associated action parameter for the column
+	 */
 	public ScriptGeneratorEditingSupport(ColumnViewer viewer, Class<ScriptGeneratorAction> rowType, JavaActionParameter actionParameter) {
 		super(viewer, rowType);
 		this.actionParameter = actionParameter;
 	}
-	
+		
+	/**
+	 * Returns whether the current cell can be edited.
+	 * @param element the action of the cell to edit
+	 */
 	@Override
 	protected boolean canEdit(Object element) {
-		if(ExecutingStatusDisplay.equalsAction(ActionDynamicScriptingStatus.EXECUTING, (ScriptGeneratorAction) element)||
-				ExecutingStatusDisplay.equalsAction(ActionDynamicScriptingStatus.PAUSED_DURING_EXECUTION, (ScriptGeneratorAction) element)) {
+		ScriptGeneratorAction action = (ScriptGeneratorAction) element;
+		if (ExecutingStatusDisplay.equalsAction(ActionDynamicScriptingStatus.EXECUTING, action)
+				|| ExecutingStatusDisplay.equalsAction(ActionDynamicScriptingStatus.PAUSED_DURING_EXECUTION, action)) {
 			return false;
 		}
 		return canEdit;

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorEditingSupport.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorEditingSupport.java
@@ -1,0 +1,35 @@
+package uk.ac.stfc.isis.ibex.ui.scriptgenerator.views;
+
+import org.eclipse.jface.viewers.ColumnViewer;
+import uk.ac.stfc.isis.ibex.scriptgenerator.JavaActionParameter;
+import uk.ac.stfc.isis.ibex.scriptgenerator.table.ActionDynamicScriptingStatus;
+import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
+import uk.ac.stfc.isis.ibex.ui.widgets.StringEditingSupport;
+
+public class ScriptGeneratorEditingSupport extends StringEditingSupport<ScriptGeneratorAction> {
+	private JavaActionParameter actionParameter;
+	public ScriptGeneratorEditingSupport(ColumnViewer viewer, Class<ScriptGeneratorAction> rowType, JavaActionParameter actionParameter) {
+		super(viewer, rowType);
+		this.actionParameter = actionParameter;
+	}
+	
+	@Override
+	protected boolean canEdit(Object element) {
+		if(ExecutingStatusDisplay.equalsAction(ActionDynamicScriptingStatus.EXECUTING, (ScriptGeneratorAction) element)||
+				ExecutingStatusDisplay.equalsAction(ActionDynamicScriptingStatus.PAUSED_DURING_EXECUTION, (ScriptGeneratorAction) element)) {
+			return false;
+		}
+		return canEdit;
+	}
+
+	@Override
+    protected String valueFromRow(ScriptGeneratorAction row) {
+        return row.getActionParameterValue(actionParameter);
+    }
+
+    @Override
+    protected void setValueForRow(ScriptGeneratorAction row, String value) {
+        row.setActionParameterValue(actionParameter, value);
+    }
+
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -65,7 +65,6 @@ import uk.ac.stfc.isis.ibex.scriptgenerator.pythoninterface.ScriptDefinitionWrap
 import uk.ac.stfc.isis.ibex.scriptgenerator.table.ScriptGeneratorAction;
 import uk.ac.stfc.isis.ibex.ui.scriptgenerator.dialogs.SaveScriptGeneratorFileMessageDialog;
 import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
-import uk.ac.stfc.isis.ibex.ui.widgets.StringEditingSupport;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 
 import uk.ac.stfc.isis.ibex.model.ModelObject;

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -942,17 +942,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	            	}
                 });
     
-            var editingSupport = new StringEditingSupport<ScriptGeneratorAction>(viewTable.viewer(), ScriptGeneratorAction.class) {          
-                @Override
-                protected String valueFromRow(ScriptGeneratorAction row) {
-                    return row.getActionParameterValue(actionParameter);
-                }
-        
-                @Override
-                protected void setValueForRow(ScriptGeneratorAction row, String value) {
-                    row.setActionParameterValue(actionParameter, value);
-                }
-            };
+            var editingSupport = new ScriptGeneratorEditingSupport(viewTable.viewer(), ScriptGeneratorAction.class, actionParameter);
             viewTable.addEditingSupport(editingSupport);
             column.setEditingSupport(editingSupport);
         }

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/StringEditingSupport.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/StringEditingSupport.java
@@ -32,6 +32,9 @@ import org.eclipse.swt.widgets.Composite;
 public abstract class StringEditingSupport<TRow> extends GenericEditingSupport<TRow, String> {
 
 	private final ResetSelectionTextCellEditor editor;
+	/**
+	 * Tracks whether editing has been disabled.
+	 */
 	protected boolean canEdit = true;
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/StringEditingSupport.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/StringEditingSupport.java
@@ -32,7 +32,7 @@ import org.eclipse.swt.widgets.Composite;
 public abstract class StringEditingSupport<TRow> extends GenericEditingSupport<TRow, String> {
 
 	private final ResetSelectionTextCellEditor editor;
-	private boolean canEdit = true;
+	protected boolean canEdit = true;
 
 	/**
 	 * Create this editing support.


### PR DESCRIPTION
### Description of work
Make script generator steps read only once they have begun execution

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/6922

### Acceptance criteria
 - [ ] When a script step is executing in the script server, it can no longer be edited within the script generator.

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests
[System tests](https://github.com/ISISComputingGroup/System_Tests_UI_E4/pull/133)
[Script definitions for tests](https://github.com/ISISComputingGroup/ScriptDefinitions/pull/9)

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

