### PR TITLE
Added rightclick menu to script generator

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -112,7 +112,6 @@ public class ScriptGeneratorView {
     private boolean scriptDefinitionsLoadedOnce = false;
 
     private ActionsViewTable table;
-    private Button btnDeleteAction;
     private Button btnMoveActionUp;
     private Button btnMoveActionDown;
     private Button btnAddAction;
@@ -127,7 +126,6 @@ public class ScriptGeneratorView {
 
     private Button generateScriptButton;
     private Button generateScriptAsButton;
-    private Button btnDuplicateAction;
     private ScriptGeneratorHelpMenu helpMenu;
 
     /**
@@ -372,17 +370,7 @@ public class ScriptGeneratorView {
 	        ugLayout.marginHeight = 10;
 	        ugLayout.marginWidth = 10;
 	        utilitiesGrp.setLayout(ugLayout);
-	        
-	        final Button copy = new Button(utilitiesGrp, SWT.NONE);
-	        copy.setText("Copy selected actions");
-	        copy.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-	        copy.addListener(SWT.Selection, e -> scriptGeneratorViewModel.copyActions(table.getSelectedTableData()));
-	        
-	        final Button paste = new Button(utilitiesGrp, SWT.NONE);
-	        paste.setText("Paste actions");
-	        paste.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-	        paste.addListener(SWT.Selection, e -> scriptGeneratorViewModel.pasteActions(table.getSelectionIndex()));
-	        
+	        	        
 	        // Composite for the row containing  total estimated run time
 	        Composite scriptTimeGrp = new Composite(scriptInfoGrp, SWT.RIGHT);
 	        scriptTimeGrp.setLayoutData(new GridData(SWT.RIGHT, SWT.NONE, true, false, 1, 2));
@@ -409,7 +397,7 @@ public class ScriptGeneratorView {
 	        // Composite for laying out new/delete/duplicate action buttons
 	        Composite actionsControlsGrp = new Composite(mainParent, SWT.NONE);
 	        actionsControlsGrp.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-	        GridLayout ssgLayout = new GridLayout(5, true);
+	        GridLayout ssgLayout = new GridLayout(3, true);
 	        ssgLayout.marginHeight = 10;
 	        ssgLayout.marginWidth = 10;
 	        actionsControlsGrp.setLayout(ssgLayout);
@@ -424,18 +412,6 @@ public class ScriptGeneratorView {
 	        btnInsertAction.setText("Insert Action Below");
 	        btnInsertAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 	        btnInsertAction.addListener(SWT.Selection, e -> scriptGeneratorViewModel.insertEmptyAction(table.getSelectionIndex() + 1));
-	
-	        btnDuplicateAction = new Button(actionsControlsGrp, SWT.NONE);
-	        btnDuplicateAction.setText("Duplicate Selected Actions Below");
-	        btnDuplicateAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-	        btnDuplicateAction.addListener(SWT.Selection, e -> 
-	        scriptGeneratorViewModel.duplicateAction(table.selectedRows(), table.getSelectionIndex() + 1));
-	        
-	        btnDeleteAction = new Button(actionsControlsGrp, SWT.NONE);
-	        btnDeleteAction.setText("Delete Selected Actions");
-	        btnDeleteAction.setToolTipText("Delete a single or multiple actions.\nTo select multiple actions, use Ctrl+Click or Shift+Click.");
-	        btnDeleteAction.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
-	        btnDeleteAction.addListener(SWT.Selection, e -> scriptGeneratorViewModel.deleteAction(table.selectedRows()));
 	
 	        final Button btnClearAction = new Button(actionsControlsGrp, SWT.NONE);
 	        btnClearAction.setText("Clear All Actions");
@@ -623,10 +599,8 @@ public class ScriptGeneratorView {
     	});
     });
 
-    bindToHasSelected(btnDeleteAction);
     bindToHasSelected(btnMoveActionUp);
     bindToHasSelected(btnMoveActionDown);
-    bindToHasSelected(btnDuplicateAction);
     }
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -1368,6 +1368,25 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	}
 	
 	/**
+	 * Checks if the clipboard has contents.
+	 * @return True if the clipboard has content, false otherwise.
+	 */
+	public boolean checkClipboard() {
+		String copiedActions = (String) clipboard.getContents(TextTransfer.getInstance());
+		if (copiedActions == null) {
+			return false;
+		}
+		return true;
+	}
+	
+	/**
+	 * Clears the clipboard has contents.
+	 */
+	public void clearClipboard() {
+		clipboard.clearContents();
+	}
+	
+	/**
 	 * Copies actions to clipboard.
 	 * @param actions copied actions
 	 */


### PR DESCRIPTION
Reduced clutter in script generator by moving some buttons into right click menu on the table itself


### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/7843)


### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

