### PR TITLE
Added PVs to beam information tab

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.beamstatus/src/uk/ac/stfc/isis/ibex/beamstatus/TS2Observables.java
+++ b/base/uk.ac.stfc.isis.ibex.beamstatus/src/uk/ac/stfc/isis/ibex/beamstatus/TS2Observables.java
@@ -66,6 +66,16 @@ public class TS2Observables extends EndStationObservables {
 	 */
 	public final FacilityPV decoupledModeratorUAHBeam;
 
+	/**
+	 * An updating value giving the beam limit of the TS2 decoupled moderator.
+	 */
+	public final FacilityPV decoupledModeratorBeamLimit;
+	
+	/**
+	 * An updating value giving the charge change time of the TS2 decoupled moderator.
+	 */
+	public final FacilityPV decoupledModeratorChargeChangeTime;
+	
 	private static final PVAddress TS2_PV = PVAddress.startWith("AC").append("TS2");
 
 	private static final String MOD_PREFIX = "TG:TS2:DMOD:";
@@ -96,6 +106,12 @@ public class TS2Observables extends EndStationObservables {
 
 		decoupledModeratorUAHBeam = new FacilityPV(MOD_PREFIX + "BEAM",
 				adaptNumber(obsFactory.getSwitchableObservable(new NumberWithPrecisionChannel(), MOD_PREFIX + "BEAM")));
+		
+		decoupledModeratorBeamLimit = new FacilityPV(MOD_PREFIX + "BEAM:LIM",
+				adaptNumber(obsFactory.getSwitchableObservable(new NumberWithPrecisionChannel(), MOD_PREFIX + "BEAM:LIM")));
+		
+		decoupledModeratorChargeChangeTime = new FacilityPV(MOD_PREFIX + "CHRGCHNG:TIME",
+				adaptNumber(obsFactory.getSwitchableObservable(new NumberWithPrecisionChannel(), MOD_PREFIX + "CHRGCHNG:TIME")));
 
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/TargetStationTwoPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/TargetStationTwoPanel.java
@@ -45,6 +45,9 @@ public class TargetStationTwoPanel extends BeamInfoComposite {
 	private final Label decoupledModeratorRuntimeLimit;
 	private final Label decoupledModeratorAnnealPressure;
 	private final Label decoupledModeratoruAhBeam;
+	private final Label decoupledModeratorBeamLimit;
+	private final Label decoupledModeratorChargeChangeTime;
+
 
 	/**
 	 * The constructor.
@@ -134,6 +137,18 @@ public class TargetStationTwoPanel extends BeamInfoComposite {
 
 		decoupledModeratoruAhBeam = new Label(this, SWT.BORDER | SWT.RIGHT);
 		decoupledModeratoruAhBeam.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		
+		Label lbdecoupledModeratorBeamLimit = new Label(this, SWT.NONE);
+		lbdecoupledModeratorBeamLimit.setText("Decoupled Moderator Beam Limit");
+
+		decoupledModeratorBeamLimit = new Label(this, SWT.BORDER | SWT.RIGHT);
+		decoupledModeratorBeamLimit.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+
+		Label lbdecoupledModeratorChargeChangeTime = new Label(this, SWT.NONE);
+		lbdecoupledModeratorChargeChangeTime.setText("Decoupled Moderator Charge Change Time");
+
+		decoupledModeratorChargeChangeTime = new Label(this, SWT.BORDER | SWT.RIGHT);
+		decoupledModeratorChargeChangeTime.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 
 		if (BeamStatus.getInstance() != null) {
 			bind(BeamStatus.getInstance().ts2());
@@ -160,6 +175,8 @@ public class TargetStationTwoPanel extends BeamInfoComposite {
 		bindAndAddMenu(ts.decoupledModeratorRuntimeLimit, decoupledModeratorRuntimeLimit, this);
 		bindAndAddMenu(ts.decoupledModeratorAnnealPressure, decoupledModeratorAnnealPressure, this);
 		bindAndAddMenu(ts.decoupledModeratorUAHBeam, decoupledModeratoruAhBeam, this);
+		bindAndAddMenu(ts.decoupledModeratorBeamLimit, decoupledModeratorBeamLimit, this);
+		bindAndAddMenu(ts.decoupledModeratorChargeChangeTime, decoupledModeratorChargeChangeTime, this);
 
 	}
 


### PR DESCRIPTION
### Description of work

Two new PV's were added to the beam information tab: 

- TG:TS2:DMOD:BEAM:LIM
- TG:TS2:DMOD:CHRGCHNG:TIME


### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/7852)

### Acceptance criteria

- [ ] TG:TS2:DMOD is visible under "Beam Information"
- [ ] TG:TS2:DMOD:CHRGCHNG:TIME is visible under "Beam Information"


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

