### PR TITLE
Add default macro for TTIEX355P

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -2629,6 +2629,7 @@
           <macro>
             <name>TTIEX355P</name>
             <description>The TTIEX355P PV prefix (e.g. TTIEX355P_01)</description>
+            <default>TTIEX355P_01</default>
           </macro>
         </macros>
       </value>


### PR DESCRIPTION
### Description of work

Added default macro instead of null for TTIEX355P

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/6628#issue-936950740

### Acceptance criteria

See ticket

### Unit tests

Small opi_info change

### System tests

Small opi_info change

### Documentation

Small opi_info change

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

