### PR TITLE
Change default perspective selection logic

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/CopyPerspectiveSnippetProcessor.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/CopyPerspectiveSnippetProcessor.java
@@ -89,14 +89,15 @@ public class CopyPerspectiveSnippetProcessor {
 
         // clone each snippet that is a perspective and add the cloned
         // perspective into the main PerspectiveStack
-        boolean isFirst = true;
         for (MPerspective perspective : perspectivesProvider.getInitialPerspectives()) {
             
             perspectiveStack.getChildren().add(perspective);
-            if (isFirst) {
+            
+            // set default (welcome) perspective
+            if (perspective.getElementId().equals(perspectivesProvider.getDefaultPerspectiveId())) {
                 perspectiveStack.setSelectedElement(perspective);
-                isFirst = false;
             }
+            
             subscribeChangedElement(broker, perspective);
             subscribeSelectedPerspective(broker, perspective);
         }

--- a/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/PerspectivesProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.ui.perspectiveswitcher/src/uk/ac/stfc/isis/ibex/e4/ui/perspectiveswitcher/PerspectivesProvider.java
@@ -30,7 +30,8 @@ public class PerspectivesProvider {
     private EModelService modelService;
     
     private static final String MAIN_PERSPECTIVE_STACK_ID = "uk.ac.stfc.isis.ibex.client.e4.product.perspectivestack.0";
-
+    private static final String DEFAULT_PERSPECTIVE_ID = "uk.ac.stfc.isis.ibex.client.e4.product.perspective.weblinks";
+    
     /**
      * Instantiates the class and initialises the internal perspective list with
      * all perspectives found in the application model.
@@ -125,6 +126,13 @@ public class PerspectivesProvider {
             }
         }
         return perspectives;
+    }
+    
+    /**
+     * @return the default perspective id (usually displayed on launch as landing page)
+     */
+    public String getDefaultPerspectiveId() {
+    	return DEFAULT_PERSPECTIVE_ID;
     }
 
     /**


### PR DESCRIPTION
### Description of work

Slight modification of default perspective selection. Now you can easily change "landing" view by changing the default perspective id constant in PerspectivesProvider.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/7403#issue-1392309733

### Acceptance criteria

[] No content change.

### Unit tests

Small change

### System tests

Small change

### Documentation

Small change

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

