### PR TITLE
Ticket7895

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/displaying/DisplayBlockTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/displaying/DisplayBlockTest.java
@@ -21,6 +21,7 @@ package uk.ac.stfc.isis.ibex.configserver.tests.displaying;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -43,6 +44,7 @@ public class DisplayBlockTest {
     TestableIOSObservable<Double> lowLimitObservable;
     
 	DisplayBlock displayBlock;
+	Block mockedBlock;
 	
 	@Before
 	public void setUp() {
@@ -53,8 +55,9 @@ public class DisplayBlockTest {
         descriptionObservable = new TestableIOSObservable<String>(mock(ClosableObservable.class));
         alarmObservable= new TestableIOSObservable<AlarmState>(mock(ClosableObservable.class));
         lowLimitObservable = new TestableIOSObservable<Double>(mock(ClosableObservable.class));
+        mockedBlock = mock(Block.class);
 		displayBlock = new DisplayBlock(
-                mock(Block.class), // block
+                mockedBlock, // block
                 valueObservable, // value
                 descriptionObservable, // description
                 alarmObservable, // alarm
@@ -299,5 +302,31 @@ public class DisplayBlockTest {
 
         // Assert
         assertEquals(lowLimit, displayBlock.getRunControlLowLimit());
+    }
+    
+    @Test
+    public void GIVEN_pv_connection_THEN_get_value_tooltip_text_correct() {
+    	// Arrange
+    	String name = "name";
+    	String pvAddress = "pv_address";
+    	String description = "description";
+    	String value = "10";
+    	
+    	when(mockedBlock.getPV()).thenReturn(pvAddress);
+    	when(mockedBlock.getName()).thenReturn(name);
+    	
+    	// Act
+    	valueObservable.setConnectionStatus(true);
+    	descriptionObservable.setValue(description);
+    	valueObservable.setValue(value);
+    	
+    	// Assert
+    	String expected = String.format("%s%sPV Address: %s%sValue: %s%sStatus: %s%s%s", 
+        		name, System.lineSeparator(),
+        		pvAddress, System.lineSeparator(),
+        		value, System.lineSeparator(), 
+        		"No alarm", System.lineSeparator(), 
+        		description);
+    	assertEquals(expected, displayBlock.getValueTooltipText());
     }
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/displaying/DisplayBlock.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/displaying/DisplayBlock.java
@@ -439,8 +439,9 @@ public class DisplayBlock extends ModelObject implements IRuncontrol, Closable {
      * @return the value tooltip text.
      */
     public String getValueTooltipText() {
-        return String.format("%s%sValue: %s%sStatus: %s%s%s", 
+        return String.format("%s%sPV Address: %s%sValue: %s%sStatus: %s%s%s", 
         		block.getName(), System.lineSeparator(),
+        		block.getPV(), System.lineSeparator(),
         		value, System.lineSeparator(), 
         		blockState.getUserFriendlyName(), System.lineSeparator(), 
         		description);


### PR DESCRIPTION
### Description of work

Extra line in hover tooltip that shows pv address.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/7895#issue-1793152685

### Acceptance criteria

See ticket

### Unit tests

Added a new unit test to check tooltip value

### System tests

No system test

### Documentation

No change

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

