### PR TITLE
Removed set buttons for RF and CarFreq, pointed fields at appropriate PVs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/aeroflex.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/aeroflex.opi
@@ -397,7 +397,7 @@ $(pv_value)</tooltip>
       <name>Set_carrier_frequency_val</name>
       <precision>5</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT_AERO):CARRIER_FREQ:SP_NO_ACTION</pv_name>
+      <pv_name>$(PV_ROOT_AERO):CARRIER_FREQ:SP</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules />
@@ -454,7 +454,7 @@ $(pv_value)</tooltip>
       <name>Set_RF_level_val</name>
       <precision>5</precision>
       <precision_from_pv>true</precision_from_pv>
-      <pv_name>$(PV_ROOT_AERO):RF_LEVEL:SP_NO_ACTION</pv_name>
+      <pv_name>$(PV_ROOT_AERO):RF_LEVEL:SP</pv_name>
       <pv_value />
       <rotation_angle>0.0</rotation_angle>
       <rules />
@@ -477,104 +477,6 @@ $(pv_value)</tooltip>
       <wuid>-1688a0b0:1836078a2e4:-7ea2</wuid>
       <x>108</x>
       <y>38</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-      <actions hook="false" hook_all="true">
-        <action type="WRITE_PV">
-          <pv_name>$(PV_ROOT_AERO):SEND_CAR_FREQ_PARAMS.PROC</pv_name>
-          <value>1</value>
-          <timeout>10</timeout>
-          <confirm_message></confirm_message>
-          <description></description>
-        </action>
-      </actions>
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
-      </font>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <height>21</height>
-      <image></image>
-      <name>Set_carrier_freq</name>
-      <push_action_index>0</push_action_index>
-      <pv_name></pv_name>
-      <pv_value />
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts />
-      <style>1</style>
-      <text>Set</text>
-      <toggle_button>false</toggle_button>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <visible>true</visible>
-      <widget_type>Action Button</widget_type>
-      <width>55</width>
-      <wuid>-1688a0b0:1836078a2e4:-7efb</wuid>
-      <x>324</x>
-      <y>6</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
-      <actions hook="false" hook_all="false">
-        <action type="WRITE_PV">
-          <pv_name>$(PV_ROOT_AERO):SEND_RF_LVL_PARAMS.PROC</pv_name>
-          <value>1</value>
-          <timeout>10</timeout>
-          <confirm_message></confirm_message>
-          <description></description>
-        </action>
-      </actions>
-      <border_alarm_sensitive>false</border_alarm_sensitive>
-      <border_color>
-        <color name="ISIS_Border" red="0" green="0" blue="0" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
-      </font>
-      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
-      <foreground_color>
-        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
-      </foreground_color>
-      <height>22</height>
-      <image></image>
-      <name>Set_rf_lvl</name>
-      <push_action_index>0</push_action_index>
-      <pv_name></pv_name>
-      <pv_value />
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts />
-      <style>1</style>
-      <text>Set</text>
-      <toggle_button>false</toggle_button>
-      <tooltip>$(pv_name)
-$(pv_value)</tooltip>
-      <visible>true</visible>
-      <widget_type>Action Button</widget_type>
-      <width>55</width>
-      <wuid>-1688a0b0:1836078a2e4:-7eec</wuid>
-      <x>324</x>
-      <y>37</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">


### PR DESCRIPTION


### Description of work

Updated the OPI to update PVs directly from entering in Values to the text fields, rather than having to push a "Set" button to do so. 

### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/7882)

### Acceptance criteria

- [ ] 'Set' button is removed in favour of accepting values when CR/Enter is pressed in setpoint box

Open aeroflex in Device Screens, after adding the IOC in configurations within IBEX, and then Run IOC, and then check that Carrier Frequency Values and RF Level can be changed by entering in a value from the left. It should update into the group on the right of the OPI called "Readout Parameters"

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

System tests will need to be reworked entirely for the Aeroflex, as several recent tickets have made significant changes to the IOC.

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [x] Do the changes function as described and is it robust?
- [x] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

