### PR TITLE
added missing connection to LED PV

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Keithley2700/keithley_scanner_values.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Keithley2700/keithley_scanner_values.opi
@@ -256,7 +256,13 @@ $(pv_value)</tooltip>
       <border_alarm_sensitive>true</border_alarm_sensitive>
       <height>25</height>
       <on_label>ON</on_label>
+<<<<<<< Updated upstream
       <border_width>1</border_width>
+=======
+      <pv_name>$(PV_ROOT):SCAN:STATE</pv_name>
+      <pv_value />
+      <rules />
+>>>>>>> Stashed changes
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>


### PR DESCRIPTION
### Description of work

added missing connection to LED PV on keithley 2700

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

Use this following command in an EPICS terminal to switch status of the scanner from on to off:

caput TE:NDW2555:KHLY2700_01:SCAN:STATE:SP 0
caput TE:NDW2555:KHLY2700_01:SCAN:STATE:SP 1

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

