### PR TITLE
Ticket7891 dg645 input

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/DG645/ChannelDelay.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/DG645/ChannelDelay.opi
@@ -378,8 +378,8 @@ $(pv_value)</tooltip>
       <height>20</height>
       <horizontal_alignment>0</horizontal_alignment>
       <limits_from_pv>false</limits_from_pv>
-      <maximum>1.7976931348623157E308</maximum>
-      <minimum>-1.7976931348623157E308</minimum>
+      <maximum>0.0</maximum>
+      <minimum>2000.0</minimum>
       <multiline_input>false</multiline_input>
       <name>Text Input</name>
       <precision>0</precision>
@@ -540,7 +540,25 @@ $(pv_value)</tooltip>
       <push_action_index>0</push_action_index>
       <pv_name></pv_name>
       <pv_value />
-      <rules />
+      <rules>
+        <rule name="Disable if value is out of range or incomplete" prop_id="enabled" out_exp="false">
+          <exp bool_exp="pvStr0 == &quot;&quot; || pvStr1 == &quot;&quot;">
+            <value>false</value>
+          </exp>
+          <exp bool_exp="+pvStr1 * Math.pow(10, (-pv2)) &gt; 2000">
+            <value>false</value>
+          </exp>
+          <exp bool_exp="+pvStr1 * Math.pow(10, (-pv2)) &lt; 0">
+            <value>false</value>
+          </exp>
+          <exp bool_exp="isNaN(+pvStr1)">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(CHANNEL_X)REFERENCE:SP</pv>
+          <pv trig="true">$(PV_ROOT)$(CHANNEL_X)DELAY:SP</pv>
+          <pv trig="true">$(PV_ROOT)$(CHANNEL_X)DELAYUNIT:SP.RVAL</pv>
+        </rule>
+      </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>
@@ -589,7 +607,25 @@ $(pv_value)</tooltip>
       <push_action_index>0</push_action_index>
       <pv_name></pv_name>
       <pv_value />
-      <rules />
+      <rules>
+        <rule name="Disable if value is out of range or incomplete" prop_id="enabled" out_exp="false">
+          <exp bool_exp="pvStr0 == &quot;&quot; || pvStr1 == &quot;&quot;">
+            <value>false</value>
+          </exp>
+          <exp bool_exp="+pvStr1 * Math.pow(10, (-pv2)) &gt; 2000">
+            <value>false</value>
+          </exp>
+          <exp bool_exp="+pvStr1 * Math.pow(10, (-pv2)) &lt; 0">
+            <value>false</value>
+          </exp>
+          <exp bool_exp="isNaN(+pvStr1)">
+            <value>false</value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)$(CHANNEL_Y)REFERENCE:SP</pv>
+          <pv trig="true">$(PV_ROOT)$(CHANNEL_Y)DELAY:SP</pv>
+          <pv trig="true">$(PV_ROOT)$(CHANNEL_Y)DELAYUNIT:SP.RVAL</pv>
+        </rule>
+      </rules>
       <scale_options>
         <width_scalable>true</width_scalable>
         <height_scalable>true</height_scalable>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/DG645/ChannelDelay.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/DG645/ChannelDelay.opi
@@ -378,8 +378,8 @@ $(pv_value)</tooltip>
       <height>20</height>
       <horizontal_alignment>0</horizontal_alignment>
       <limits_from_pv>false</limits_from_pv>
-      <maximum>0.0</maximum>
-      <minimum>2000.0</minimum>
+      <maximum>1.7976931348623157E308</maximum>
+      <minimum>-1.7976931348623157E308</minimum>
       <multiline_input>false</multiline_input>
       <name>Text Input</name>
       <precision>0</precision>


### PR DESCRIPTION
### Description of work

I added some simple rules to the set buttons in `ChannelDelay.opi` that disable the button 
- if the inputs are incomplete (i.e. there is no channel link set) or 
- if the value is of wrong format (e.i. not a number) or
- if the values of delay are out of the supported range based on the manual (0 - 2000 sec)

### Ticket

[#7891](https://github.com/ISISComputingGroup/IBEX/issues/7891)

### Acceptance criteria

- [x] The user cannot send invalid input to the device with the set button.

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [x] Do the changes function as described and is it robust?
- [x] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [x] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

