### PR TITLE
Remove linked file

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/.project
+++ b/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/.project
@@ -31,11 +31,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<linkedResources>
-		<link>
-			<name>src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/IconConventionsTest.java</name>
-			<type>1</type>
-			<location>C:/Instrument/Dev/ibex_gui/base/uk.ac.stfc.isis.ibex.ui.devicescreens.tests/src/uk/ac/stfc/isis/ibex/ui/devicescreens/tests/IconConventionsTest.java</location>
-		</link>
-	</linkedResources>
 </projectDescription>


### PR DESCRIPTION
Change form linked to normal file - there was an embedded link to an explicit filesystem path that broke my build as i use a non-standard directory layout