### PR TITLE
Ticket7943 alarm history

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.alarm.tests/src/uk/ac/stfc/isis/ibex/alarm/tests/AlarmSettingsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm.tests/src/uk/ac/stfc/isis/ibex/alarm/tests/AlarmSettingsTest.java
@@ -105,7 +105,6 @@ public class AlarmSettingsTest {
      * RDB URL for localhost.
      */
     private static final String LOCALHOST_RDB_URL = buildRdbUrl(LOCALHOST, "ALARM");
-    private static final String LOCALHOST_RDB_HIST_URL = buildRdbUrl(LOCALHOST, "log");
 
     /**
      * JMS URL for localhost.
@@ -168,7 +167,6 @@ public class AlarmSettingsTest {
      * RDB URL for the default instrument (currently localhost).
      */
     private static final String DEFAULT_RDB_URL = LOCALHOST_RDB_URL;
-    private static final String DEFAULT_RDB_HIST_URL = LOCALHOST_RDB_HIST_URL;
 
     /**
      * JMS URL for the default instrument (currently localhost).
@@ -213,7 +211,6 @@ public class AlarmSettingsTest {
      * Return value for mocked preference store rdb value.
      */
     private String mockRdbUrl;
-    private String mockRdbHistUrl;
 
     /**
      * Set up procedure to run before tests.
@@ -222,7 +219,6 @@ public class AlarmSettingsTest {
     public void setUp() {
         // Arrange
         mockRdbUrl = DEFAULT_RDB_URL;
-        mockRdbHistUrl = DEFAULT_RDB_HIST_URL;
         mockJmsUrl = DEFAULT_JMS_URL;
 
         preferences = mock(org.osgi.service.prefs.Preferences.class);

--- a/base/uk.ac.stfc.isis.ibex.alarm.tests/src/uk/ac/stfc/isis/ibex/alarm/tests/AlarmSettingsTest.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm.tests/src/uk/ac/stfc/isis/ibex/alarm/tests/AlarmSettingsTest.java
@@ -86,8 +86,8 @@ public class AlarmSettingsTest {
      * @return The archive settings string corresponding to the given
      *         instrument.
      */
-    private static String buildRdbUrl(String hostName) {
-        return "jdbc:mysql://" + hostName + "/ALARM?useSSL=false&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=Europe/London&autoReconnect=true";
+    private static String buildRdbUrl(String hostName, String table) {
+        return "jdbc:mysql://" + hostName + "/" + table + "?useSSL=false&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=Europe/London&autoReconnect=true";
     }
 
     /**
@@ -104,7 +104,8 @@ public class AlarmSettingsTest {
     /**
      * RDB URL for localhost.
      */
-    private static final String LOCALHOST_RDB_URL = buildRdbUrl(LOCALHOST);
+    private static final String LOCALHOST_RDB_URL = buildRdbUrl(LOCALHOST, "ALARM");
+    private static final String LOCALHOST_RDB_HIST_URL = buildRdbUrl(LOCALHOST, "log");
 
     /**
      * JMS URL for localhost.
@@ -114,7 +115,7 @@ public class AlarmSettingsTest {
     /**
      * RDB URL for larmor.
      */
-    private static final String LARMOR_RDB_URL = buildRdbUrl(NDXLARMOR);
+    private static final String LARMOR_RDB_URL = buildRdbUrl(NDXLARMOR, "ALARM");
 
     /**
      * JMS URL for larmor.
@@ -124,7 +125,7 @@ public class AlarmSettingsTest {
     /**
      * RDB URL for demo.
      */
-    private static final String DEMO_RDB_URL = buildRdbUrl(NDXDEMO);
+    private static final String DEMO_RDB_URL = buildRdbUrl(NDXDEMO, "ALARM");
 
     /**
      * JMS URL for demo.
@@ -134,7 +135,7 @@ public class AlarmSettingsTest {
     /**
      * RDB URL for a custom instrument.
      */
-    private static final String CUSTOM_RDB_URL = buildRdbUrl(NDWCUSTOM);
+    private static final String CUSTOM_RDB_URL = buildRdbUrl(NDWCUSTOM, "ALARM");
 
     /**
      * JMS URL for a custom instrument.
@@ -145,7 +146,7 @@ public class AlarmSettingsTest {
      * RDB URL for an instrument not conforming to standard ISIS naming
      * convention.
      */
-    private static final String NON_ISIS_INST_RDB_URL = buildRdbUrl(NON_ISIS_INST_NAME);
+    private static final String NON_ISIS_INST_RDB_URL = buildRdbUrl(NON_ISIS_INST_NAME, "ALARM");
 
     /**
      * JMS URL for an instrument not conforming to standard ISIS naming
@@ -156,7 +157,7 @@ public class AlarmSettingsTest {
     /**
      * RDB URL for an instrument in IP address format.
      */
-    private static final String IP_RDB_URL = buildRdbUrl(IP_ADDRESS);
+    private static final String IP_RDB_URL = buildRdbUrl(IP_ADDRESS, "ALARM");
 
     /**
      * JMS URL for an instrument in IP address format.
@@ -167,6 +168,7 @@ public class AlarmSettingsTest {
      * RDB URL for the default instrument (currently localhost).
      */
     private static final String DEFAULT_RDB_URL = LOCALHOST_RDB_URL;
+    private static final String DEFAULT_RDB_HIST_URL = LOCALHOST_RDB_HIST_URL;
 
     /**
      * JMS URL for the default instrument (currently localhost).
@@ -200,7 +202,7 @@ public class AlarmSettingsTest {
     /**
      * Preference store.
      */
-    private org.osgi.service.prefs.Preferences preferences;
+    private org.osgi.service.prefs.Preferences preferences, preferences_hist;
 
     /**
      * Return value for mocked preference store jms value.
@@ -211,6 +213,7 @@ public class AlarmSettingsTest {
      * Return value for mocked preference store rdb value.
      */
     private String mockRdbUrl;
+    private String mockRdbHistUrl;
 
     /**
      * Set up procedure to run before tests.
@@ -219,9 +222,11 @@ public class AlarmSettingsTest {
     public void setUp() {
         // Arrange
         mockRdbUrl = DEFAULT_RDB_URL;
+        mockRdbHistUrl = DEFAULT_RDB_HIST_URL;
         mockJmsUrl = DEFAULT_JMS_URL;
 
         preferences = mock(org.osgi.service.prefs.Preferences.class);
+        preferences_hist = mock(org.osgi.service.prefs.Preferences.class);
         doAnswer(new Answer<Void>() {
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -252,7 +257,7 @@ public class AlarmSettingsTest {
             }
         }).when(preferences).get(eq(Preferences.RDB_URL), nullable(String.class));
 
-        alarmSettings = new AlarmSettings(preferences);
+        alarmSettings = new AlarmSettings(preferences, preferences_hist);
 
         mockLocalHost = mockInstrument(LOCALHOST);
         mockLarmor = mockInstrument(NDXLARMOR);

--- a/base/uk.ac.stfc.isis.ibex.alarm/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.alarm/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Alarm
 Bundle-SymbolicName: uk.ac.stfc.isis.ibex.alarm;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: uk.ac.stfc.isis.ibex.alarm.Alarm
+Export-Package: uk.ac.stfc.isis.ibex.alarm
 Require-Bundle: org.eclipse.core.runtime,
  uk.ac.stfc.isis.ibex.model,
  org.eclipse.ui.workbench,
@@ -15,6 +16,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.csstudio.alarm.beast;bundle-version="4.5.0",
  uk.ac.stfc.isis.ibex.ui;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Bundle-ActivationPolicy: lazy
-Export-Package: uk.ac.stfc.isis.ibex.alarm
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.alarm
+Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
+ javax.inject;version="1.0.0"
+Bundle-ActivationPolicy: lazy

--- a/base/uk.ac.stfc.isis.ibex.alarm/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.alarm/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.core.runtime,
  uk.ac.stfc.isis.ibex.activemq;bundle-version="1.0.0",
  org.csstudio.platform.libs.jms,
  org.csstudio.alarm.beast;bundle-version="4.5.0",
- uk.ac.stfc.isis.ibex.ui;bundle-version="1.0.0"
+ uk.ac.stfc.isis.ibex.ui;bundle-version="1.0.0",
+ org.csstudio.alarm.beast.msghist;bundle-version="4.0.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.alarm
 Import-Package: javax.annotation;version="1.0.0";resolution:=optional,

--- a/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmCounter.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmCounter.java
@@ -60,7 +60,7 @@ public class AlarmCounter extends ModelObject {
     	int current = 0;
         AlarmTreePV[] pvs = alarmModel.getActiveAlarms();
         int total = pvs.length; 
-        for(int i = 0; i < total; ++i) {
+        for (int i = 0; i < total; ++i) {
             if (pvs[i].getCurrentSeverity() != SeverityLevel.OK) {
             	++current;
             }

--- a/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmCounter.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmCounter.java
@@ -54,12 +54,13 @@ public class AlarmCounter extends ModelObject {
      * the alarms  
      * 
      * @param alarmModel the alarm model
+     * @return alarm count
      */
     public int getAlarmCount(final AlarmClientModel alarmModel) {
     	int current = 0;
         AlarmTreePV[] pvs = alarmModel.getActiveAlarms();
         int total = pvs.length; 
-        for(int i=0; i<total; ++i) {
+        for(int i = 0; i < total; ++i) {
             if (pvs[i].getCurrentSeverity() != SeverityLevel.OK) {
             	++current;
             }

--- a/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmSettings.java
@@ -70,8 +70,7 @@ public class AlarmSettings {
         String hostName = instrument.hostName();
         preferences.put(org.csstudio.alarm.beast.Preferences.RDB_URL, buildRdbUrl(hostName, "ALARM"));
         preferences.put(org.csstudio.alarm.beast.Preferences.JMS_URL, buildJmsUrl(hostName));
-//        preferences_hist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl(hostName, "log"));
-        preferencesHist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl("localhost", "log"));
+        preferences_hist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl(hostName, "log"));
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmSettings.java
@@ -70,7 +70,7 @@ public class AlarmSettings {
         String hostName = instrument.hostName();
         preferences.put(org.csstudio.alarm.beast.Preferences.RDB_URL, buildRdbUrl(hostName, "ALARM"));
         preferences.put(org.csstudio.alarm.beast.Preferences.JMS_URL, buildJmsUrl(hostName));
-        preferences_hist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl(hostName, "log"));
+        preferencesHist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl(hostName, "log"));
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmSettings.java
@@ -37,15 +37,16 @@ public class AlarmSettings {
      * The plugin activator ID for beast.
      */
     private static final String PREF_QUALIFIER_ID = org.csstudio.alarm.beast.Activator.ID;
+    private static final String PREF_QUALIFIER_HIST_ID = org.csstudio.alarm.beast.msghist.Activator.ID;
 
-    private Preferences preferences;
+    private Preferences preferences, preferences_hist;
 
 
     /**
      * Instantiates a new alarm settings with default preferences store.
      */
     public AlarmSettings() {
-        this(InstanceScope.INSTANCE.getNode(PREF_QUALIFIER_ID));
+        this(InstanceScope.INSTANCE.getNode(PREF_QUALIFIER_ID), InstanceScope.INSTANCE.getNode(PREF_QUALIFIER_HIST_ID));
     }
 
 
@@ -54,8 +55,9 @@ public class AlarmSettings {
      *
      * @param preferences The preferences to use
      */
-    public AlarmSettings(Preferences preferences) {
+    public AlarmSettings(Preferences preferences, Preferences preferences_hist) {
         this.preferences = preferences;
+        this.preferences_hist = preferences_hist;
     }
 
     /**
@@ -65,17 +67,20 @@ public class AlarmSettings {
      */
     public void setInstrument(InstrumentInfo instrument) {
         String hostName = instrument.hostName();
-        preferences.put(org.csstudio.alarm.beast.Preferences.RDB_URL, buildRdbUrl(hostName));
+        preferences.put(org.csstudio.alarm.beast.Preferences.RDB_URL, buildRdbUrl(hostName, "ALARM"));
         preferences.put(org.csstudio.alarm.beast.Preferences.JMS_URL, buildJmsUrl(hostName));
+//        preferences_hist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl(hostName, "log"));
+        preferences_hist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl("localhost", "log"));
     }
 
     /**
      * @param hostName The instrument name
+     * @table Database table name
      * @return The archive settings string corresponding to the given
      *         instrument.
      */
-    private static String buildRdbUrl(String hostName) {
-        return "jdbc:mysql://" + hostName + "/ALARM?useSSL=false&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=Europe/London&autoReconnect=true";
+    private static String buildRdbUrl(String hostName, String table) {
+        return "jdbc:mysql://" + hostName + "/" + table + "?useSSL=false&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=Europe/London&autoReconnect=true";
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.alarm/src/uk/ac/stfc/isis/ibex/alarm/AlarmSettings.java
@@ -39,7 +39,7 @@ public class AlarmSettings {
     private static final String PREF_QUALIFIER_ID = org.csstudio.alarm.beast.Activator.ID;
     private static final String PREF_QUALIFIER_HIST_ID = org.csstudio.alarm.beast.msghist.Activator.ID;
 
-    private Preferences preferences, preferences_hist;
+    private Preferences preferences, preferencesHist;
 
 
     /**
@@ -53,11 +53,12 @@ public class AlarmSettings {
     /**
      * Instantiates a new alarm settings with desired preferences.
      *
-     * @param preferences The preferences to use
+     * @param preferences The preferences to use for normal alarms
+     * @param preferencesHist The preferences to use for alarm history
      */
-    public AlarmSettings(Preferences preferences, Preferences preferences_hist) {
+    public AlarmSettings(Preferences preferences, Preferences preferencesHist) {
         this.preferences = preferences;
-        this.preferences_hist = preferences_hist;
+        this.preferencesHist = preferencesHist;
     }
 
     /**
@@ -70,7 +71,7 @@ public class AlarmSettings {
         preferences.put(org.csstudio.alarm.beast.Preferences.RDB_URL, buildRdbUrl(hostName, "ALARM"));
         preferences.put(org.csstudio.alarm.beast.Preferences.JMS_URL, buildJmsUrl(hostName));
 //        preferences_hist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl(hostName, "log"));
-        preferences_hist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl("localhost", "log"));
+        preferencesHist.put(org.csstudio.alarm.beast.msghist.Preferences.RDB_URL, buildRdbUrl("localhost", "log"));
     }
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -233,6 +233,8 @@
       <children xsi:type="basic:PartSashContainer" xmi:id="_i2zuEGGWEee2EOm7UkHWHg" elementId="uk.ac.stfc.isis.ibex.client.e4.product.partsashcontainer.1" containerData="70" horizontal="true">
         <children xsi:type="basic:PartStack" xmi:id="_Cah-0GIsEeeBJ_yF1PfHTw" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.3" containerData="">
           <children xsi:type="basic:Part" xmi:id="_9zpdoHziEee7XtTTU-lRdw" elementId="uk.ac.stfc.isis.ibex.ui.alarm.AlarmView" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Alarms"/>
+          <children xsi:type="basic:Part" xmi:id="_STVkYDFzEe6Zd5hUjrQ4XA" elementId="uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistory" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Alarm History"/>
+          <children xsi:type="basic:Part" xmi:id="_tAzWcDF8Ee6Zd5hUjrQ4XA" elementId="uk.ac.stfc.isis.ibex.ui.alarm.AlarmTable" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Alarm Table"/>
         </children>
       </children>
     </children>

--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -232,9 +232,9 @@
       </children>
       <children xsi:type="basic:PartSashContainer" xmi:id="_i2zuEGGWEee2EOm7UkHWHg" elementId="uk.ac.stfc.isis.ibex.client.e4.product.partsashcontainer.1" containerData="70" horizontal="true">
         <children xsi:type="basic:PartStack" xmi:id="_Cah-0GIsEeeBJ_yF1PfHTw" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.3" containerData="">
-          <children xsi:type="basic:Part" xmi:id="_9zpdoHziEee7XtTTU-lRdw" elementId="uk.ac.stfc.isis.ibex.ui.alarm.AlarmView" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Alarms"/>
-          <children xsi:type="basic:Part" xmi:id="_STVkYDFzEe6Zd5hUjrQ4XA" elementId="uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistory" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Alarm History"/>
+          <children xsi:type="basic:Part" xmi:id="_9zpdoHziEee7XtTTU-lRdw" elementId="uk.ac.stfc.isis.ibex.ui.alarm.AlarmView" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Alarm Tree"/>
           <children xsi:type="basic:Part" xmi:id="_tAzWcDF8Ee6Zd5hUjrQ4XA" elementId="uk.ac.stfc.isis.ibex.ui.alarm.AlarmTable" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Alarm Table"/>
+          <children xsi:type="basic:Part" xmi:id="_STVkYDFzEe6Zd5hUjrQ4XA" elementId="uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistory" contributionURI="bundleclass://org.eclipse.ui.workbench/org.eclipse.ui.internal.e4.compatibility.CompatibilityView" label="Alarm History"/>
         </children>
       </children>
     </children>

--- a/base/uk.ac.stfc.isis.ibex.e4.client/authorization.conf
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/authorization.conf
@@ -18,7 +18,8 @@
 alarm_ack=.*
 
 # Anybody may configure alarms
-alarm_config=.*
+#alarm_config=.*
+alarm_config=ky9
 
 # Anybody called xyz-admin has full access
 FULL = .*-admin,    ky9, 5hz

--- a/base/uk.ac.stfc.isis.ibex.e4.client/authorization.conf
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/authorization.conf
@@ -1,0 +1,27 @@
+# Configure authorizations and users who have them
+# based on user name patterns
+
+# Format:
+# authorization = pattern for users, pattern for users, ...
+#
+# Authorizations are defined by applications.
+# For example, the alarm system GUI might require the "alarm_acknowledge"
+# authorization for acknowledging an alarm.
+#
+# In addition, the authorization "FULL" covers everything.
+#
+# User patterns are regular expressions.
+# Multiple patterns are separated by ",".
+# Each pattern itself must not contain a ",".
+
+# Anybody can acknowledge alarms
+alarm_ack=.*
+
+# Anybody may configure alarms
+alarm_config=.*
+
+# Anybody called xyz-admin has full access
+FULL = .*-admin,    ky9, 5hz
+
+# The following would allow anybody to do anything
+# FULL = .*

--- a/base/uk.ac.stfc.isis.ibex.e4.client/jaas.conf
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/jaas.conf
@@ -1,0 +1,123 @@
+/** JAAS Configuration file example
+ *
+ *  This is the default JAAS configuration file.
+ *
+ *  To use a different file, copy this file, edit as needed,
+ *  then define the Eclipse preference
+ *
+ *   org.csstudio.security/jaas_config_file=/path/to/your/file
+ *
+ * to specify the file, combined with the Eclipse preference
+ *
+ *   org.csstudio.security/jaas_config_name=Local_LDAP
+ *
+ * so select one of the login configurations specified in your file.
+ */ 
+
+
+/** The following two entries need to be present
+ *  to support automatic login based on the current user.
+ *  See LoginJob.forCurrentUser()
+ */
+
+/* Use the currently logged-in user on Linux and Mac OS X */
+unix
+{
+    com.sun.security.auth.module.UnixLoginModule required
+    /* debug="true" */;
+};
+
+
+/* Use the currently logged-in user on Windows */
+windows
+{
+    com.sun.security.auth.module.NTLoginModule required
+    /* debug="true" */;
+};
+
+
+/* Use plain-text password file.
+
+ * The passwordFile as listed in here works for
+ * plain JUnit tests.
+ 
+ * In the real world, it has to be the full path
+ * to the file, which should probably be located
+ * in for example /usr/local/etc.
+ * But then again in the real world you should not
+ * use such a plain-text password file anyway...
+ */
+file
+{
+    com.sun.jmx.remote.security.FileLoginModule required
+    debug="true"
+    passwordFile="passwords.conf";
+};
+
+
+/* LDAP authentication.
+ * Example of using LDAP on 'localhost' and some root DN.
+ *
+ * Refer to javadoc of com.sun.security.auth.module.JndiLoginModule
+ * for full details.
+ * The user URL must point to entries in the LDAP "inetOrgPerson" schema
+ * with "uid" and "userPassword" attributes.
+ * The provided user name must match a "uid",
+ * and the password must match the "{crypt}..." version of "userPassword".
+ */ 
+Local_LDAP
+{
+    com.sun.security.auth.module.JndiLoginModule required
+    debug="true"
+    user.provider.url="ldap://localhost:389/ou=People,dc=test,dc=ics"
+    group.provider.url="ldap://localhost:389/ou=People,dc=test,dc=ics";
+};
+
+
+/* Authentication as used by SNS UCAMS.
+ * Performs an LDAP 'bind' with user name and password.
+ */
+SNS_LDAP
+{
+    com.sun.security.auth.module.LdapLoginModule required
+    /* debug=true */
+    userProvider="ldaps://skynet2.ornl.gov/ou=Users,dc=ornl,dc=gov"
+    authIdentity="uid={USERNAME},ou=Users,dc=ornl,dc=gov";
+};
+
+
+/* Dummy log in:
+ * Allows any name and password except "fail".
+ * "fail" is used to test a failed log in.
+ *
+ * Also an example for adding a custom LoginModule:
+ *
+ * 1) Implement a LoginModule. See JAAS documentation.
+ *    Assume it's called org.csstudio.security.xy.XYLoginModule
+ * 2) In plugin.xml of the plugin that implements the JAAS LoginModule,
+ *    register it via the Eclipse extension point:
+ *  <extension point="org.eclipse.equinox.security.loginModule"
+ *       id="XYLoginModule">
+ *     <loginModule
+ *           class="org.csstudio.security.xy.XYLoginModule"
+ *           description="XY Login Mechanism">
+ *     </loginModule>
+ *  </extension>
+ * 3) Use it via the Eclipse ExtensionLoginModule.
+ *
+ * Fundamentally, JAAS could directly use
+ *  org.csstudio.security.xy.XYLoginModule
+ * but under Eclipse/OSGi it would not have access
+ * to the correct classloader.
+ * The ExtensionLoginModule can locate login modules
+ * that are registered via the extension point.
+ */
+dummy
+{
+    /* Get custom LoginModule via Eclipse */
+    org.eclipse.equinox.security.auth.module.ExtensionLoginModule required
+    extensionId=org.csstudio.security.DummyLoginModule
+    /* Parameters for XYLoginModule */
+    debug=true
+    whatever.your.loginmodule.uses="value";
+};

--- a/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/plugin_customization.ini
@@ -23,8 +23,14 @@ org.csstudio.email/smtp_host=exchsmtp.stfc.ac.uk
 # Channel Access
 # The following are the settings for genie_python, to change those for the GUI in general see uk.ac.stfc.isis.ibex.epics/resources/diirt/datasources/ca/ca.xml
 org.csstudio.platform.libs.epics/auto_addr_list=false
+org.csstudio.platform.libs.epics/use_pure_java=true
 org.csstudio.platform.libs.epics/addr_list=127.255.255.255 130.246.51.255 130.246.55.255 130.246.39.255 130.246.59.255 130.246.39.152:5066
 org.csstudio.platform.libs.epics/max_array_bytes=20000000
+
+org.csstudio.diirt.util.core.preferences/diirt.ca.addr.list=127.255.255.255 130.246.51.255 130.246.55.255 130.246.39.255 130.246.59.255 130.246.39.152:5066
+org.csstudio.diirt.util.core.preferences/diirt.ca.pure.java=true
+org.csstudio.diirt.util.core.preferences/diirt.ca.auto.addr.list=false
+org.csstudio.diirt.util.core.preferences/diirt.ca.max.array.size=20000000
 
 # OPI Builder
 org.csstudio.opibuilder/pv_connection_layer=pvmanager
@@ -70,6 +76,15 @@ org.csstudio.alarm.beast/rdb_user=alarm
 org.csstudio.alarm.beast/rdb_password=$alarm
 org.csstudio.alarm.beast/rdb_schema=ALARM
 
+org.csstudio.alarm.beast.msghist/rdb_url=jdbc:mysql://localhost/log
+org.csstudio.alarm.beast.msghist/rdb_user=log
+org.csstudio.alarm.beast.msghist/rdb_password=$log
+org.csstudio.alarm.beast.msghist/rdb_schema=
+org.csstudio.alarm.beast.msghist/auto_refresh_period=30
+org.csstudio.alarm.beast.msghist/start=-1 hours
+
+org.csstudio.alarm.beast.ui.areapanel/columns=4
+
 # JMS Connection
 org.csstudio.alarm.beast/jms_url=failover:(tcp://localhost:39990)
 org.csstudio.alarm.beast/jms_user=alarm
@@ -77,3 +92,17 @@ org.csstudio.alarm.beast/jms_password=$alarm
  
 # Specify alarm configuration (root element)
 org.csstudio.alarm.beast/root_component=Instrument
+
+## security
+# Path to JAAS configuration file
+# - When located inside a plugin "platform:/plugin/name.of.plugin/path/within/plugin.conf"
+# - when inside the product's "configuration/" directory, use "platform:/config/my_jaas_settings.conf"
+# - For plain files, use either "file:/full/path/to/my_jaas_settings.conf" or just "/full/path/to/my_jaas_settings.conf"
+# we are using default files, but forcing windows rather than dummy authentication
+#org.csstudio.security/jaas_config_file=platform:/plugin/org.csstudio.security/jaas.conf
+org.csstudio.security/jaas_config_file=platform:/plugin/uk.ac.stfc.isis.ibex.e4.client/jaas.conf
+#org.csstudio.security/jaas_config_name=windows
+org.csstudio.security/jaas_config_name=dummy
+org.csstudio.security/authorization_provider=FileBased
+#org.csstudio.security/authorization_file_name=platform:/plugin/org.csstudio.security/authorization.conf
+org.csstudio.security/authorization_file_name=platform:/plugin/uk.ac.stfc.isis.ibex.e4.client/authorization.conf

--- a/base/uk.ac.stfc.isis.ibex.e4.product/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  uk.ac.stfc.isis.ibex.logger;bundle-version="1.0.0",
  uk.ac.stfc.isis.ibex.epics,
- uk.ac.stfc.isis.ibex.ui;bundle-version="1.0.0"
+ uk.ac.stfc.isis.ibex.ui;bundle-version="1.0.0",
+ org.csstudio.security;bundle-version="1.1.1"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.e4.product

--- a/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/Application.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/Application.java
@@ -25,6 +25,8 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 
+import org.csstudio.security.authentication.LoginJob;
+
 import uk.ac.stfc.isis.ibex.epics.pvmanager.PVManagerSettings;
 import uk.ac.stfc.isis.ibex.ui.JMXServer;
 
@@ -54,6 +56,9 @@ public class Application implements IApplication {
 		
 		// Set up diirt as early as possible in the startup sequence.
 		PVManagerSettings.setUp();
+		
+        // Authenticate user
+        LoginJob.forCurrentUser().schedule();
 		
 		Display display = PlatformUI.createDisplay();
 		try {

--- a/base/uk.ac.stfc.isis.ibex.feature.css/feature.xml
+++ b/base/uk.ac.stfc.isis.ibex.feature.css/feature.xml
@@ -768,6 +768,34 @@
          unpack="false"/>
 
    <plugin
+         id="org.csstudio.alarm.beast.ui.alarmtable"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.csstudio.alarm.beast.ui.alarmtable.opiwidget"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.csstudio.alarm.beast.msghist"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.csstudio.alarm.beast.msghist.opiwidget"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.csstudio.opibuilder.rcp"
          download-size="0"
          install-size="0"

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Alarm/AlarmHistory.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Alarm/AlarmHistory.opi
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
+  <actions hook="false" hook_all="false" />
+  <auto_scale_widgets>
+    <auto_scale_widgets>false</auto_scale_widgets>
+    <min_width>-1</min_width>
+    <min_height>-1</min_height>
+  </auto_scale_widgets>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <background_color>
+    <color red="240" green="240" blue="240" />
+  </background_color>
+  <boy_version>5.1.0</boy_version>
+  <foreground_color>
+    <color red="192" green="192" blue="192" />
+  </foreground_color>
+  <grid_space>6</grid_space>
+  <height>600</height>
+  <macros>
+    <include_parent_macros>true</include_parent_macros>
+  </macros>
+  <name></name>
+  <rules />
+  <scripts />
+  <show_close_button>true</show_close_button>
+  <show_edit_range>true</show_edit_range>
+  <show_grid>true</show_grid>
+  <show_ruler>true</show_ruler>
+  <snap_to_geometry>true</snap_to_geometry>
+  <widget_type>Display</widget_type>
+  <width>800</width>
+  <wuid>-467b8db1:189acad3484:-7df9</wuid>
+  <x>-1</x>
+  <y>-1</y>
+  <widget typeId="org.csstudio.alarm.beast.msghist" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <background_color>
+      <color red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <column_headers>true</column_headers>
+    <columns>
+      <column name="SEQ" weight="5" width="40" visible="true" />
+      <column name="TIME" weight="10" width="180" visible="true" />
+      <column name="DELTA" weight="1" width="60" visible="true" />
+      <column name="TYPE" weight="5" width="45" visible="true" />
+      <column name="TEXT" weight="400" width="50" visible="true" />
+      <column name="NAME" weight="100" width="50" visible="true" />
+      <column name="STATUS" weight="80" width="45" visible="true" />
+      <column name="SEVERITY" weight="80" width="50" visible="true" />
+      <column name="CURRENT_SEVERITY" weight="80" width="50" visible="true" />
+      <column name="VALUE" weight="50" width="35" visible="true" />
+      <column name="CREATETIME" weight="50" width="80" visible="true" />
+      <column name="USER" weight="10" width="45" visible="true" />
+      <column name="HOST" weight="40" width="50" visible="true" />
+      <column name="APPLICATION-ID" weight="10" width="40" visible="true" />
+      <column name="CLASS" weight="10" width="50" visible="true" />
+      <column name="FILENAME" weight="10" width="50" visible="true" />
+    </columns>
+    <enabled>true</enabled>
+    <filter>START_TIME=-1 hours AND END_TIME=now</filter>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <foreground_color>
+      <color red="192" green="192" blue="192" />
+    </foreground_color>
+    <height>562</height>
+    <max_messages>10000</max_messages>
+    <name>Message history</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <sort_ascending>true</sort_ascending>
+    <sorting_column>0</sorting_column>
+    <time_format>yyyy-MM-dd'T'HH:mmX</time_format>
+    <tooltip></tooltip>
+    <visible>true</visible>
+    <widget_type>Message history</widget_type>
+    <width>754</width>
+    <wuid>-467b8db1:189acad3484:-7dea</wuid>
+    <x>27</x>
+    <y>21</y>
+  </widget>
+</display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/Alarm/AlarmTable.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/Alarm/AlarmTable.opi
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<display typeId="org.csstudio.opibuilder.Display" version="1.0.0">
+  <actions hook="false" hook_all="false" />
+  <auto_scale_widgets>
+    <auto_scale_widgets>false</auto_scale_widgets>
+    <min_width>-1</min_width>
+    <min_height>-1</min_height>
+  </auto_scale_widgets>
+  <auto_zoom_to_fit_all>false</auto_zoom_to_fit_all>
+  <background_color>
+    <color red="240" green="240" blue="240" />
+  </background_color>
+  <boy_version>5.1.0</boy_version>
+  <foreground_color>
+    <color red="192" green="192" blue="192" />
+  </foreground_color>
+  <grid_space>6</grid_space>
+  <height>600</height>
+  <macros>
+    <include_parent_macros>true</include_parent_macros>
+  </macros>
+  <name></name>
+  <rules />
+  <scripts />
+  <show_close_button>true</show_close_button>
+  <show_edit_range>true</show_edit_range>
+  <show_grid>true</show_grid>
+  <show_ruler>true</show_ruler>
+  <snap_to_geometry>true</snap_to_geometry>
+  <widget_type>Display</widget_type>
+  <width>800</width>
+  <wuid>-467b8db1:189acad3484:-7dff</wuid>
+  <x>-1</x>
+  <y>-1</y>
+  <widget typeId="org.csstudio.alarm.beast.ui.alarmtable" version="1.0.0">
+    <actions hook="false" hook_all="false" />
+    <background_color>
+      <color red="240" green="240" blue="240" />
+    </background_color>
+    <border_color>
+      <color red="0" green="128" blue="255" />
+    </border_color>
+    <border_style>0</border_style>
+    <border_width>1</border_width>
+    <columns>
+      <column id="ICON" weight="0" width="20" visible="true" />
+      <column id="PV" weight="50" width="97" visible="true" />
+      <column id="DESCRIPTION" weight="100" width="194" visible="true" />
+      <column id="TIME" weight="70" width="136" visible="true" />
+      <column id="CURRENT_SEVERITY" weight="30" width="58" visible="true" />
+      <column id="CURRENT_STATUS" weight="30" width="58" visible="true" />
+      <column id="SEVERITY" weight="30" width="58" visible="true" />
+      <column id="STATUS" weight="30" width="58" visible="true" />
+      <column id="VALUE" weight="30" width="58" visible="true" />
+      <column id="ACK" weight="0" width="35" visible="false" />
+      <column id="ACTION" weight="30" width="45" visible="false" />
+      <column id="ID" weight="30" width="45" visible="false" />
+    </columns>
+    <columns_headers_visible>true</columns_headers_visible>
+    <enabled>true</enabled>
+    <filter_item>/Instrument</filter_item>
+    <font>
+      <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+    </font>
+    <foreground_color>
+      <color red="192" green="192" blue="192" />
+    </foreground_color>
+    <height>564</height>
+    <max_number_of_alarms>50</max_number_of_alarms>
+    <name>Alarm Table</name>
+    <rules />
+    <scale_options>
+      <width_scalable>true</width_scalable>
+      <height_scalable>true</height_scalable>
+      <keep_wh_ratio>false</keep_wh_ratio>
+    </scale_options>
+    <scripts />
+    <separate_tables>true</separate_tables>
+    <sort_ascending>false</sort_ascending>
+    <sorting_column>4</sorting_column>
+    <table_header_visible>false</table_header_visible>
+    <table_weight_acknowledge>80</table_weight_acknowledge>
+    <table_weight_unacknowledge>20</table_weight_unacknowledge>
+    <time_format>dd. MMM HH:mm:ss.S</time_format>
+    <tooltip></tooltip>
+    <unacknowledged_blinking>true</unacknowledged_blinking>
+    <visible>true</visible>
+    <widget_type>Alarm Table</widget_type>
+    <width>764</width>
+    <writable>true</writable>
+    <wuid>-467b8db1:189acad3484:-7dfa</wuid>
+    <x>23</x>
+    <y>25</y>
+  </widget>
+</display>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -3340,5 +3340,26 @@
         </categories>
       </value>
     </entry>
+    <entry>
+      <key>Alarm Table</key>
+      <value>
+        <type>UNKNOWN</type>
+        <path>Alarm/AlarmTable.opi</path>
+        <description>Alarm Table</description>
+        <macros/>
+        <categories/>
+        <type>UNKNOWN</type>
+      </value>
+    </entry>
+    <entry>
+      <key>Alarm History</key>
+      <value>
+        <type>UNKNOWN</type>
+        <path>Alarm/AlarmHistory.opi</path>
+        <description>Alarm History</description>
+        <macros/>
+        <categories/>
+      </value>
+    </entry>
   </opis>
 </descriptions>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -3340,26 +3340,5 @@
         </categories>
       </value>
     </entry>
-    <entry>
-      <key>Alarm Table</key>
-      <value>
-        <type>UNKNOWN</type>
-        <path>Alarm/AlarmTable.opi</path>
-        <description>Alarm Table</description>
-        <macros/>
-        <categories/>
-        <type>UNKNOWN</type>
-      </value>
-    </entry>
-    <entry>
-      <key>Alarm History</key>
-      <value>
-        <type>UNKNOWN</type>
-        <path>Alarm/AlarmHistory.opi</path>
-        <description>Alarm History</description>
-        <macros/>
-        <categories/>
-      </value>
-    </entry>
   </opis>
 </descriptions>

--- a/base/uk.ac.stfc.isis.ibex.targetplatform/targetplatform.target
+++ b/base/uk.ac.stfc.isis.ibex.targetplatform/targetplatform.target
@@ -11,43 +11,6 @@
          <repository location="http://download.eclipse.org/releases/2018-09"/>
      </location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="http://shadow.nd.rl.ac.uk/ICP_P2/css_gui_dependencies_2023_03_27/p2repo/"/>
-		<unit id="org.epics.jca" version="0.0.0"/>
-		<unit id="com.fasterxml.jackson.core.jackson-annotations" version="0.0.0"/>
-		<unit id="com.fasterxml.jackson.core.jackson-core" version="0.0.0"/>
-		<unit id="com.fasterxml.jackson.core.jackson-databind" version="0.0.0"/>
-		<unit id="com.fasterxml.jackson.dataformat.jackson-dataformat-smile" version="0.0.0"/>
-		<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="0.0.0"/>
-		<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="0.0.0"/>
-		<unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations" version="0.0.0"/>
-		<unit id="org.csstudio.alarm.beast.tools.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.alarm.beast.ui.alarmtable.opiwidget.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.alarm.beast.ui.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.alarm.diirt.datasource.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.applications.opibuilder.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.applications.opibuilder.widgets.detailpanel.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.applications.pvmanager.diag.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.applications.utility.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.archive.reader.rdb.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.core.base.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.core.base.feature.source.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.core.diirt.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.core.platform.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.core.platform.feature.source.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.core.utility.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.core.utility.feature.source.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.thirdparty.all.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.thirdparty.all.feature.source.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.trends.databrowser2.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.trends.databrowser2.opiwidget.feature.feature.group" version="0.0.0"/>
-		<unit id="org.csstudio.utilities.feature.feature.group" version="0.0.0"/>
-		<unit id="org.epics.caj" version="0.0.0"/>
-		<unit id="org.epics.channelfinder.cf-client-api" version="0.0.0"/>
-		<unit id="org.epics.jca.source" version="0.0.0"/>
-		<unit id="org.epics.pvaccess.source" version="0.0.0"/>
-		<unit id="org.epics.pvdata.source" version="0.0.0"/>
-	</location>
-	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<repository location="https://download.eclipse.org/rt/eclipselink/updates/"/>
 		<unit id="org.eclipse.persistence.sdk.feature.group" version="2.7.11.v20220804-52dea2a3c0"/>
 	</location>
@@ -108,6 +71,43 @@
 		<repository location="http://shadow.nd.rl.ac.uk/ICP_P2/Pydev_10_1_3/features/org.python.pydev.p2-repo/target/repository/"/>
 		<unit id="org.python.pydev.feature.feature.group" version="10.1.3.202302240955"/>
 		<unit id="org.python.pydev.feature.source.feature.group" version="10.1.3.202302240955"/>
+	</location>
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<repository location="http://shadow.nd.rl.ac.uk/ICP_P2/css_gui_dependencies_2023_08_11/p2repo/"/>
+		<unit id="com.fasterxml.jackson.core.jackson-annotations" version="2.9.0"/>
+		<unit id="com.fasterxml.jackson.core.jackson-core" version="2.9.7"/>
+		<unit id="com.fasterxml.jackson.core.jackson-databind" version="2.9.7"/>
+		<unit id="com.fasterxml.jackson.dataformat.jackson-dataformat-smile" version="2.6.3"/>
+		<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-base" version="2.6.3"/>
+		<unit id="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider" version="2.6.3"/>
+		<unit id="com.fasterxml.jackson.module.jackson-module-jaxb-annotations" version="2.9.7"/>
+		<unit id="org.csstudio.alarm.beast.tools.feature.feature.group" version="4.0.1.202308110153"/>
+		<unit id="org.csstudio.alarm.beast.ui.alarmtable.opiwidget.feature.feature.group" version="1.0.0.202308110153"/>
+		<unit id="org.csstudio.alarm.beast.ui.feature.feature.group" version="4.1.0.202308110153"/>
+		<unit id="org.csstudio.alarm.diirt.datasource.feature.feature.group" version="0.0.1.202308110153"/>
+		<unit id="org.csstudio.applications.opibuilder.feature.feature.group" version="5.0.0.202308110153"/>
+		<unit id="org.csstudio.applications.opibuilder.widgets.detailpanel.feature.feature.group" version="0.0.1.202308110153"/>
+		<unit id="org.csstudio.applications.pvmanager.diag.feature.feature.group" version="1.0.0.202308110153"/>
+		<unit id="org.csstudio.applications.utility.feature.feature.group" version="1.0.0.202308110153"/>
+		<unit id="org.csstudio.archive.reader.rdb.feature.feature.group" version="1.0.0.202308110153"/>
+		<unit id="org.csstudio.core.base.feature.feature.group" version="0.0.1.202308110153"/>
+		<unit id="org.csstudio.core.base.feature.source.feature.group" version="0.0.1.202308110153"/>
+		<unit id="org.csstudio.core.diirt.feature.feature.group" version="0.0.1.202308110153"/>
+		<unit id="org.csstudio.core.platform.feature.feature.group" version="0.0.1.202308110153"/>
+		<unit id="org.csstudio.core.platform.feature.source.feature.group" version="0.0.1.202308110153"/>
+		<unit id="org.csstudio.core.utility.feature.feature.group" version="4.1.0.202308110153"/>
+		<unit id="org.csstudio.core.utility.feature.source.feature.group" version="4.1.0.202308110153"/>
+		<unit id="org.csstudio.thirdparty.all.feature.feature.group" version="1.0.3.202101071159"/>
+		<unit id="org.csstudio.thirdparty.all.feature.source.feature.group" version="1.0.3.202101071159"/>
+		<unit id="org.csstudio.trends.databrowser2.feature.feature.group" version="4.1.0.202308110153"/>
+		<unit id="org.csstudio.trends.databrowser2.opiwidget.feature.feature.group" version="3.2.0.202308110153"/>
+		<unit id="org.csstudio.utilities.debugging.feature.feature.group" version="1.0.0.202308110153"/>
+		<unit id="org.epics.caj" version="1.1.14"/>
+		<unit id="org.epics.channelfinder.cf-client-api" version="3.0.3"/>
+		<unit id="org.epics.jca" version="2.4.3"/>
+		<unit id="org.epics.jca.source" version="2.4.2"/>
+		<unit id="org.epics.pvaccess.source" version="5.1.2"/>
+		<unit id="org.epics.pvdata.source" version="6.1.2"/>
 	</location>
 	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 		<dependencies>
@@ -279,7 +279,7 @@
 			</dependency>
 		</dependencies>
 	</location>
-  <location includeDependencyDepth="none" includeSource="true" missingManifest="generate" type="Maven">
+	<location includeDependencyDepth="none" includeDependencyScopes="compile" includeSource="true" missingManifest="generate" type="Maven">
 		<dependencies>
 			<dependency>
 				<groupId>org.mockito</groupId>

--- a/base/uk.ac.stfc.isis.ibex.ui.alarm/META-INF/MANIFEST.MF
+++ b/base/uk.ac.stfc.isis.ibex.ui.alarm/META-INF/MANIFEST.MF
@@ -4,6 +4,7 @@ Bundle-Name: Alarm
 Bundle-SymbolicName: uk.ac.stfc.isis.ibex.ui.alarm;singleton:=true
 Bundle-Version: 1.0.0.qualifier
 Bundle-Activator: uk.ac.stfc.isis.ibex.ui.alarm.Alarms
+Export-Package: uk.ac.stfc.isis.ibex.ui.alarm
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.runtime,
@@ -14,8 +15,11 @@ Require-Bundle: org.eclipse.ui,
  javax.annotation;bundle-version="1.2.0",
  org.hamcrest;bundle-version="1.1.0",
  org.hamcrest.core;bundle-version="1.3.0",
- org.hamcrest.library;bundle-version="1.3.0"
-Bundle-ActivationPolicy: lazy
+ org.hamcrest.library;bundle-version="1.3.0",
+ org.csstudio.alarm.beast.msghist;bundle-version="4.0.1",
+ org.csstudio.alarm.beast.ui.alarmtable;bundle-version="4.1.2"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Export-Package: uk.ac.stfc.isis.ibex.ui.alarm
 Automatic-Module-Name: uk.ac.stfc.isis.ibex.ui.alarm
+Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
+ javax.inject;version="1.0.0"
+Bundle-ActivationPolicy: lazy

--- a/base/uk.ac.stfc.isis.ibex.ui.alarm/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.alarm/plugin.xml
@@ -6,19 +6,19 @@
       <view
             class="uk.ac.stfc.isis.ibex.ui.alarm.AlarmView"
             id="uk.ac.stfc.isis.ibex.ui.alarm.AlarmView"
-            name="Alarm"
-            restorable="true">
-      </view>
-      <view
-            class="uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistoryView"
-            id="uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistory"
-            name="Alarm History"
+            name="Alarm Tree"
             restorable="true">
       </view>
       <view
             class="uk.ac.stfc.isis.ibex.ui.alarm.AlarmTableView"
             id="uk.ac.stfc.isis.ibex.ui.alarm.AlarmTable"
             name="Alarm Table"
+            restorable="true">
+      </view>
+      <view
+            class="uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistoryView"
+            id="uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistory"
+            name="Alarm History"
             restorable="true">
       </view>
    </extension>

--- a/base/uk.ac.stfc.isis.ibex.ui.alarm/plugin.xml
+++ b/base/uk.ac.stfc.isis.ibex.ui.alarm/plugin.xml
@@ -9,6 +9,18 @@
             name="Alarm"
             restorable="true">
       </view>
+      <view
+            class="uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistoryView"
+            id="uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistory"
+            name="Alarm History"
+            restorable="true">
+      </view>
+      <view
+            class="uk.ac.stfc.isis.ibex.ui.alarm.AlarmTableView"
+            id="uk.ac.stfc.isis.ibex.ui.alarm.AlarmTable"
+            name="Alarm Table"
+            restorable="true">
+      </view>
    </extension>
 
 </plugin>

--- a/base/uk.ac.stfc.isis.ibex.ui.alarm/src/uk/ac/stfc/isis/ibex/ui/alarm/AlarmHistoryView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.alarm/src/uk/ac/stfc/isis/ibex/ui/alarm/AlarmHistoryView.java
@@ -1,0 +1,48 @@
+
+/*
+* This file is part of the ISIS IBEX application.
+* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* All rights reserved.
+*
+* This program is distributed in the hope that it will be useful.
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v1.0 which accompanies this distribution.
+* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM
+* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+*
+* You should have received a copy of the Eclipse Public License v1.0
+* along with this program; if not, you can obtain a copy from
+* https://www.eclipse.org/org/documents/epl-v10.php or
+* http://opensource.org/licenses/eclipse-1.0.php
+*/
+
+package uk.ac.stfc.isis.ibex.ui.alarm;
+
+import org.csstudio.alarm.beast.msghist.MessageHistoryView;
+import org.eclipse.swt.widgets.Composite;
+
+import uk.ac.stfc.isis.ibex.alarm.Alarm;
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+
+
+/**
+ * The Class AlarmView which is the view which contains the alarm tree.
+ */
+public class AlarmHistoryView extends MessageHistoryView {
+
+	/**
+	 * The ID for this class.
+	 */
+    public static final String ID = "uk.ac.stfc.isis.ibex.ui.alarm.AlarmHistory"; //$NON-NLS-1$
+
+    @Override
+    public void createPartControl(final Composite parent) {
+		Alarm.getInstance().initInstrument();
+        try {
+			super.createPartControl(parent);
+		} catch (Exception e) {
+            IsisLog.getLogger(getClass()).error("Cannot load alarm model", e); //$NON-NLS-1$
+		}
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.alarm/src/uk/ac/stfc/isis/ibex/ui/alarm/AlarmTableView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.alarm/src/uk/ac/stfc/isis/ibex/ui/alarm/AlarmTableView.java
@@ -1,0 +1,47 @@
+
+/*
+* This file is part of the ISIS IBEX application.
+* Copyright (C) 2012-2015 Science & Technology Facilities Council.
+* All rights reserved.
+*
+* This program is distributed in the hope that it will be useful.
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v1.0 which accompanies this distribution.
+* EXCEPT AS EXPRESSLY SET FORTH IN THE ECLIPSE PUBLIC LICENSE V1.0, THE PROGRAM
+* AND ACCOMPANYING MATERIALS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES
+* OR CONDITIONS OF ANY KIND.  See the Eclipse Public License v1.0 for more details.
+*
+* You should have received a copy of the Eclipse Public License v1.0
+* along with this program; if not, you can obtain a copy from
+* https://www.eclipse.org/org/documents/epl-v10.php or
+* http://opensource.org/licenses/eclipse-1.0.php
+*/
+
+package uk.ac.stfc.isis.ibex.ui.alarm;
+
+import org.eclipse.swt.widgets.Composite;
+
+import uk.ac.stfc.isis.ibex.alarm.Alarm;
+import uk.ac.stfc.isis.ibex.logger.IsisLog;
+
+
+/**
+ * The Class AlarmView which is the view which contains the alarm tree.
+ */
+public class AlarmTableView extends org.csstudio.alarm.beast.ui.alarmtable.AlarmTableView {
+
+	/**
+	 * The ID for this class.
+	 */
+    public static final String ID = "uk.ac.stfc.isis.ibex.ui.alarm.AlarmTable"; //$NON-NLS-1$
+
+    @Override
+    public void createPartControl(final Composite parent) {
+		Alarm.getInstance().initInstrument();
+        try {
+			super.createPartControl(parent);
+		} catch (Exception e) {
+            IsisLog.getLogger(getClass()).error("Cannot load alarm model", e); //$NON-NLS-1$
+		}
+    }
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.alarm/src/uk/ac/stfc/isis/ibex/ui/alarm/AlarmView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.alarm/src/uk/ac/stfc/isis/ibex/ui/alarm/AlarmView.java
@@ -52,8 +52,9 @@ public class AlarmView extends ViewPart {
 
         gui = new GUI(parent, model, getViewSite());
 
-        // There's nothing on the default menu we currently want
-        gui.getTreeViewer().getTree().setMenu(null);
+        // Use this if there's is nothing on the default menu we wanted
+        // now we can acknowledge alarms, have added back menu
+        //gui.getTreeViewer().getTree().setMenu(null);
 
         // Lots of other controls available (see AlarmTreeView). For now they're just clutter
         getViewSite().getActionBars().getToolBarManager().add(new RefreshAction());


### PR DESCRIPTION
### Description of work

* Add alarm history and table to Alarm perspective
* Allow alarm acknowledgememnt and disable
* Alarm counter is orange and not flashing rather than red and flashing if unacknowledged alarms that are no longer in alarm  

Note that building the client is not dependent on the CSStudio / EPICS-CSS changes - these just build a new separate product, everything else needed by GUI is already present and unchanged

A gui is built from this PR by  `ibex_gui_pr_pipeline` and deployed to  `Kits$\CompGroup\ICP\Client_E4\branches`
  
### Ticket

See ISISComputingGroup/IBEX#7943

### Acceptance criteria

See description

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

