### PR TITLE
Show title and Users in dataweb option was added to the dashboard

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.dashboard/src/uk/ac/stfc/isis/ibex/dashboard/DashboardObservables.java
+++ b/base/uk.ac.stfc.isis.ibex.dashboard/src/uk/ac/stfc/isis/ibex/dashboard/DashboardObservables.java
@@ -28,8 +28,12 @@ import uk.ac.stfc.isis.ibex.epics.pv.Closer;
 import uk.ac.stfc.isis.ibex.epics.switching.ObservableFactory;
 import uk.ac.stfc.isis.ibex.epics.switching.OnInstrumentSwitch;
 import uk.ac.stfc.isis.ibex.epics.switching.SwitchableObservable;
+import uk.ac.stfc.isis.ibex.epics.switching.WritableFactory;
+import uk.ac.stfc.isis.ibex.epics.writing.Writable;
 import uk.ac.stfc.isis.ibex.instrument.InstrumentUtils;
+import uk.ac.stfc.isis.ibex.instrument.channels.BooleanChannel;
 import uk.ac.stfc.isis.ibex.instrument.channels.CompressedCharWaveformChannel;
+import uk.ac.stfc.isis.ibex.instrument.channels.LongChannel;
 import uk.ac.stfc.isis.ibex.instrument.channels.StringChannel;
 
 /**
@@ -39,22 +43,33 @@ import uk.ac.stfc.isis.ibex.instrument.channels.StringChannel;
 public class DashboardObservables extends Closer {
 
     private static final String USERS = "ED:SURNAME";
-
+    private static final String DISPLAY_TITLE = "DAE:TITLE:DISPLAY";
 
     private final ObservableFactory obsFactory = new ObservableFactory(OnInstrumentSwitch.SWITCH);
 
     private final Map<DashboardPv, SwitchableObservable<String>> valueObservables = new EnumMap<>(DashboardPv.class);
     private final Map<DashboardPv, SwitchableObservable<String>> labelObservables = new EnumMap<>(DashboardPv.class);
-
+    private final WritableFactory writeFactory = new WritableFactory(OnInstrumentSwitch.SWITCH);
+    
     /**
      * An observable for the list of users to be displayed on the dashboard.
      */
-    
     public final ForwardingObservable<String> users;
+    
     /**
      * An observable for the title on the dashboard.
      */
     public final ForwardingObservable<String> title;
+    
+    /**
+     * An observable for the flag which denotes whether the title is displayed on the dashboard.
+     */
+    public final ForwardingObservable<Boolean> displayTitle;
+    
+    /**
+     * An observable for the flag which denotes whether the title is displayed on the dashboard.
+     */
+    public final Writable<Long> displayTitleSetter;
     
     /**
      * An observable for the run state on the dashboard.
@@ -71,7 +86,12 @@ public class DashboardObservables extends Closer {
     public DashboardObservables() {
 	users = registerForClose(obsFactory.getSwitchableObservable(new CompressedCharWaveformChannel(),
 		InstrumentUtils.addPrefix(USERS)));
-
+	
+    displayTitleSetter = writeFactory.getSwitchableWritable(new LongChannel(),
+    		InstrumentUtils.addPrefix(DISPLAY_TITLE));
+	
+    displayTitle = obsFactory.getSwitchableObservable(new BooleanChannel(),
+            InstrumentUtils.addPrefix(DISPLAY_TITLE));
 	final DaeObservables dae = new DaeObservables();
 	title = registerForClose(dae.title);
 	runState = registerForClose(dae.runState);

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/TitlePanelModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/models/TitlePanelModel.java
@@ -21,8 +21,12 @@ package uk.ac.stfc.isis.ibex.ui.dashboard.models;
 
 import uk.ac.stfc.isis.ibex.epics.adapters.TextUpdatedObservableAdapter;
 import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
+import uk.ac.stfc.isis.ibex.epics.observing.BooleanWritableObservableAdapter;
 import uk.ac.stfc.isis.ibex.epics.observing.ForwardingObservable;
 import uk.ac.stfc.isis.ibex.epics.pv.Closer;
+import uk.ac.stfc.isis.ibex.epics.writing.Writable;
+import uk.ac.stfc.isis.ibex.instrument.InstrumentUtils;
+import uk.ac.stfc.isis.ibex.instrument.channels.BooleanChannel;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 
 /**
@@ -34,15 +38,26 @@ public class TitlePanelModel extends Closer {
 	private final UpdatedObservableAdapter<String> users;
 	
 	/**
+	 * An observable for whether to display the title on the web dashboard.
+	 */
+	public final BooleanWritableObservableAdapter displayTitle;
+
+	
+	/**
 	 * Create the model.
 	 * @param title an observable on the title
 	 * @param users an observable on the users
+	 * @param displayTitle is an observable and writer on the displayTitle
 	 */
-	public TitlePanelModel(ForwardingObservable<String> title, ForwardingObservable<String> users) {
+	public TitlePanelModel(ForwardingObservable<String> title, ForwardingObservable<String> users, ForwardingObservable<Boolean> displayTitle, Writable<Long> displayTitleSetter) {
 		this.title = registerForClose(new TextUpdatedObservableAdapter(title));
 		this.users = registerForClose(new TextUpdatedObservableAdapter(users));
-	}
+        this.displayTitle = registerForClose(new BooleanWritableObservableAdapter(displayTitleSetter, displayTitle));
+        
 
+
+	}
+	
 	/**
 	 * Gets the title.
 	 * @return the title
@@ -58,4 +73,14 @@ public class TitlePanelModel extends Closer {
 	public UpdatedValue<String> users() {
 		return users;
 	}
+	
+	/**
+	 * Gets the displayTitle.
+	 * @return the displayTitle
+	 */
+	public BooleanWritableObservableAdapter displayTitle() {
+		return displayTitle;
+	}
+
+
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
@@ -62,7 +62,7 @@ public class DashboardView {
 	private final BannerModel bannerModel = new BannerModel(dashboard.observables());
 	
 	private final TitlePanelModel titleModel = 
-			new TitlePanelModel(dashboard.observables().title, dashboard.observables().users);
+			new TitlePanelModel(dashboard.observables().title, dashboard.observables().users, dashboard.observables().displayTitle, dashboard.observables().displayTitleSetter);
 
 	/**
 	 * Create the dashboard view.

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/widgets/TitlePanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/widgets/TitlePanel.java
@@ -25,11 +25,14 @@ import org.eclipse.core.databinding.beans.typed.BeanProperties;
 import org.eclipse.core.databinding.conversion.Converter;
 import org.eclipse.jface.databinding.swt.typed.WidgetProperties;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Button;
 
 import uk.ac.stfc.isis.ibex.ui.Utils;
 import uk.ac.stfc.isis.ibex.ui.dashboard.models.TitlePanelModel;
@@ -41,7 +44,8 @@ public class TitlePanel extends Composite {
 
 	private final Label title;
 	private final Label users;
-	
+	private Button btnDisplayTitle;
+
     /**
      * Default constructor, creates the panel.
      * 
@@ -60,7 +64,7 @@ public class TitlePanel extends Composite {
 		this.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		
 		Label lblTitle = new Label(this, SWT.NONE);
-		lblTitle.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+		lblTitle.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1));
 		lblTitle.setFont(font);
 		lblTitle.setText("Title:");
 		
@@ -71,7 +75,7 @@ public class TitlePanel extends Composite {
 		title.setToolTipText("Experiment title");
 		
 		Label lblUsers = new Label(this, SWT.NONE);
-		lblUsers.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
+		lblUsers.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false, 1, 1));
 		lblUsers.setFont(font);
 		lblUsers.setText("Users:");
 		
@@ -79,6 +83,19 @@ public class TitlePanel extends Composite {
 		users.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 		users.setFont(font);
 		users.setText("Experiment users");
+		users.setToolTipText("Experiment users");
+
+		btnDisplayTitle = new Button(this, SWT.CHECK);
+		btnDisplayTitle.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, false, false));
+		btnDisplayTitle.setFont(font);
+		btnDisplayTitle.setText("Show Title and Users in Dataweb Dashboard Page");
+		btnDisplayTitle.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				super.widgetSelected(e);
+				model.displayTitle().uncheckedSetValue(btnDisplayTitle.getSelection());
+			}
+		});
 		
 		if (model != null) {
 			bind(model);
@@ -103,7 +120,11 @@ public class TitlePanel extends Composite {
         		WidgetProperties.tooltipText().observe(title), 
         		BeanProperties.<Object, String>value("value").observe(model.title()), 
         		null, literalAmpersands);
-		
+		bindingContext.bindValue(WidgetProperties.buttonSelection().observe(btnDisplayTitle),
+				BeanProperties.value("value").observe(model.displayTitle().value()));
+		bindingContext.bindValue(WidgetProperties.enabled().observe(btnDisplayTitle), 
+		        BeanProperties.value("value").observe(model.displayTitle().canSetValue()));
+
         if (Utils.SHOULD_HIDE_USER_INFORMATION) {
         	users.setText("<Users unavailable>");
         	users.setToolTipText("<Users unavailable>");
@@ -116,7 +137,7 @@ public class TitlePanel extends Composite {
 			bindingContext.bindValue(
 					WidgetProperties.tooltipText().observe(users), 
 					BeanProperties.<Object, String>value("value").observe(model.users()), 
-					null, new UpdateValueStrategy<String, String>().setConverter(deJsoner));
+					null, new UpdateValueStrategy<String, String>().setConverter(deJsoner));	
         }
 	}
 }


### PR DESCRIPTION
### Description of work

The 'Show title and Users in dataweb option was added to the dashboard' checkbox that can be found on both DAE < Run Summary and Experiment Details tab has been added to the dashboard, making it easier to locate the funcationality. 

The PV within the box appears to be linked to the others, where checking and unchecking is copied by all others within IBEX.

### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/7921)

### Acceptance criteria

See Ticket

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

