### PR TITLE
Fixed missing closing tags in opi_info.xml

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -3538,6 +3538,8 @@
         <categories>
           <category>Miscellaneous motion control</category>
         </categories>
+      </value>
+    </entry>
     <entry>
       <key>PRE4500</key>
       <value>


### PR DESCRIPTION
### Description of work

A <value> and <entry> tag in the opi_info.xml were missing closing tags. This was breaking the GUI so required changes have been made. 

### Ticket

N/A - Flash review requested.