### PR TITLE
Ticket7896 iocs in use

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaInfoPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaInfoPanel.java
@@ -2,7 +2,9 @@ package uk.ac.stfc.isis.ibex.ui.moxas.views;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.util.List;
 import java.util.ArrayList;
+import static java.util.stream.Collectors.joining;
 
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.TreeViewer;
@@ -14,6 +16,8 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+
+import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
 
 /**
  * A panel showing port mappings of networked Moxa switches set up for this
@@ -69,6 +73,22 @@ public class MoxaInfoPanel extends Composite {
 				return p.getComPort();
 			}
 		});
+		TreeViewerColumn iocColumn = new TreeViewerColumn(viewer, SWT.NONE);
+		iocColumn.getColumn().setText("Connected IOC");
+		iocColumn.getColumn().setWidth(COLUMN_WIDTH);
+
+		iocColumn.setLabelProvider(new ColumnLabelProvider() {
+			@Override
+			public String getText(Object element) {
+				if (element instanceof ArrayList<?>) {
+					return null;
+				}
+				MoxaModelObject p = (MoxaModelObject) element;
+				List<Ioc> iocs = p.getIocs();
+								
+				return iocs.stream().map(Ioc::getName).collect(joining(", "));
+			}
+		});
 		viewer.setContentProvider(new MoxaTableContentProvider());
 
 		viewer.setInput(model.getMoxaPorts());
@@ -107,7 +127,6 @@ public class MoxaInfoPanel extends Composite {
 				viewer.getTree().setVisible(true);
 			}
 		});
-
 	}
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaInfoPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaInfoPanel.java
@@ -15,6 +15,7 @@ import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.TreeEvent;
 import org.eclipse.swt.events.TreeListener;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
@@ -82,6 +83,20 @@ public class MoxaInfoPanel extends Composite {
 		iocColumn.getColumn().setWidth(COLUMN_WIDTH);
 
 		iocColumn.setLabelProvider(new ColumnLabelProvider() {
+			@Override
+			public Color getForeground(Object element) {
+				// Change the text colour of cells where a port is connected to multiple IOCs
+				if (element instanceof MoxaModelObject) {
+					MoxaModelObject p = (MoxaModelObject) element;
+					List<Ioc> iocs = p.getIocs();
+					
+					if (iocs.size() > 1) {
+						return new Color(255, 0, 0);
+					}
+				}
+				return super.getForeground(element);
+			}
+			
 			@Override
 			public String getText(Object element) {
 				if (element instanceof ArrayList<?>) {

--- a/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaModelObject.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaModelObject.java
@@ -28,7 +28,11 @@
  */
 package uk.ac.stfc.isis.ibex.ui.moxas.views;
 
+import java.util.List;
+import java.util.ArrayList;
+
 import uk.ac.stfc.isis.ibex.model.ModelObject;
+import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
 
 /**
  * Class to hold information about the mapping between physical moxa ports and
@@ -39,6 +43,7 @@ public class MoxaModelObject extends ModelObject implements Comparable<MoxaModel
 
 	private final String physport;
 	private final String comport;
+	private final List<Ioc> iocs;
 
 	/**
 	 * Instantiates a new moxa mapping pair.
@@ -46,9 +51,10 @@ public class MoxaModelObject extends ModelObject implements Comparable<MoxaModel
 	 * @param physport physical moxa port number for a mapping.
 	 * @param comport  COM port for a mapping.
 	 */
-	public MoxaModelObject(String physport, String comport) {
+	public MoxaModelObject(String physport, String comport, List<Ioc> iocs) {
 		this.physport = physport;
 		this.comport = comport;
+		this.iocs = new ArrayList<Ioc>(iocs);
 	}
 
 	/**
@@ -69,7 +75,14 @@ public class MoxaModelObject extends ModelObject implements Comparable<MoxaModel
 	public String getComPort() {
 		return comport;
 	}
-
+	
+	/**
+	 * @return IOCs that use the COM port
+	 */
+	public List<Ioc> getIocs() {
+		return new ArrayList<Ioc>(iocs);
+	}
+	
 	/**
 	 * {@inheritDoc}
 	 */

--- a/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaModelObject.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaModelObject.java
@@ -50,6 +50,7 @@ public class MoxaModelObject extends ModelObject implements Comparable<MoxaModel
 	 *
 	 * @param physport physical moxa port number for a mapping.
 	 * @param comport  COM port for a mapping.
+	 * @param iocs List of IOCs using the COM port.
 	 */
 	public MoxaModelObject(String physport, String comport, List<Ioc> iocs) {
 		this.physport = physport;

--- a/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxasViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxasViewModel.java
@@ -3,10 +3,18 @@ package uk.ac.stfc.isis.ibex.ui.moxas.views;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
 import uk.ac.stfc.isis.ibex.model.ModelObject;
+import uk.ac.stfc.isis.ibex.configserver.configuration.Configuration;
+import uk.ac.stfc.isis.ibex.configserver.configuration.Ioc;
+import uk.ac.stfc.isis.ibex.configserver.configuration.Macro;
+import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
 
 /**
  * The Moxa mappings view model.
@@ -15,7 +23,8 @@ public class MoxasViewModel extends ModelObject {
 
 	private HashMap<String, MoxaList> moxaPorts = new HashMap<String, MoxaList>();
 	private final Configurations control;
-
+	private final UpdatedObservableAdapter<Configuration> currentConfig;
+	
 	/**
 	 * Represents all moxa physical port to COM port mappings.
 	 * 
@@ -23,22 +32,58 @@ public class MoxasViewModel extends ModelObject {
 	 */
 	public HashMap<String, MoxaList> getMoxaPorts() {
 		HashMap<String, MoxaList> map = new HashMap<String, MoxaList>();
+		Collection<Ioc> iocsInConfig = getIocsInConfig();
 
 		HashMap<String, ArrayList<ArrayList<String>>> ret = control.moxaMappings().getValue();
 		if (ret != null) {
 			ret.forEach((key, value) -> {
 				MoxaList list = new MoxaList(key);
 				for (ArrayList<String> item : value) {
-					list.add(new MoxaModelObject(item.get(0), item.get(1)));
+					final String comPort = item.get(1);
+					
+					List<Ioc> iocsUsingComPort = getIocsForCom(iocsInConfig, comPort);
+					
+					list.add(new MoxaModelObject(item.get(0), comPort, iocsUsingComPort));
 				}
 				map.put(key, list);
 			});
 		}
 		return map;
 	};
-
+	
+	private Collection<Ioc> getIocsInConfig() {
+		final Collection<Ioc> configIocs = new ArrayList<>();
+	
+		try {
+	    	Configuration currentConfig = control.server().currentConfig().getValue();
+	        Collection<Configuration> components = control.server().componentDetails().getValue();
+	
+	        Set<String> enabledComponentNames =
+	                currentConfig.getComponents().stream().map(comp -> comp.getName()).collect(Collectors.toSet());
+	
+	        configIocs.addAll(currentConfig.getIocs());
+	        components.stream().forEach(comp -> {
+	            if (enabledComponentNames.contains(comp.getName())) {
+	                configIocs.addAll(comp.getIocs());
+	            }
+	        });
+		} catch (Exception exception) {
+			// error while retrieving iocs in config
+			// could be that the server is not running
+		}
+        return configIocs;
+	}
+	
+	public List<Ioc> getIocsForCom(Collection<Ioc> iocs, String comPort) {
+		return iocs.stream().filter((ioc) -> {
+			Macro portMacro = ioc.getMacros().stream().filter(macro -> macro.getName().equals("PORT")).findFirst().orElse(null);
+			if (portMacro == null) return false;
+			return portMacro.getValue().equals(comPort);
+		}).toList();
+	}
+	
 	private PropertyChangeListener moxasListener;
-
+	
 	/**
 	 * The constructor of the viewmodel.
 	 * 
@@ -47,6 +92,8 @@ public class MoxasViewModel extends ModelObject {
 	 */
 	public MoxasViewModel(Configurations control) {
 		this.control = control;
+		this.currentConfig = new UpdatedObservableAdapter<Configuration>(control.server().currentConfig());
+		
 		moxaPorts = getMoxaPorts();
 
 		moxasListener = new PropertyChangeListener() {
@@ -57,6 +104,9 @@ public class MoxasViewModel extends ModelObject {
 		};
 
 		control.moxaMappings().addPropertyChangeListener(moxasListener);
+    	
+		// Listen to changes in configuration to update table if e.g. an IOC port is changed
+        currentConfig.addPropertyChangeListener(moxasListener);
 	}
 
 	/**
@@ -64,5 +114,6 @@ public class MoxasViewModel extends ModelObject {
 	 */
 	public void removeListeners() {
 		control.moxaMappings().removePropertyChangeListener(moxasListener);
+		currentConfig.removePropertyChangeListener(moxasListener);
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxasViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxasViewModel.java
@@ -5,6 +5,7 @@ import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,6 +25,8 @@ public class MoxasViewModel extends ModelObject {
 	private HashMap<String, MoxaList> moxaPorts = new HashMap<String, MoxaList>();
 	private final Configurations control;
 	private final UpdatedObservableAdapter<Configuration> currentConfig;
+	
+	private HashSet<String> expanded = new HashSet<String>(); // Store keys of expanded MoxaLists to re-expand on refresh
 	
 	/**
 	 * Represents all moxa physical port to COM port mappings.
@@ -67,7 +70,7 @@ public class MoxasViewModel extends ModelObject {
 	                configIocs.addAll(comp.getIocs());
 	            }
 	        });
-		} catch (Exception exception) {
+		} catch (Exception ignore) {
 			// error while retrieving iocs in config
 			// could be that the server is not running
 		}
@@ -109,6 +112,38 @@ public class MoxasViewModel extends ModelObject {
         currentConfig.addPropertyChangeListener(moxasListener);
 	}
 
+	/**
+	 * Add a currently expanded tree item.
+	 * @param key The MoxaList key.
+	 */
+	public void addExpanded(final String key) {
+		expanded.add(key);
+	}
+	
+	/**
+	 * Remove from expanded as the tree item was collapsed in the view.
+	 * @param key The MoxaList key.
+	 */
+	public void removeExpanded(final String key) {
+		expanded.remove(key);
+	}
+	
+	/**
+	 * @return The MoxaLists that were previously expanded.
+	 */
+	public List<MoxaList> getExpanded() {
+		return expanded.stream()
+					   .map(key -> moxaPorts.get(key))
+					   .collect(Collectors.toList());
+	}
+	
+	/**
+	 * Fire the view state restore properties.
+	 */
+	public void refresh() {
+		firePropertyChange("expanded", null, getExpanded());
+	}
+	
 	/**
 	 * Removes listeners on Moxa mappings.
 	 */

--- a/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxasViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxasViewModel.java
@@ -77,10 +77,18 @@ public class MoxasViewModel extends ModelObject {
         return configIocs;
 	}
 	
+	/**
+	 * Get a list of IOCs for a given COM port.
+	 * @param iocs All IOCs in the current config.
+	 * @param comPort a COM port to check against.
+	 * @return A list of IOCs for a given COM port.
+	 */
 	public List<Ioc> getIocsForCom(Collection<Ioc> iocs, String comPort) {
 		return iocs.stream().filter((ioc) -> {
 			Macro portMacro = ioc.getMacros().stream().filter(macro -> macro.getName().equals("PORT")).findFirst().orElse(null);
-			if (portMacro == null) return false;
+			if (portMacro == null) {
+				return false; 
+			}
 			return portMacro.getValue().equals(comPort);
 		}).toList();
 	}


### PR DESCRIPTION
### Description of work

Show IOC connected to COM ports in Moxa table.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/7896

### Acceptance criteria

- [ ] IOC usage is correctly shown on Moxa table.
- [ ] Table updates when IOC config is changed (i.e. you change the PORT macro for an IOC in the configuration)
- [ ] When more than one IOCs are connected to the same port, the text is red to raise attention

### To Review

Make sure the above is true.

To test:
- Make sure your EPICS server is running
- Open `Moxa Ports` perspective
- Change PORT macro of IOCs in `Configuration > Edit COnfiguration > IOC > Select and Edit IOC`

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

