### PR TITLE
Add null check before calling trim() to avoid exception

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.targets/src/uk/ac/stfc/isis/ibex/ui/targets/OpiTargetView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.targets/src/uk/ac/stfc/isis/ibex/ui/targets/OpiTargetView.java
@@ -105,7 +105,7 @@ public abstract class OpiTargetView extends OpiView {
     	macros.put("OPINAME", target.opiName());
     	macros.put("P", pvPrefix);
     	for (Map.Entry<String, String> macro : target.properties().entrySet()) {
-    		if (!macro.getValue().trim().equals("")) {
+    		if (macro.getValue() != null && !macro.getValue().trim().equals("")) {
     			macros.put(macro.getKey(), macro.getValue());
     		}
     	}


### PR DESCRIPTION
### Description of work

Null check to avoid confusing exception if device screen is opened with an undefined macro

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/8020

### Acceptance criteria

The error does not appear anymore and valid macros get loaded as usual.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

