### PR TITLE
Add rule and script to disable tab if not in manager mode and switch …

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/PEARLPC.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/PEARLPC.opi
@@ -1885,13 +1885,32 @@ $(pv_value)</tooltip>
     </macros>
     <minimum_tab_height>10</minimum_tab_height>
     <name>Pressure_Screens_Tabbed_Container</name>
-    <rules/>
+    <rules>
+      <rule name="Disable advanced tab if not in manager mode" prop_id="tab_2_enabled" out_exp="false">
+        <exp bool_exp="pv0==0">
+          <value>false</value>
+        </exp>
+        <pv trig="true">$(P)CS:MANAGER</pv>
+      </rule>
+    </rules>
     <scale_options>
       <width_scalable>true</width_scalable>
       <height_scalable>true</height_scalable>
       <keep_wh_ratio>false</keep_wh_ratio>
     </scale_options>
-    <scripts/>
+    <scripts>
+      <path pathString="EmbeddedPy" checkConnect="true" sfe="false" seoe="false">
+        <scriptName>EmbeddedScript</scriptName>
+        <scriptText><![CDATA[from org.csstudio.opibuilder.scriptUtil import PVUtil
+
+active_tab = widget.getActiveTabIndex()
+manager_mode = PVUtil.getDouble(pvs[0])
+
+if active_tab == 2 and manager_mode == 0:
+	widget.setActiveTabIndex(0)]]></scriptText>
+        <pv trig="true">$(P)CS:MANAGER</pv>
+      </path>
+    </scripts>
     <tab_0_background_color>
       <color name="ISIS_OPI_Background" red="240" green="240" blue="240"/>
     </tab_0_background_color>


### PR DESCRIPTION
…to first tab if manager mode changes while viewing the tab

### Description of work

Advanced tab in the PEARLPC (Pressure Controller) opi is disabled if manager mode is disabled.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/8032

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### To Test

Open the opi as a deviuce screen and toggle manager mode. Check that active tabs switches back to first if manager mode is disabled while viewing the advanced tab.

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

