### PR TITLE
DAE remains grey if the main is not Localhost

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
@@ -385,7 +385,7 @@ public class Instrument implements BundleActivator {
         }
     }
     /**
-     * Checks that the instrument is the local host 
+     * @return Return true or false depending on whether the current instrument is the localhost or not.
      */
     public boolean isLocalInstrument() {
     	InstrumentInfo info = this.currentInstrument();

--- a/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
+++ b/base/uk.ac.stfc.isis.ibex.instrument/src/uk/ac/stfc/isis/ibex/instrument/Instrument.java
@@ -384,4 +384,11 @@ public class Instrument implements BundleActivator {
             LoggerUtils.logErrorWithStackTrace(LOG, "Unable to set initial instrument", e);
         }
     }
+    /**
+     * Checks that the instrument is the local host 
+     */
+    public boolean isLocalInstrument() {
+    	InstrumentInfo info = this.currentInstrument();
+    	return info.hostName().equals("localhost");
+    }
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -291,9 +291,7 @@ public class ExperimentSetup {
             @Override
             public void run() {
                 // access to the Experiment Setup page is disabled if IBEX is not run on the localhost
-            	InstrumentInfo info = Instrument.getInstance().currentInstrument();
-            	final Boolean isLocal = info.hostName().equals("localhost");
-                setChildrenEnabled(isRunning != null && !isRunning && isLocal);
+                setChildrenEnabled(isRunning != null && !isRunning && Instrument.getInstance().isLocalInstrument());
             }
         });
     }
@@ -337,18 +335,22 @@ public class ExperimentSetup {
      *              True if the button should be enabled.
      */
     public void setSendChangeBtnEnableState(boolean enable) {
-        btnSendChanges.setEnabled(enable);
-        if (enable) {
-            btnSendChanges.setBackground(panelViewModel.getColour("changedColour"));
-        } else {
-            btnSendChanges.setBackground(panelViewModel.getColour("unchangedColour"));
+    	btnSendChanges.setEnabled(false);
+    	if ( Instrument.getInstance().isLocalInstrument()) {
+        	btnSendChanges.setEnabled(enable);
+    	
+	        if (enable) {
+	            btnSendChanges.setBackground(panelViewModel.getColour("changedColour"));
+	        } else {
+	            btnSendChanges.setBackground(panelViewModel.getColour("unchangedColour"));
+	        }
         }
     }
     
     /**
      * Adds the listeners used in the panels.
      */
-    private void addChangeListeners() {
+    private void addChangeListeners() { 
         timeChannels.createInitialCachedValues();
         timeChannels.addListeners();
         dataAcquisition.createInitialCachedValues();

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -47,6 +47,8 @@ import org.eclipse.swt.widgets.Display;
 import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 import uk.ac.stfc.isis.ibex.dae.Dae;
 import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
+import uk.ac.stfc.isis.ibex.instrument.Instrument;
+import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.ui.UIUtils;
 import uk.ac.stfc.isis.ibex.ui.dae.DaeUI;
@@ -288,7 +290,10 @@ public class ExperimentSetup {
         DISPLAY.asyncExec(new Runnable() {
             @Override
             public void run() {
-                setChildrenEnabled(isRunning != null && !isRunning);
+                // access to the Experiment Setup page is disabled if IBEX is not run on the localhost
+            	InstrumentInfo info = Instrument.getInstance().currentInstrument();
+            	final Boolean isLocal = info.hostName().equals("localhost");
+                setChildrenEnabled(isRunning != null && !isRunning && isLocal);
             }
         });
     }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -48,7 +48,6 @@ import uk.ac.stfc.isis.ibex.model.UpdatedValue;
 import uk.ac.stfc.isis.ibex.dae.Dae;
 import uk.ac.stfc.isis.ibex.epics.adapters.UpdatedObservableAdapter;
 import uk.ac.stfc.isis.ibex.instrument.Instrument;
-import uk.ac.stfc.isis.ibex.instrument.InstrumentInfo;
 import uk.ac.stfc.isis.ibex.logger.IsisLog;
 import uk.ac.stfc.isis.ibex.ui.UIUtils;
 import uk.ac.stfc.isis.ibex.ui.dae.DaeUI;
@@ -335,15 +334,11 @@ public class ExperimentSetup {
      *              True if the button should be enabled.
      */
     public void setSendChangeBtnEnableState(boolean enable) {
-    	btnSendChanges.setEnabled(false);
-    	if ( Instrument.getInstance().isLocalInstrument()) {
-        	btnSendChanges.setEnabled(enable);
-    	
-	        if (enable) {
-	            btnSendChanges.setBackground(panelViewModel.getColour("changedColour"));
-	        } else {
-	            btnSendChanges.setBackground(panelViewModel.getColour("unchangedColour"));
-	        }
+        btnSendChanges.setEnabled(enable);
+        if (enable) {
+            btnSendChanges.setBackground(panelViewModel.getColour("changedColour"));
+        } else {
+            btnSendChanges.setBackground(panelViewModel.getColour("unchangedColour"));
         }
     }
     

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/PanelViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/PanelViewModel.java
@@ -28,6 +28,7 @@ import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.widgets.Display;
 
 import uk.ac.stfc.isis.ibex.model.ModelObject;
+import uk.ac.stfc.isis.ibex.instrument.Instrument;
 
 
 /**
@@ -373,11 +374,11 @@ public class PanelViewModel extends ModelObject {
         
         if (change) {
             experimentSetupViewModel.setIsChanged(change);
-            experimentSetup.setSendChangeBtnEnableState(change);
+            experimentSetup.setSendChangeBtnEnableState(change && Instrument.getInstance().isLocalInstrument());
         } else {
             if (!isChanged.containsValue(true)) {
                 experimentSetupViewModel.setIsChanged(change);
-                experimentSetup.setSendChangeBtnEnableState(change);
+                experimentSetup.setSendChangeBtnEnableState(change && Instrument.getInstance().isLocalInstrument());
             }
         }
     }


### PR DESCRIPTION
### Description of work

There was an issue where Experimental Control where you could can the variables of other machines remotely.

I have added a clause that prevents the user from changing it unless it is on the localhost machine

### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/8011)

### Acceptance criteria

1. The instrument's Experimental Control panel is greyed out whilst the instrument is in various statuses - RUNNING, STEP UP

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

