### PR TITLE
remove S4 and add Monitor3 on front panel

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/INTER/hgaps.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/INTER/hgaps.opi
@@ -240,48 +240,6 @@
       <x>0</x>
       <y>80</y>
     </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-      </font>
-      <foreground_color>
-        <color red="192" green="192" blue="192" />
-      </foreground_color>
-      <group_name></group_name>
-      <height>25</height>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S4HG</PARAM_PV>
-        <PARAM_NAME>S4HG</PARAM_NAME>
-      </macros>
-      <name>vgap_4</name>
-      <opi_file>../param_move.opi</opi_file>
-      <resize_behaviour>1</resize_behaviour>
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts />
-      <tooltip></tooltip>
-      <visible>true</visible>
-      <widget_type>Linking Container</widget_type>
-      <width>441</width>
-      <wuid>28840e26:169d9726b77:-7997</wuid>
-      <x>0</x>
-      <y>110</y>
-    </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
     <actions hook="false" hook_all="false" />

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/INTER/important_params.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/INTER/important_params.opi
@@ -155,7 +155,7 @@
       <width>441</width>
       <wuid>-76f649f7:171a7364276:-7b59</wuid>
       <x>0</x>
-      <y>40</y>
+      <y>38</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -197,7 +197,7 @@
       <width>441</width>
       <wuid>-76f649f7:171a7364276:-7b57</wuid>
       <x>0</x>
-      <y>65</y>
+      <y>61</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -239,7 +239,7 @@
       <width>441</width>
       <wuid>79a399b8:17329b621e0:-7efd</wuid>
       <x>0</x>
-      <y>90</y>
+      <y>84</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -281,7 +281,7 @@
       <width>441</width>
       <wuid>79a399b8:17329b621e0:-7f11</wuid>
       <x>0</x>
-      <y>115</y>
+      <y>107</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -322,6 +322,48 @@
       <wuid>-76f649f7:171a7364276:-7b55</wuid>
       <x>170</x>
       <y>-2</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <foreground_color>
+        <color red="192" green="192" blue="192" />
+      </foreground_color>
+      <group_name></group_name>
+      <height>25</height>
+      <macros>
+        <include_parent_macros>true</include_parent_macros>
+        <PARAM_NAME>Monitor3InBeam</PARAM_NAME>
+        <PARAM_PV>PARAM:MONITOR3IN</PARAM_PV>
+      </macros>
+      <name>SM2 In Beam</name>
+      <opi_file>../param_inout.opi</opi_file>
+      <resize_behaviour>1</resize_behaviour>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <tooltip></tooltip>
+      <visible>true</visible>
+      <widget_type>Linking Container</widget_type>
+      <width>441</width>
+      <wuid>3ceb1b55:18b61e2bca8:-7ef6</wuid>
+      <x>0</x>
+      <y>130</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/INTER/vgaps.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/reflectometry/INTER/vgaps.opi
@@ -218,48 +218,6 @@
         <color red="192" green="192" blue="192" />
       </foreground_color>
       <group_name></group_name>
-      <height>25</height>
-      <macros>
-        <include_parent_macros>true</include_parent_macros>
-        <PARAM_PV>S4VG</PARAM_PV>
-        <PARAM_NAME>S4VG</PARAM_NAME>
-      </macros>
-      <name>vgap_4</name>
-      <opi_file>../param_move.opi</opi_file>
-      <resize_behaviour>1</resize_behaviour>
-      <rules />
-      <scale_options>
-        <width_scalable>true</width_scalable>
-        <height_scalable>true</height_scalable>
-        <keep_wh_ratio>false</keep_wh_ratio>
-      </scale_options>
-      <scripts />
-      <tooltip></tooltip>
-      <visible>true</visible>
-      <widget_type>Linking Container</widget_type>
-      <width>441</width>
-      <wuid>28840e26:169d9726b77:-7b90</wuid>
-      <x>0</x>
-      <y>115</y>
-    </widget>
-    <widget typeId="org.csstudio.opibuilder.widgets.linkingContainer" version="1.0.0">
-      <actions hook="false" hook_all="false" />
-      <background_color>
-        <color red="240" green="240" blue="240" />
-      </background_color>
-      <border_color>
-        <color red="0" green="128" blue="255" />
-      </border_color>
-      <border_style>0</border_style>
-      <border_width>1</border_width>
-      <enabled>true</enabled>
-      <font>
-        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
-      </font>
-      <foreground_color>
-        <color red="192" green="192" blue="192" />
-      </foreground_color>
-      <group_name></group_name>
       <height>17</height>
       <macros>
         <include_parent_macros>true</include_parent_macros>
@@ -323,6 +281,104 @@
       <wuid>-72a790dc:173e7cce652:-426d</wuid>
       <x>0</x>
       <y>40</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
+      <actions hook="false" hook_all="false" />
+      <auto_size>false</auto_size>
+      <background_color>
+        <color name="ISIS_Title_Background_NEW" red="240" green="240" blue="240" />
+      </background_color>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="1" pixels="false">ISIS_Label_NEW</opifont.name>
+      </font>
+      <foreground_color>
+        <color name="ISIS_Standard_Text" red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <horizontal_alignment>2</horizontal_alignment>
+      <name>S3 Blocker label</name>
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <text>S3 Blocker:</text>
+      <tooltip></tooltip>
+      <transparent>true</transparent>
+      <vertical_alignment>1</vertical_alignment>
+      <visible>true</visible>
+      <widget_type>Label</widget_type>
+      <width>100</width>
+      <wrap_words>false</wrap_words>
+      <wuid>-345d8048:18b28720506:-7d02</wuid>
+      <x>52</x>
+      <y>120</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.MenuButton" version="1.0.0">
+      <actions_from_pv>true</actions_from_pv>
+      <alarm_pulsing>false</alarm_pulsing>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color red="240" green="240" blue="240" />
+      </background_color>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color red="0" green="128" blue="255" />
+      </border_color>
+      <border_style>6</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">Default</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color red="0" green="0" blue="0" />
+      </foreground_color>
+      <height>20</height>
+      <label></label>
+      <name>s3 blocker</name>
+      <pv_name>$(PV_ROOT)PARAM:S3BLOCK:SP</pv_name>
+      <pv_value />
+      <rules>
+        <rule name="Highlight_ParamChanged" prop_id="background_color" out_exp="false">
+          <exp bool_exp="pv0==0">
+            <value>
+              <color name="ISIS_OPI_Background" red="240" green="240" blue="240" />
+            </value>
+          </exp>
+          <exp bool_exp="pv0==1">
+            <value>
+              <color name="ISIS_Yellow" red="255" green="255" blue="0" />
+            </value>
+          </exp>
+          <pv trig="true">$(PV_ROOT)PARAM:S3BLOCK:CHANGED</pv>
+        </rule>
+      </rules>
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <show_down_arrow>true</show_down_arrow>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <transparent>false</transparent>
+      <visible>true</visible>
+      <widget_type>Menu Button</widget_type>
+      <width>100</width>
+      <wuid>-345d8048:18b28720506:-7d01</wuid>
+      <x>177</x>
+      <y>120</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">


### PR DESCRIPTION
### Description of work

- Removed references to obsolete Slit 4 on front panel
- Added Button for S3 beam blocker mode to front panel
- Added Button for Monitor 3 In/Out toggle to front panel

### Before:
![refl-inter-before](https://github.com/ISISComputingGroup/ibex_gui/assets/18398579/863adf9c-392d-4918-9250-d4b8b2c8c764)

### After:
![refl-inter-after](https://github.com/ISISComputingGroup/ibex_gui/assets/18398579/837902d1-9270-4073-b86a-3949b07e6409)

### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/8061

### Acceptance criteria

see ticket

### Unit tests

N/A

### System tests

N/A

### Documentation

N/A

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

