### PR TITLE
Ticket8069_apply_enum_dropdown_fix

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/EnumEditingSupport.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/EnumEditingSupport.java
@@ -52,6 +52,8 @@ public abstract class EnumEditingSupport<T, E extends Enum<E>> extends EditingSu
 		this.enumType = enumType;
 		
 		cellEditor = new ComboBoxViewerCellEditor((Composite) viewer.getControl(), SWT.READ_ONLY);
+		cellEditor.setActivationStyle(ComboBoxViewerCellEditor.DROP_DOWN_ON_MOUSE_ACTIVATION);	
+		
         cellEditor.setLabelProvider(new LabelProvider());
         cellEditor.setContentProvider(new ArrayContentProvider());
 

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/EnumEditingSupport.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/EnumEditingSupport.java
@@ -53,7 +53,6 @@ public abstract class EnumEditingSupport<T, E extends Enum<E>> extends EditingSu
 		
 		cellEditor = new ComboBoxViewerCellEditor((Composite) viewer.getControl(), SWT.READ_ONLY);
 		cellEditor.setActivationStyle(ComboBoxViewerCellEditor.DROP_DOWN_ON_MOUSE_ACTIVATION);	
-		
         cellEditor.setLabelProvider(new LabelProvider());
         cellEditor.setContentProvider(new ArrayContentProvider());
 


### PR DESCRIPTION
### Description of work

Added dropdown fix that makes it easier to open a number of dropdowns in the GUI. Specifically any that use the class `EnumEditingSupport` in `uk.ac.stfc.isis.ibex.ui.widgets` in `ibex_gui`.

### Ticket

[8069](https://github.com/ISISComputingGroup/IBEX/issues/8069)

### Acceptance Criteria
- [x] Fix applied to all relevant and compatible dropdowns. - any inheriting from the class stated above.
- [x] Dropdowns work correctly as before. - tested by committer.
- [x] Squish tests added as appropriate - no squish tests need to be changed regarding this change.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

