### PR TITLE
Ticket5496_script_gen_load_params

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/Constants.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/Constants.java
@@ -27,7 +27,7 @@ import org.eclipse.wb.swt.ResourceManager;
 /**
  * Constants used on the script generator page.
  */
-final class Constants {
+final class Constants {	
 	protected static final String BUTTON_TITLE_SAVE = "Save Script";
 	protected static final String BUTTON_TITLE_SAVE_AS = "Save Script As";
 	protected static final String BUTTON_TITLE_LOAD = "Load Script";
@@ -36,13 +36,21 @@ final class Constants {
 	protected static final String BUTTON_TITLE_INSERT_ROW_BELOW = "Insert Row Below";
 	protected static final String BUTTON_TITLE_DELETE_ROWS = "Clear All Rows";
 	
+	protected static final String CHECKBOX_TITLE_PARAM_TRANSFER = "Parameter Transferring";
+	
 	protected static final String BUTTON_TOOLTIP_ADD_ROW_TO_END = "Add a new row to the end of the table";
 	protected static final String BUTTON_TOOLTIP_INSERT_ROW_BELOW = "Insert a new row below the selected line in the table";
 	protected static final String BUTTON_TOOLTIP_DELETE_ROWS = "Delete all rows in the table";
-
+	protected static final String TOOLTIP_PARAM_TRANSFER = "Enable parameter transferring where possible when changing script definitions";
+	
     protected static final String LOADING_MESSAGE = "Loading...";
     protected static final String RELOADING_MESSAGE = "Reloading...";
     
+    /**
+     * Defines the  default behaviour of parameter transferring.
+     */
+	protected static final boolean PARAM_TRANSFER_DEFAULT = true;
+
 	protected static final Image IMAGE_RUN = ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui.scriptgenerator", "icons/play.png");
 	protected static final Image IMAGE_PAUSE = ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui.scriptgenerator", "icons/pause.png");
 	protected static final Image IMAGE_STOP = ResourceManager.getPluginImage("uk.ac.stfc.isis.ibex.ui.scriptgenerator", "icons/stop.png");

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/Constants.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/Constants.java
@@ -36,18 +36,18 @@ final class Constants {
 	protected static final String BUTTON_TITLE_INSERT_ROW_BELOW = "Insert Row Below";
 	protected static final String BUTTON_TITLE_DELETE_ROWS = "Clear All Rows";
 	
-	protected static final String CHECKBOX_TITLE_PARAM_TRANSFER = "Parameter Transferring";
+	protected static final String CHECKBOX_TITLE_PARAM_TRANSFER = "Transfer Compatible Parameters";
 	
 	protected static final String BUTTON_TOOLTIP_ADD_ROW_TO_END = "Add a new row to the end of the table";
 	protected static final String BUTTON_TOOLTIP_INSERT_ROW_BELOW = "Insert a new row below the selected line in the table";
 	protected static final String BUTTON_TOOLTIP_DELETE_ROWS = "Delete all rows in the table";
-	protected static final String TOOLTIP_PARAM_TRANSFER = "Enable parameter transferring where possible when changing script definitions";
+	protected static final String TOOLTIP_PARAM_TRANSFER = "Enable action parameter transferring where possible when changing script definitions";
 	
     protected static final String LOADING_MESSAGE = "Loading...";
     protected static final String RELOADING_MESSAGE = "Reloading...";
     
     /**
-     * Defines the  default behaviour of parameter transferring.
+     * Defines the default behaviour of action parameter transferring.
      */
 	protected static final boolean PARAM_TRANSFER_DEFAULT = true;
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -332,6 +332,16 @@ public class ScriptGeneratorView {
 		return group;
 	}
 
+	private void makeToggleParameterTransfer(Composite parent) {
+		Composite actionsControlsGrp = makeGrid(parent, 1, true, 10);
+
+		Button checkbox = IBEXButtonFactory.checkbox(actionsControlsGrp, Constants.CHECKBOX_TITLE_PARAM_TRANSFER, Constants.TOOLTIP_PARAM_TRANSFER, evt -> {
+			boolean enabled = ((Button) evt.widget).getSelection();
+			scriptGeneratorViewModel.setParameterTransferEnabled(enabled);
+		});
+		checkbox.setSelection(Constants.PARAM_TRANSFER_DEFAULT);
+	}
+	
 	/**
 	 * Creates a column containing three buttons for table row modifications.
 	 * 
@@ -473,6 +483,7 @@ public class ScriptGeneratorView {
 	 * Draws right side of the panel containing the buttons
 	 */
 	private void makeControlButtons(Composite parent) {
+		makeToggleParameterTransfer(parent);
 		makeScriptSaveLoadButtons(parent);
 		makeTableRowControlButtons(parent);
 		makeDynamicScriptingControlButtons(parent);

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -821,10 +821,18 @@ public class ScriptGeneratorViewModel extends ModelObject {
 		}
 	};
 
+	/**
+	 * @return true if parameter transferring is enabled, false otherwise.
+	 */
 	public boolean getParameterTransferEnabled() {
 		return this.parameterTransferEnabled;
 	}
 	
+	/**
+	 * Enables or disables the parameter transfer functionality.
+	 * 
+	 * @param enabled true or false to enable or disable.
+	 */
 	public void setParameterTransferEnabled(boolean enabled) {
 		this.parameterTransferEnabled = enabled;
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -152,7 +152,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	 */
 	private boolean hasSelection;
 	
-	private boolean parameterTransferEnabled = Constants.PARAM_TRANSFER_DEFAULT
+	private boolean parameterTransferEnabled = Constants.PARAM_TRANSFER_DEFAULT;
 
 	private Clipboard clipboard;
 	private static final String TAB = "\t";

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -822,7 +822,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	 * the new script definition.
 	 * 
 	 * @param previousParameters list of previous parameters
-	 * @param previousActions list of previous actions
+	 * @param previousActions    list of previous actions
 	 * @return a list of parameters that were transferred
 	 */
 	private List<JavaActionParameter> transferPreviousParameters(List<JavaActionParameter> previousParameters,
@@ -1360,12 +1360,12 @@ public class ScriptGeneratorViewModel extends ModelObject {
 		dialog.setOverwrite(true);
 		if (action == SWT.SAVE) {
 			dialog.setText("Save as");
-			dialog.setFilterExtensions(new String[] { "*.sgp" });
+			dialog.setFilterExtensions(new String[] {"*.sgp"});
 
 		} else {
 			dialog.setText("Load");
 			// Keep JSON extension when loading (for older param. files)
-			dialog.setFilterExtensions(new String[] { "*.sgp", "*.json" });
+			dialog.setFilterExtensions(new String[] {"*.sgp", "*.json"});
 		}
 		return Optional.ofNullable(dialog.open());
 	}
@@ -1397,7 +1397,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
 				dialogResponse = 0;
 			} else {
 				emptyModel = false;
-				String[] replaceOrAppend = new String[] { "Append", "Replace" };
+				String[] replaceOrAppend = new String[] {"Append", "Replace"};
 				MessageDialog dialog = new MessageDialog(Constants.DISPLAY.getActiveShell(), "Replace or Append", null,
 						"Would you like to replace the current parameters or append the new parameters?",
 						MessageDialog.QUESTION, replaceOrAppend, -1);
@@ -1473,7 +1473,7 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	 * @param actions copied actions
 	 */
 	public void copyActions(String actions) {
-		clipboard.setContents(new Object[] { actions }, new Transfer[] { TextTransfer.getInstance() });
+		clipboard.setContents(new Object[] {actions}, new Transfer[] {TextTransfer.getInstance()});
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -151,6 +151,8 @@ public class ScriptGeneratorViewModel extends ModelObject {
 	 * The currently selected rows
 	 */
 	private boolean hasSelection;
+	
+	private boolean parameterTransferEnabled = Constants.PARAM_TRANSFER_DEFAULT;
 
 	private Clipboard clipboard;
 	private static final String TAB = "\t";
@@ -806,17 +808,27 @@ public class ScriptGeneratorViewModel extends ModelObject {
 								.setScriptDefinition(selectedScriptDefinitionName));
 			}
 
-			// Transfer previous parameters if possible
-			List<JavaActionParameter> matchingParams = transferPreviousParameters(previousParameters, previousActions);
-			if (!matchingParams.isEmpty() && !previousActions.isEmpty()) {
-				MessageDialog.openInformation(Constants.DISPLAY.getActiveShell(), "Action parameters transferred",
-						"The following action parameters have been transferred from previous configuration:"
-								+ System.lineSeparator()
-								+ String.join(", ", matchingParams.stream().map(p -> p.getName()).toList()));
+			if (parameterTransferEnabled) {
+				// Transfer previous parameters if possible
+				List<JavaActionParameter> matchingParams = transferPreviousParameters(previousParameters, previousActions);
+				if (!matchingParams.isEmpty() && !previousActions.isEmpty()) {
+					MessageDialog.openInformation(Constants.DISPLAY.getActiveShell(), "Action parameters transferred",
+							"The following action parameters have been transferred from previous configuration:"
+									+ System.lineSeparator()
+									+ String.join(", ", matchingParams.stream().map(p -> p.getName()).toList()));
+				}
 			}
 		}
 	};
 
+	public boolean getParameterTransferEnabled() {
+		return this.parameterTransferEnabled;
+	}
+	
+	public void setParameterTransferEnabled(boolean enabled) {
+		this.parameterTransferEnabled = enabled;
+	}
+	
 	/**
 	 * Transfer actions that have parameters that match exactly some parameters of
 	 * the new script definition.

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/IBEXButtonFactory.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/IBEXButtonFactory.java
@@ -38,6 +38,15 @@ public class IBEXButtonFactory {
 	    throw new UnsupportedOperationException();
 	}
 	
+	/**
+	 * Creates a button that appears as a checkbox.
+	 * 
+	 * @param parent a composite control which will be the parent of the new instance (cannot be null)
+	 * @param text the title of the checkbox
+	 * @param tooltip the tooltip of the button (can be null)
+	 * @param onClickListener the event handler for clicks
+	 * @return n new button instance
+	 */
 	public static Button checkbox(Composite parent, String text, String tooltip, Listener onClickListener) {
 		int style = SWT.CHECK;
 		GridData layoutData = new GridData();

--- a/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/IBEXButtonFactory.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.widgets/src/uk/ac/stfc/isis/ibex/ui/widgets/IBEXButtonFactory.java
@@ -38,6 +38,13 @@ public class IBEXButtonFactory {
 	    throw new UnsupportedOperationException();
 	}
 	
+	public static Button checkbox(Composite parent, String text, String tooltip, Listener onClickListener) {
+		int style = SWT.CHECK;
+		GridData layoutData = new GridData();
+		
+		return create(parent, style, text, tooltip, null, onClickListener, layoutData);
+	}
+	
 	/**
 	 * Creates a button that fills all available horizontal space.
 	 * 
@@ -85,7 +92,7 @@ public class IBEXButtonFactory {
      * @return the new button instance
      */
     public static Button create(Composite parent, int style, String text, String tooltip, Image image, Listener onClickListener, Object layoutData) {
-    	Button btn = new Button(parent, SWT.NONE);
+    	Button btn = new Button(parent, style);
         if (text != null) {
         	btn.setText(text);
         }


### PR DESCRIPTION
### Description of work

Script generator now transfers/loads actions and parameters whenever possible on a script definition change. Those that cannot be transferred are initialised to their default value.

I added a checkbox to enable/disable this feature because a lot of our testing was relying on the old behavior and it seemed useful to enable the user to turn this feature on/off. By default it is on.
### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/5496

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

