### PR TITLE
set JAVA_TOOL_OPTIONS env variable to disable CEN header checks

### DIFF
--- a/build/build.bat
+++ b/build/build.bat
@@ -27,6 +27,8 @@ set "PATH=%PATH%;%~dp0maven\bin"
 
 SET "JAVA_HOME=%~dp0jdk"
 
+set "JAVA_TOOL_OPTIONS=-Djdk.util.zip.disableZip64ExtraFieldValidation=true"
+
 if "%PYTHON3%" == "" (
 	set "PYTHON3=C:\Instrument\Apps\Python3\python.exe"
 )

--- a/build/build.bat
+++ b/build/build.bat
@@ -27,6 +27,7 @@ set "PATH=%PATH%;%~dp0maven\bin"
 
 SET "JAVA_HOME=%~dp0jdk"
 
+REM temporarily disable checks as workaround for JDK CEN header issue
 set "JAVA_TOOL_OPTIONS=-Djdk.util.zip.disableZip64ExtraFieldValidation=true"
 
 if "%PYTHON3%" == "" (

--- a/build/build_script_generator.bat
+++ b/build/build_script_generator.bat
@@ -23,6 +23,9 @@ set "PATH=%PATH%;%~dp0maven\bin"
 
 SET "JAVA_HOME=%LOCAL_JRE_LOCATION%"
 
+REM temporarily disable checks as workaround for JDK CEN header issue
+set "JAVA_TOOL_OPTIONS=-Djdk.util.zip.disableZip64ExtraFieldValidation=true"
+
 if "%PYTHON3%" == "" (
 	set "PYTHON3=C:\Instrument\Apps\Python3\python.exe"
 )


### PR DESCRIPTION
Same fix as [CS-Studio](https://github.com/ISISComputingGroup/isis_css_top/commit/98811562d58b989ef096087ec1f269165763d0f4) that was causing build to break. 

