### PR TITLE
Ticket 8067 switch instruments

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/dataacquisition/DaeSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/dataacquisition/DaeSettings.java
@@ -20,6 +20,7 @@
 package uk.ac.stfc.isis.ibex.dae.dataacquisition;
 
 import uk.ac.stfc.isis.ibex.model.ModelObject;
+import org.eclipse.swt.widgets.Display;
 
 /**
  * The settings for connecting to the DAE.
@@ -147,7 +148,9 @@ public class DaeSettings extends ModelObject {
      * @param value The new monitor spectrum number
      */
 	public void setMonitorSpectrum(int value) {
-		firePropertyChange("monitorSpectrum", monitorSpectrum, monitorSpectrum = value);
+		Display.getDefault().asyncExec(() -> {
+			firePropertyChange("monitorSpectrum", monitorSpectrum, monitorSpectrum = value);
+		});
 	}
 
     /**

--- a/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/dataacquisition/DaeSettings.java
+++ b/base/uk.ac.stfc.isis.ibex.dae/src/uk/ac/stfc/isis/ibex/dae/dataacquisition/DaeSettings.java
@@ -171,7 +171,6 @@ public class DaeSettings extends ModelObject {
 	 */
 	public void setMonitorSpectrum(int value) {
 		firePropertyChange(MONITOR_SPECTRUM, monitorSpectrum, monitorSpectrum = value);
-
 	}
 
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -239,7 +239,8 @@ public class ExperimentSetup {
 	}
     
     private void resetChangeLabels() {
-        addChangeListeners();
+    	updateChangeListeners(); ///seems to remove the yellow is it reset the compared values cache, however the changed value remains 
+    	addChangeListeners();
         changeLabelsIfDifferentFromCachedValues();
     }
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetup.java
@@ -239,7 +239,7 @@ public class ExperimentSetup {
 	}
     
     private void resetChangeLabels() {
-    	updateChangeListeners(); ///seems to remove the yellow is it reset the compared values cache, however the changed value remains 
+    	updateChangeListeners(); 
     	addChangeListeners();
         changeLabelsIfDifferentFromCachedValues();
     }

--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetupViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/ExperimentSetupViewModel.java
@@ -30,6 +30,7 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
 import uk.ac.stfc.isis.ibex.ui.dae.experimentsetup.periods.PeriodsViewModel;
 import uk.ac.stfc.isis.ibex.ui.dae.experimentsetup.timechannels.TimeChannelsViewModel;
 
+
 /**
  * The view model that contains the logic for displaying how the experiment is
  * set up on the DAE.
@@ -291,17 +292,17 @@ public class ExperimentSetupViewModel extends ModelObject {
     }
     
     /**
-     * Saves the current maps of cached values and loads the one related to the instrument that is being loaded.
-     * 
-     * @param newInstrument
-     *                              The name of the instrument that is being loaded.
-     */
-    public void switchInstrumentCachedValues(String newInstrument) {
-        setInstrumentCachedValues(currentInstrumentName);
-        cachedValues = getInstrumentCachedValues(newInstrument);
-        radioBtnsCachedValues = getRadioBtnsInstrumentCachedValues(newInstrument);
-        tableCachedValues = getTableInstrumentCachedValues(newInstrument);
-        currentInstrumentName = newInstrument;
-    }
-    
+	 * Saves the current maps of cached values and loads the one related to the
+	 * instrument that is being loaded.
+	 * 
+	 * @param newInstrument The name of the instrument that is being loaded.
+	 */
+	public void switchInstrumentCachedValues(String newInstrument) {
+		setInstrumentCachedValues(currentInstrumentName);
+		cachedValues = getInstrumentCachedValues(newInstrument);
+		radioBtnsCachedValues = getRadioBtnsInstrumentCachedValues(newInstrument);
+		tableCachedValues = getTableInstrumentCachedValues(newInstrument);
+		currentInstrumentName = newInstrument;
+
+	}
 }


### PR DESCRIPTION
### Description of work

The UI and GUI seems to be out of sync, code was added to bring them back inline after switching instruments.

### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/8067)

### Acceptance criteria

See Ticket

### Unit tests

Squish test added - tst_make_change_without_applying_and_switch_instrument

---

#### Code Review

- [x] Is the code of an acceptable quality?
- [x] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [x] Do the changes function as described and is it robust?
- [x] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [x] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

