### PR TITLE
updated_eclipse_releases_target

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.targetplatform/targetplatform.target
+++ b/base/uk.ac.stfc.isis.ibex.targetplatform/targetplatform.target
@@ -40,7 +40,7 @@
 		<unit id="org.eclipse.nebula.visualization.feature.feature.group" version="2.1.0.202208171809"/>
 	</location>
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/releases/2023-03/"/>
+		<repository location="https://download.eclipse.org/releases/2024-03/"/>
 		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.gef.cloudio.sdk.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.gef.cloudio.user.feature.group" version="0.0.0"/>


### PR DESCRIPTION
### Description of work
After investigating it appears that we can move the newer version of eclipse releases, however eclipse updates causes issues with both the maven build, and requires a new version of eclipse which cannot resolve the css gui dependencies.

The gui dependencies fail to resolve due to it being unable to read the jython manifest, the maven build fails at the stage of being unable to find `equinox.p2.iu` and `apache.lucene`, notabley, eclipse 4.27 onwards uses a newer version of `apache.lucerne`, and has also renamed some of the packages compared with older eclipse versions.

This may require updating CS-Studio's dependencies to resolbe/

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/8149

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

