### PR TITLE
Ticket8346 add component display to blocks and iocs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlocksTable.java
@@ -92,6 +92,7 @@ public class BlocksTable extends DataboundTable<EditableBlock> {
 		if (isBlockVisibilityShown) {
 			blockIsVisible();
 		}
+		component();
 	}
 	
 	@Override
@@ -130,6 +131,21 @@ public class BlocksTable extends DataboundTable<EditableBlock> {
 	
 	private void blockIsVisible() {
 		enabled = createColumn("Visible?", 2, visibilityLabelProvider);
+	}
+	
+	private void component() {
+		createColumn("Component", 3, new DecoratedCellLabelProvider<EditableBlock>(
+				observeProperty("component"), 
+				Arrays.asList(rowDecorator)) {
+			@Override
+			public String stringFromRow(EditableBlock row) {
+				String component = row.getComponent();
+				if (component == null || component.isEmpty()) {
+					 component = "Configuration";
+				}
+				return component;
+			}
+		});	
 	}
 	
 	/**

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/EditableIocsTable.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/EditableIocsTable.java
@@ -128,6 +128,7 @@ public class EditableIocsTable extends DataboundTable<EditableIoc> {
 		autostart();
 		restart();
 		remotePvPrefix();
+		component();
 	}
 
     /**
@@ -207,6 +208,24 @@ public class EditableIocsTable extends DataboundTable<EditableIoc> {
      */
 	private void remotePvPrefix() {
         remotePvPrefix = createColumn("Remote prefix", 1, false, remotePvPrefixLabelProvider);
+	}
+	
+	/**
+     * Creates the Component column.
+     */
+	private void component() {
+        createColumn("Component", 1, false, new DecoratedCellLabelProvider<EditableIoc>(
+				observeProperty("component"), 
+				Arrays.asList(rowDecorator)) {
+			@Override
+			public String stringFromRow(EditableIoc row) {
+				String component = row.getComponent();
+				if (component == null || component.isEmpty()) {
+					 component = "Configuration";
+				}
+				return component;
+			}
+		});
 	}
 
     /**


### PR DESCRIPTION
### Description of work
Added a column to the ioc and blocks table when editing/viewing a config that displays which component iocs and blocks added by components were aqdded by.

### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/8346)

### Acceptance criteria
- [ ] It's easy to see which component added a block or ioc to a config.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

