### PR TITLE
Disable Zip64 validation for jython

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
+++ b/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
@@ -22,6 +22,7 @@
 -XX:+CreateCoredumpOnCrash
 -Dlog4j2.formatMsgNoLookups=true
 -agentlib:jdwp=transport=dt_socket,server=y,suspend=n
+-Djdk.util.zip.disableZip64ExtraFieldValidation
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>

--- a/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
+++ b/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
@@ -22,7 +22,7 @@
 -XX:+CreateCoredumpOnCrash
 -Dlog4j2.formatMsgNoLookups=true
 -agentlib:jdwp=transport=dt_socket,server=y,suspend=n
--Djdk.util.zip.disableZip64ExtraFieldValidation
+-Djdk.util.zip.disableZip64ExtraFieldValidation=true
       </vmArgs>
       <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts
       </vmArgsMac>


### PR DESCRIPTION
### Description of work

Disables zip64 field validation for jython.

This is needed to successfully launch IBEX from newer eclipse IDEs, and likely needed in order for future updates to eclipse framework.

This had previously been added to the maven build here https://github.com/ISISComputingGroup/ibex_gui/blob/master/build/build.bat#L31 but it is also needed at runtime from the IDE (and likely if we were to update our eclipse framework version too).

### Ticket

*Link to Ticket*

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

