### PR TITLE
Make blocks font size user-configurable

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client/default.css
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/default.css
@@ -2,3 +2,11 @@
     swt-maximize-visible: false; 
     swt-minimize-visible: false; 
 }
+
+.block {
+	all: inherit;
+	/* Uncomment the following lines to make font size on blocks larger and/or bold */
+	/* Can be edited in a built client under plugins/uk.ac.stfc.isis.ibex.e4.client/default.css */
+	/* font-size: 10; */
+	/* font-weight: bold; */
+}

--- a/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/GroupRow.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.blocks/src/uk/ac/stfc/isis/ibex/ui/blocks/groups/GroupRow.java
@@ -175,6 +175,7 @@ public class GroupRow extends Composite {
     
     private Label boundLabelMaker(Composite composite, int style, Optional<String> text, DisplayBlock block, String propertyName) {
         Label label = new Label(composite, style);
+        label.setData("org.eclipse.e4.ui.css.CssClassName", "block");
 
         text.ifPresent(label::setText);
 


### PR DESCRIPTION
### Description of work

Make font size/style on blocks configurable

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/8414

### Acceptance criteria

Blocks font size is configurable

### Unit tests

n/a, CSS change only

### System tests

n/a, CSS change only

### Documentation

Will add user-facing documentation on how to adjust this once it is merged

Might want an upgrade mechanism to merge in any scientist changes to the client css when a new client gets deployed - or at least a step to flag if it is non-default and reapply on a new client deploy.

It might also be possible to include external `.css` fragments from a location that doesn't get cleared on deploy? Haven't tried this but might be an interesting approach.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

