### PR TITLE
Quick fix to find mock for import

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_generator.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_generator.py
@@ -1,5 +1,9 @@
 import unittest
-from mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
 from script_definition_loader import Generator, ScriptDefinitionWrapper
 from typing import Dict, AnyStr, List
 from hamcrest.core import assert_that, equal_to

--- a/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_git_utils.py
+++ b/base/uk.ac.stfc.isis.ibex.scriptgenerator/python_support/test_git_utils.py
@@ -1,8 +1,10 @@
 import unittest
-from mock import patch
+try:
+    from unittest.mock import patch, Mock, MagicMock
+except ImportError:
+    from mock import patch, Mock, MagicMock
 from git_utils import DefinitionsRepository, DEFAULT_REPO_PATH
 
-from mock import Mock, MagicMock
 from git.exc import GitCommandError
 
 


### PR DESCRIPTION
### Description of work

Hopefully fixes the build issue with IBEX_GUI. The build is failing with the message "ModuleNotFoundError: No module named 'mock'". See the [logs](https://epics-jenkins.isis.rl.ac.uk/view/WallDisplay/job/ibex_gui_pipeline/5460/console)

### Acceptance criteria
The build shouldn't fail with ModuleNotFoundError.

### Unit tests
Run the build.bat in C:\Instrument\Dev\ibex_gui\build and verify there are no failures.


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?

