### PR TITLE
small typo in beam status pvs

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.beamstatus/src/uk/ac/stfc/isis/ibex/beamstatus/TS2Observables.java
+++ b/base/uk.ac.stfc.isis.ibex.beamstatus/src/uk/ac/stfc/isis/ibex/beamstatus/TS2Observables.java
@@ -101,7 +101,7 @@ public class TS2Observables extends EndStationObservables {
 		decoupledModeratorRuntimeLimit = new FacilityPV(MOD_PREFIX + "RTLIM", adaptNumber(
 				obsFactory.getSwitchableObservable(new NumberWithPrecisionChannel(), MOD_PREFIX + "RTLIM")));
 
-		decoupledModeratorAnnealPressure = new FacilityPV(MOD_PREFIX + "RTLIM", adaptEnum(
+		decoupledModeratorAnnealPressure = new FacilityPV(MOD_PREFIX + "ANNPLOW:STAT", adaptEnum(
 				obsFactory.getSwitchableObservable(new EnumChannel<YesNo>(YesNo.class), MOD_PREFIX + "ANNPLOW:STAT")));
 
 		decoupledModeratorUAHBeam = new FacilityPV(MOD_PREFIX + "BEAM",


### PR DESCRIPTION
to test this, before checking out see that right-clicking this PV in the beam status view gives the wrong PV to add to a config or add to log plotter. this should fix it.

### Description of work

*Add your own description here*

### Ticket

*Link to Ticket*

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

