### PR TITLE
Add CAENV895 CRATE macro

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/opi_info.xml
@@ -3090,6 +3090,11 @@
             <description>The CAEN PV prefix (e.g. CAENV895_01)</description>
             <default>CAENV895_01</default>
           </macro>
+          <macro>
+            <name>CRATE</name>
+            <description>The crate to communicate with (default 0)</description>
+            <default>0</default>
+          </macro>
         </macros>
         <categories>
           <category>Monitors</category>


### PR DESCRIPTION
### Description of work

Adds the CRATE macro (new to the CAENV895 OPI) to opi_info.xml

### Acceptance criteria

CAENV895 OPI opens with default crate 0


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

