### PR TITLE
Add RE = get_run_engine() as a default GUI initialization command

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Commands.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scripting/src/uk/ac/stfc/isis/ibex/ui/scripting/Commands.java
@@ -41,7 +41,9 @@ public final class Commands {
             + "_mpl_backend.set_up_plot_default(is_primary=True, should_open_ibex_window_on_show=True, max_figures=3)\n"
             + "from genie_python.genie_startup import * \n" 
             + "import os \n"
-            + "os.environ[\"FROM_IBEX\"] = str(True) \n";
+            + "os.environ[\"FROM_IBEX\"] = str(True) \n"
+            + "from ibex_bluesky_core.run_engine import get_run_engine\n"
+            + "RE = get_run_engine()\n";
 
     private Commands() {
     }


### PR DESCRIPTION
Now that we have added `ibex_bluesky_core` as a `genie_python` requirement, it also makes sense to make the `RE` available by default in the IBEX UI.

https://github.com/ISISComputingGroup/ibex_bluesky_core/issues/15