### PR TITLE
CHIPIR snags - xyz table add stop buttons, filters rename to secondary shutter

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/chipir_filter_set.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/chipir_filter_set.opi
@@ -1021,7 +1021,7 @@ $(pv_value)</tooltip>
     <macros>
       <include_parent_macros>true</include_parent_macros>
     </macros>
-    <name>Shutter</name>
+    <name>Secondary Shutter</name>
     <rules />
     <scale_options>
       <width_scalable>true</width_scalable>
@@ -1034,7 +1034,7 @@ $(pv_value)</tooltip>
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>655</width>
+    <width>775</width>
     <wuid>-13ed6b84:191564d6d49:-7d76</wuid>
     <x>6</x>
     <y>120</y>
@@ -1125,13 +1125,13 @@ $(pv_value)</tooltip>
       </scale_options>
       <scripts />
       <show_scrollbar>false</show_scrollbar>
-      <text>Shutter State:</text>
+      <text>Secondary Shutter State:</text>
       <tooltip></tooltip>
       <transparent>true</transparent>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>108</width>
+      <width>139</width>
       <wrap_words>true</wrap_words>
       <wuid>-13ed6b84:191564d6d49:-7ac9</wuid>
       <x>36</x>
@@ -1200,7 +1200,7 @@ $(pv_value)</tooltip>
       <widget_type>LED</widget_type>
       <width>25</width>
       <wuid>-13ed6b84:191564d6d49:-786b</wuid>
-      <x>234</x>
+      <x>294</x>
       <y>7</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
@@ -1232,16 +1232,16 @@ $(pv_value)</tooltip>
       </scale_options>
       <scripts />
       <show_scrollbar>false</show_scrollbar>
-      <text>Shutter Moving Readback</text>
+      <text>Secondary Shutter Moving Readback</text>
       <tooltip></tooltip>
       <transparent>true</transparent>
       <vertical_alignment>1</vertical_alignment>
       <visible>true</visible>
       <widget_type>Label</widget_type>
-      <width>187</width>
+      <width>247</width>
       <wrap_words>true</wrap_words>
       <wuid>-13ed6b84:191564d6d49:-786a</wuid>
-      <x>234</x>
+      <x>300</x>
       <y>10</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
@@ -1287,7 +1287,7 @@ $(pv_value)</tooltip>
       <widget_type>Action Button</widget_type>
       <width>80</width>
       <wuid>-13ed6b84:191564d6d49:-76ba</wuid>
-      <x>430</x>
+      <x>556</x>
       <y>7</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
@@ -1333,7 +1333,7 @@ $(pv_value)</tooltip>
       <widget_type>Action Button</widget_type>
       <width>80</width>
       <wuid>-13ed6b84:191564d6d49:-76b9</wuid>
-      <x>528</x>
+      <x>654</x>
       <y>7</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
@@ -1395,7 +1395,7 @@ $(pv_value)</tooltip>
       <width>69</width>
       <wrap_words>false</wrap_words>
       <wuid>56101941:1916a18f18a:-7d93</wuid>
-      <x>138</x>
+      <x>174</x>
       <y>10</y>
     </widget>
   </widget>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/chipir_xyz_table.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/chipir_xyz_table.opi
@@ -772,7 +772,21 @@ $(pv_value)</tooltip>
     <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
       <actions hook="false" hook_all="false">
         <action type="WRITE_PV">
-          <pv_name>$(P)CS:MOT:STOP:ALL</pv_name>
+          <pv_name>$(MOTX).STOP</pv_name>
+          <value>1</value>
+          <timeout>10</timeout>
+          <confirm_message></confirm_message>
+          <description></description>
+        </action>
+        <action type="WRITE_PV">
+          <pv_name>$(MOTY).STOP</pv_name>
+          <value>1</value>
+          <timeout>10</timeout>
+          <confirm_message></confirm_message>
+          <description></description>
+        </action>
+        <action type="WRITE_PV">
+          <pv_name>$(MOTZ).STOP</pv_name>
           <value>1</value>
           <timeout>10</timeout>
           <confirm_message></confirm_message>
@@ -802,7 +816,7 @@ $(pv_value)</tooltip>
       <image></image>
       <name>StopButton</name>
       <push_action_index>0</push_action_index>
-      <pv_name>$(P)CS:MOT:STOP:ALL</pv_name>
+      <pv_name>$(MOTZ).STOP</pv_name>
       <pv_value />
       <rules />
       <scale_options>

--- a/base/uk.ac.stfc.isis.ibex.opis/resources/chipir_xyz_table.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/chipir_xyz_table.opi
@@ -135,7 +135,7 @@
     <foreground_color>
       <color name="ISIS_OPI_Foreground" red="192" green="192" blue="192" />
     </foreground_color>
-    <height>157</height>
+    <height>187</height>
     <lock_children>false</lock_children>
     <macros>
       <include_parent_macros>true</include_parent_macros>
@@ -153,7 +153,7 @@
     <transparent>false</transparent>
     <visible>true</visible>
     <widget_type>Grouping Container</widget_type>
-    <width>451</width>
+    <width>517</width>
     <wuid>-4805f29c:1579922e8d6:-7f64</wuid>
     <x>6</x>
     <y>84</y>
@@ -346,7 +346,7 @@ $(pv_value)</tooltip>
       <wrap_words>true</wrap_words>
       <wuid>7fbb376b:1916fb53b7b:-7f8f</wuid>
       <x>6</x>
-      <y>30</y>
+      <y>34</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -398,7 +398,7 @@ $(pv_value)</tooltip>
       <wrap_words>false</wrap_words>
       <wuid>7fbb376b:1916fb53b7b:-7f8e</wuid>
       <x>120</x>
-      <y>30</y>
+      <y>34</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
       <actions hook="false" hook_all="false" />
@@ -455,7 +455,7 @@ $(pv_value)</tooltip>
       <width>90</width>
       <wuid>7fbb376b:1916fb53b7b:-7f8d</wuid>
       <x>216</x>
-      <y>30</y>
+      <y>34</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.Label" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -496,7 +496,7 @@ $(pv_value)</tooltip>
       <wrap_words>true</wrap_words>
       <wuid>7fbb376b:1916fb53b7b:-7f7f</wuid>
       <x>6</x>
-      <y>54</y>
+      <y>67</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextUpdate" version="1.0.0">
       <actions hook="false" hook_all="false" />
@@ -548,7 +548,7 @@ $(pv_value)</tooltip>
       <wrap_words>false</wrap_words>
       <wuid>7fbb376b:1916fb53b7b:-7f7e</wuid>
       <x>120</x>
-      <y>54</y>
+      <y>67</y>
     </widget>
     <widget typeId="org.csstudio.opibuilder.widgets.TextInput" version="2.0.0">
       <actions hook="false" hook_all="false" />
@@ -605,7 +605,223 @@ $(pv_value)</tooltip>
       <width>90</width>
       <wuid>7fbb376b:1916fb53b7b:-7f7d</wuid>
       <x>216</x>
-      <y>54</y>
+      <y>67</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+      <actions hook="false" hook_all="false">
+        <action type="WRITE_PV">
+          <pv_name>$(MOTX).STOP</pv_name>
+          <value>1</value>
+          <timeout>10</timeout>
+          <confirm_message></confirm_message>
+          <description></description>
+        </action>
+      </actions>
+      <alarm_pulsing>false</alarm_pulsing>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Red" red="255" green="0" blue="0" />
+      </background_color>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Gold" red="249" green="218" blue="60" />
+      </foreground_color>
+      <height>27</height>
+      <image></image>
+      <name>StopButton</name>
+      <push_action_index>0</push_action_index>
+      <pv_name>$(MOTX).STOP</pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <style>0</style>
+      <text>STOP</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>113</width>
+      <wuid>-3326528:19320ae9bbc:-7f67</wuid>
+      <x>312</x>
+      <y>2</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+      <actions hook="false" hook_all="false">
+        <action type="WRITE_PV">
+          <pv_name>$(MOTY).STOP</pv_name>
+          <value>1</value>
+          <timeout>10</timeout>
+          <confirm_message></confirm_message>
+          <description></description>
+        </action>
+      </actions>
+      <alarm_pulsing>false</alarm_pulsing>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Red" red="255" green="0" blue="0" />
+      </background_color>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Gold" red="249" green="218" blue="60" />
+      </foreground_color>
+      <height>27</height>
+      <image></image>
+      <name>StopButton</name>
+      <push_action_index>0</push_action_index>
+      <pv_name>$(MOTY).STOP</pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <style>0</style>
+      <text>STOP</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>113</width>
+      <wuid>-3326528:19320ae9bbc:-7f5f</wuid>
+      <x>312</x>
+      <y>30</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+      <actions hook="false" hook_all="false">
+        <action type="WRITE_PV">
+          <pv_name>$(MOTZ).STOP</pv_name>
+          <value>1</value>
+          <timeout>10</timeout>
+          <confirm_message></confirm_message>
+          <description></description>
+        </action>
+      </actions>
+      <alarm_pulsing>false</alarm_pulsing>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Red" red="255" green="0" blue="0" />
+      </background_color>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Gold" red="249" green="218" blue="60" />
+      </foreground_color>
+      <height>27</height>
+      <image></image>
+      <name>StopButton</name>
+      <push_action_index>0</push_action_index>
+      <pv_name>$(MOTZ).STOP</pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <style>0</style>
+      <text>STOP</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>113</width>
+      <wuid>-3326528:19320ae9bbc:-7f57</wuid>
+      <x>312</x>
+      <y>60</y>
+    </widget>
+    <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">
+      <actions hook="false" hook_all="false">
+        <action type="WRITE_PV">
+          <pv_name>$(P)CS:MOT:STOP:ALL</pv_name>
+          <value>1</value>
+          <timeout>10</timeout>
+          <confirm_message></confirm_message>
+          <description></description>
+        </action>
+      </actions>
+      <alarm_pulsing>false</alarm_pulsing>
+      <backcolor_alarm_sensitive>false</backcolor_alarm_sensitive>
+      <background_color>
+        <color name="ISIS_Red" red="255" green="0" blue="0" />
+      </background_color>
+      <border_alarm_sensitive>false</border_alarm_sensitive>
+      <border_color>
+        <color name="ISIS_Border" red="0" green="0" blue="0" />
+      </border_color>
+      <border_style>0</border_style>
+      <border_width>1</border_width>
+      <enabled>true</enabled>
+      <font>
+        <opifont.name fontName="Segoe UI" height="9" style="0" pixels="false">ISIS_Button_NEW</opifont.name>
+      </font>
+      <forecolor_alarm_sensitive>false</forecolor_alarm_sensitive>
+      <foreground_color>
+        <color name="ISIS_Gold" red="249" green="218" blue="60" />
+      </foreground_color>
+      <height>27</height>
+      <image></image>
+      <name>StopButton</name>
+      <push_action_index>0</push_action_index>
+      <pv_name>$(P)CS:MOT:STOP:ALL</pv_name>
+      <pv_value />
+      <rules />
+      <scale_options>
+        <width_scalable>true</width_scalable>
+        <height_scalable>true</height_scalable>
+        <keep_wh_ratio>false</keep_wh_ratio>
+      </scale_options>
+      <scripts />
+      <style>0</style>
+      <text>STOP ALL</text>
+      <toggle_button>false</toggle_button>
+      <tooltip>$(pv_name)
+$(pv_value)</tooltip>
+      <visible>true</visible>
+      <widget_type>Action Button</widget_type>
+      <width>113</width>
+      <wuid>-3326528:19320ae9bbc:-7f4f</wuid>
+      <x>312</x>
+      <y>120</y>
     </widget>
   </widget>
   <widget typeId="org.csstudio.opibuilder.widgets.ActionButton" version="2.0.0">


### PR DESCRIPTION
This fixes a couple of things needed for CHIPIR - 
- renames "shutter" to "secondary shutter" on filters opi 
- adds individual stop buttons and a stop all which puts 1 to all 3 motors `.STOP` fields
once this is merged i'll patch onto CHIPIR. 