### PR TITLE
Fix for array index out of bounds

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DaeExperimentSetupTableViewer.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dae/src/uk/ac/stfc/isis/ibex/ui/dae/experimentsetup/DaeExperimentSetupTableViewer.java
@@ -260,14 +260,15 @@ public class DaeExperimentSetupTableViewer extends TableViewer {
             x = xStart;
             y = yStart;
             ViewerCell cell = getCellFromPoint();
+            int rowIndex = (int) Math.floor((y - headerHeight) / height);
             while (cell != null) {
-                int rowIndex = (int) Math.floor((y - headerHeight) / height);
                 ifCellValueDifferentFromCachedValueThenChangeLabel(cell, rowIndex * table.getColumnCount());
                 for (int i = 0; i < table.getColumnCount() - 1; i++) {
                     cell = findNextCell(cell, true);
                     ifCellValueDifferentFromCachedValueThenChangeLabel(cell, rowIndex * table.getColumnCount());
                 }
                 cell = findNextCell(cell, false);
+                rowIndex++;
             }
         }
     }


### PR DESCRIPTION
### Description of work
This PR fixes [the ticket](https://github.com/ISISComputingGroup/IBEX/issues/8568)

To replicate the issue, go to DAE screen, "Experiment Setup" Tab and click on the "Periods" subtab.

### Acceptance criteria

- [ ] The code should follow the coding standards
- [ ] The array index out of bounds shouldn't come when DAE experiment setup is done
- [ ] Code should build without errors including checkstyle issues.


---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?

### Final Steps


