### PR TITLE
removed final from application.java

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/Application.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/Application.java
@@ -43,7 +43,7 @@ public class Application implements IApplication {
 	 * selected to build with.
 	 */
 	private sealed interface Java17SealedInterface permits Java17SealedInterfaceImpl { }
-	private static non-sealed final class Java17SealedInterfaceImpl implements Java17SealedInterface { }
+	private static non-sealed class Java17SealedInterfaceImpl implements Java17SealedInterface { }
 
 	/* (non-Javadoc)
 	 * @see org.eclipse.equinox.app.IApplication#start(org.eclipse.equinox.app.IApplicationContext)


### PR DESCRIPTION
### Description of work

Recieve the following error: 

'The type Java17SealedInterfaceImpl may have only one modifier out of sealed, non-sealed, and final'

@Tom-Willemsen suggested to remove 'Final' from the line in question, within Application.java

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

