### PR TITLE
Use PVUtil.getStringArray to get a string array

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/HV/Scripts/ChannelUtilities.py
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/HV/Scripts/ChannelUtilities.py
@@ -52,7 +52,7 @@ def get_summary_channels(channel_list_pv, get_string_from_pv=PVUtil.getString, l
     channels = list()
     try:
         if channel_list_pv.getValue().getData().size() > 0:  # default method throws uncaught java exception if empty
-    	    channels = [channel_formatter(chan) for chan in get_string_from_pv(channel_list_pv).split(' ')]
+    	    channels = [channel_formatter(chan) for chan in PVUtil.getStringArray(channel_list_pv)]
     except Exception, e:  # Jython slightly different to standard Python
         log("Unable to get channel list for HVCaen: " + str(e))  # Jython str has no 'format'
     return channels


### PR DESCRIPTION
### Description of work

Previously this used `getString` which is format-limited to printing 100 items in CS-Studio.  See [source code](https://github.com/ISISComputingGroup/cs-studio/blob/776ca26fb97c16816812b3ea27058ce86ab47f28/applications/opibuilder/opibuilder-plugins/org.csstudio.simplepv/src/org/csstudio/simplepv/VTypeHelper.java#L59).

Instead of requesting CS-Studio to human-format an array and then immediately unformatting it, just request the unformatted data in the first place...

### Ticket

[8660](https://github.com/ISISComputingGroup/IBEX/issues/8660)

### Acceptance criteria

Possible to select up to the maximum number of channels in the summary tab of the HVCAEN OPI.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

