### PR TITLE
Do not use local PV prefix for trigger PV

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/RIKEN/Magnet/RIKEN_magnet_PSUs.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/RIKEN/Magnet/RIKEN_magnet_PSUs.opi
@@ -2370,7 +2370,7 @@ $(pv_value)</tooltip>
             <exp bool_exp="pv0==4">
               <value>../solenoid_kickers_fault.png</value>
             </exp>
-            <pv trig="true">TE:NDLT1540:SCHNDR_01:KICKERS:SUMMARY:STAT</pv>
+            <pv trig="true">IN:RIKENFE:SCHNDR_01:KICKERS:SUMMARY:STAT</pv>
           </rule>
         </rules>
         <scale_options>


### PR DESCRIPTION
### Description of work

Corrected PV prefix of trigger PV for Kickers 'icon' on OPI.  Was mistakenly left with local prefix during development.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

