### PR TITLE
add muon and epb1 beam current fields to beam status view

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.beamstatus/src/uk/ac/stfc/isis/ibex/beamstatus/TS1Observables.java
+++ b/base/uk.ac.stfc.isis.ibex.beamstatus/src/uk/ac/stfc/isis/ibex/beamstatus/TS1Observables.java
@@ -45,6 +45,16 @@ public class TS1Observables extends EndStationObservables {
 	 * An updating value giving the status of the muon kicker in TS1.
 	 */
 	public final FacilityPV muonKicker;
+	
+	/**
+	 * An updating value giving the muon beam current.
+	 */
+	public final FacilityPV muonBeamCurr;
+	
+	/**
+	 * An updating value giving the EPB1 beam current.
+	 */
+	public final FacilityPV epb1BeamCurr;
 
 	private static final String MOD_PREFIX = "TG:TS1:MOD:";
 
@@ -65,6 +75,17 @@ public class TS1Observables extends EndStationObservables {
 		ForwardingObservable<OnOff> muonKickerObs = obsFactory
 				.getSwitchableObservable(new EnumChannel<OnOff>(OnOff.class), "AC:MUON:KICKR:STAT");
 		muonKicker = new FacilityPV("AC:MUON:KICKR:STAT", adaptEnum(muonKickerObs));
+		
+		
+		ForwardingObservable<Number> muonBeamCurrObs = obsFactory
+				.getSwitchableObservable(new NumberWithPrecisionChannel(), "AC:MUON:BEAM:CURR");
+		muonBeamCurr = new FacilityPV("AC:MUON:BEAM:CURR", adaptNumber(muonBeamCurrObs));
+		
+		
+		ForwardingObservable<Number> epb1BeamCurrObs = obsFactory
+				.getSwitchableObservable(new NumberWithPrecisionChannel(), "AC:EPB1:BEAM:CURR");
+		epb1BeamCurr = new FacilityPV("AC:EPB1:BEAM:CURR", adaptNumber(epb1BeamCurrObs));
+		
 	}
 
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/BeamInfoView.java
@@ -57,7 +57,7 @@ public class BeamInfoView {
 		xpndtmTargetStation1.setText("Target Station 1");
 		TargetStationOnePanel ts1 = new TargetStationOnePanel(expandBar, SWT.NONE);
 		xpndtmTargetStation1.setControl(ts1);
-		xpndtmTargetStation1.setHeight(220);
+		xpndtmTargetStation1.setHeight(260);
 
 		ExpandItem xpndtmTargetStation2 = new ExpandItem(expandBar, SWT.NONE);
 		xpndtmTargetStation2.setExpanded(true);

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/TargetStationOnePanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/TargetStationOnePanel.java
@@ -41,6 +41,10 @@ public class TargetStationOnePanel extends BeamInfoComposite {
 	private final Label methaneTemperature;
 	private final Label hydrogenTemperature;
 	private final Label muonKicker;
+	private final Label muonBeamCurrent;
+	private final Label epb1BeamCurrent;
+
+
 
 	/**
 	 * The constructor.
@@ -106,6 +110,21 @@ public class TargetStationOnePanel extends BeamInfoComposite {
 
 		muonKicker = new Label(this, SWT.BORDER | SWT.RIGHT);
 		muonKicker.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		
+		
+		Label lblMuonBeamCurrent = new Label(this, SWT.NONE);
+		lblMuonBeamCurrent.setText("Muon Beam Current");
+
+		muonBeamCurrent = new Label(this, SWT.BORDER | SWT.RIGHT);
+		muonBeamCurrent.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		
+		
+		Label lblEpb1BeamCurrent = new Label(this, SWT.NONE);
+		lblEpb1BeamCurrent.setText("EPB1 Beam Current");
+
+		epb1BeamCurrent = new Label(this, SWT.BORDER | SWT.RIGHT);
+		epb1BeamCurrent.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		
 
 		if (BeamStatus.getInstance() != null) {
 			bind(BeamStatus.getInstance().ts1());
@@ -127,6 +146,8 @@ public class TargetStationOnePanel extends BeamInfoComposite {
 		bindAndAddMenu(ts.methaneTemperature, methaneTemperature, this);
 		bindAndAddMenu(ts.hydrogenTemperature, hydrogenTemperature, this);
 		bindAndAddMenu(ts.muonKicker, muonKicker, this);
+		bindAndAddMenu(ts.muonBeamCurr, muonBeamCurrent, this);
+		bindAndAddMenu(ts.epb1BeamCurr, epb1BeamCurrent, this);
 
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/TargetStationOnePanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.beamstatus/src/uk/ac/stfc/isis/ibex/ui/beamstatus/views/TargetStationOnePanel.java
@@ -68,6 +68,18 @@ public class TargetStationOnePanel extends BeamInfoComposite {
 
 		pps = new Label(this, SWT.BORDER | SWT.RIGHT);
 		pps.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		
+		Label lblEpb1BeamCurrent = new Label(this, SWT.NONE);
+		lblEpb1BeamCurrent.setText("EPB1 Beam Current");
+
+		epb1BeamCurrent = new Label(this, SWT.BORDER | SWT.RIGHT);
+		epb1BeamCurrent.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		
+		Label lblMuonBeamCurrent = new Label(this, SWT.NONE);
+		lblMuonBeamCurrent.setText("Muon Beam Current");
+
+		muonBeamCurrent = new Label(this, SWT.BORDER | SWT.RIGHT);
+		muonBeamCurrent.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 
 		Label lblBeamCurrent = new Label(this, SWT.NONE);
 		lblBeamCurrent.setText("TS1 Beam Current");
@@ -110,21 +122,6 @@ public class TargetStationOnePanel extends BeamInfoComposite {
 
 		muonKicker = new Label(this, SWT.BORDER | SWT.RIGHT);
 		muonKicker.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		
-		
-		Label lblMuonBeamCurrent = new Label(this, SWT.NONE);
-		lblMuonBeamCurrent.setText("Muon Beam Current");
-
-		muonBeamCurrent = new Label(this, SWT.BORDER | SWT.RIGHT);
-		muonBeamCurrent.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		
-		
-		Label lblEpb1BeamCurrent = new Label(this, SWT.NONE);
-		lblEpb1BeamCurrent.setText("EPB1 Beam Current");
-
-		epb1BeamCurrent = new Label(this, SWT.BORDER | SWT.RIGHT);
-		epb1BeamCurrent.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		
 
 		if (BeamStatus.getInstance() != null) {
 			bind(BeamStatus.getInstance().ts1());


### PR DESCRIPTION
(as per https://github.com/ISISComputingGroup/WebDashboard/issues/110 and https://github.com/ISISComputingGroup/EPICS-VMS/pull/3)

release notes: https://github.com/ISISComputingGroup/IBEX/pull/8686

to review check out, build the gui (eclipse or maven) and check that the EPB1 and Muon beam current are shown in the beam status view.