### PR TITLE
fix axis errors view on inter beckhoff screen

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.opis/resources/inter_beckhoff_params.opi
+++ b/base/uk.ac.stfc.isis.ibex.opis/resources/inter_beckhoff_params.opi
@@ -18,7 +18,8 @@
   <height>600</height>
   <macros>
     <include_parent_macros>true</include_parent_macros>
-    <PV_ROOT>$(P)TC_01:</PV_ROOT>
+    <TC>TC_01</TC>
+    <PV_ROOT>$(P)$(TC):</PV_ROOT>
   </macros>
   <name></name>
   <rules />


### PR DESCRIPTION
TC_01 was not set - set this. It'll never be TC_02 so just hardcode it as `$(TC)`.

to review, check out master and build a gui, point instrument to INTER and see that the TC macro is not defined when looking at their "inter tank" screen, then check this out and see that its fixed. 
