### PR TITLE
Fix button using both databinding and manual updates

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/NicosModel.java
+++ b/base/uk.ac.stfc.isis.ibex.nicos/src/uk/ac/stfc/isis/ibex/nicos/NicosModel.java
@@ -88,7 +88,9 @@ public class NicosModel extends ModelObject {
     private long lastEntryTime;
     private List<QueuedScript> queuedScripts = new ArrayList<>();
 
-	private NicosErrorState error = NicosErrorState.NO_ERROR;
+    // Start with a 'connection failed' error. This will get cleared when
+    // a successful connection gets made.
+	private NicosErrorState error = NicosErrorState.CONNECTION_FAILED;
 
     /**
      * Default constructor.

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorNicosViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorNicosViewModel.java
@@ -68,7 +68,7 @@ public class ScriptGeneratorNicosViewModel implements PropertyChangeListener {
 		bindPauseButton(pauseButton);
 		bindStopButton(stopButton);
 		formatButtonsBasedOnStatus(dynamicScriptingManager.getDynamicScriptingStatus());
-		nicosModel.addPropertyChangeListener(e -> updateButtonEnablement());
+		nicosModel.addUiThreadPropertyChangeListener(e -> updateButtonEnablement());
 	}
 	
 	/**
@@ -76,7 +76,8 @@ public class ScriptGeneratorNicosViewModel implements PropertyChangeListener {
 	 */
 	@Override
 	public void propertyChange(PropertyChangeEvent evt) {
-		if (evt.getPropertyName().equals(DynamicScriptingProperties.STATE_CHANGE_PROPERTY)) {
+		var propName = evt.getPropertyName();
+		if (propName.equals(DynamicScriptingProperties.STATE_CHANGE_PROPERTY) || propName.equals("error")) {
 			updateButtonEnablement();
 		}
 	}
@@ -125,9 +126,7 @@ public class ScriptGeneratorNicosViewModel implements PropertyChangeListener {
 	}
 	
 	private void updateButtonEnablement() {
-		Display.getDefault().asyncExec(() -> {
-			formatButtonsBasedOnStatus(dynamicScriptingManager.getDynamicScriptingStatus());
-		});
+		formatButtonsBasedOnStatus(dynamicScriptingManager.getDynamicScriptingStatus());
 	}
 	
 	private void formatButtonsBasedOnStatus(DynamicScriptingStatus status) {

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -457,6 +457,7 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 				.image(Constants.IMAGE_RUN)
 				.tooltip("Run")
 				.layoutData(IBEXButton.expandingGrid)
+				.enabled(false)
 				.get();
 		pauseButton = new IBEXButton(dynamicScriptingButtonsGrp, SWT.NONE)
 				.image(Constants.IMAGE_PAUSE)
@@ -715,7 +716,6 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 				}
 			}
 
-			runButton.setEnabled(allActionsValid);
 			errorLabel.setText(allActionsValid ? "" : "\u26A0 There are invalid actions.");
 			errorLabel.setVisible(!allActionsValid);
 			errorLabel.getParent().layout();


### PR DESCRIPTION
### Description of work

Fixes https://github.com/ISISComputingGroup/IBEX/issues/8697

### Ticket

Fixes https://github.com/ISISComputingGroup/IBEX/issues/8697

### Acceptance criteria

- State of "run" button always matches state of underlying NICOS connection

### Unit tests

This is a change in the UI layer - it is not possible to unit test easily. This is best-tested manually.

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

