### PR TITLE
Ticket8445 made useDefault a value to pass to blockserver

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/internal/ImportConverterTest.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver.tests/src/uk/ac/stfc/isis/ibex/configserver/tests/internal/ImportConverterTest.java
@@ -50,7 +50,7 @@ public class ImportConverterTest {
 	private final static boolean IOC_AUTOSTART = true;
 	private final static boolean IOC_RESTART = true;
 	
-	private final static Macro MACRO = new Macro("MACRO", "10", "DESC", "pattern", "1", HasDefault.YES);
+	private final static Macro MACRO = new Macro("MACRO", "10", "DESC", "pattern", "1", HasDefault.YES, false);
 	private final static PVDefaultValue PV = new PVDefaultValue(SOURCE_PREFIX.concat(":PV"), "10");
 	private final static PVSet PV_SET = new PVSet(SOURCE_PREFIX.concat(":PV_SET"), true);
 	private final static Block BLOCK = new Block("BLOCK", SOURCE_PREFIX.concat(":PV"), true, true);

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Macro.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Macro.java
@@ -51,6 +51,10 @@ public class Macro extends ModelObject {
 	 */
 	private String defaultValue;
 	/**
+	 * Whether the default value is being used or not, defaults to true.
+	 */
+	private Boolean useDefault = true;
+	/**
 	 * Whether the macro has a default value or not (or if it is unknown).
 	 */
 	private HasDefault hasDefault;
@@ -94,7 +98,7 @@ public class Macro extends ModelObject {
 	 * @param other exiting Macro to clone
 	 */
 	public Macro(Macro other) {
-		this(other.getName(), other.getValue(), other.getDescription(), other.getPattern(), other.getDefaultValue(), other.getHasDefault());
+		this(other.getName(), other.getValue(), other.getDescription(), other.getPattern(), other.getDefaultValue(), other.getHasDefault(), other.getUseDefault());
 	}
 
 	/**
@@ -107,14 +111,16 @@ public class Macro extends ModelObject {
 	 * @param defaultValue the default value of the macro
 	 * @param hasDefault if the macro has a default, does not, or unknown
 	 */
-	public Macro(String name, String value, String description, String pattern, String defaultValue, HasDefault hasDefault) {
+	public Macro(String name, String value, String description, String pattern, String defaultValue, HasDefault hasDefault, boolean useDefault) {
 		this.name = name;
 		this.value = value;
 		this.description = description;
 		this.pattern = pattern;
 		this.defaultValue = defaultValue;
 		this.hasDefault = hasDefault;
+		this.useDefault = useDefault;
 	}
+	
 
 	/**
      * @return if the macro has a default, does not have a default, or unknown. 
@@ -138,6 +144,22 @@ public class Macro extends ModelObject {
 	public void setValue(String value) {
 		firePropertyChange("value", this.value, this.value = value);
 	}
+	
+	/**
+	 * Set whether the macro is using it's default.
+	 * 
+	 * @param value new useDefault value
+	 */
+	public void setUseDefault(boolean value) {
+		firePropertyChange("useDefault", this.useDefault, this.useDefault = value);
+	}
+	
+	/**
+     * @return if the macro is set to use it's default value. 
+     */
+    public boolean getUseDefault() {
+        return this.useDefault;
+    }
 
 	 /**
      * @return macro value, null indicates the default value is being used
@@ -169,7 +191,7 @@ public class Macro extends ModelObject {
 
 	@Override
 	public String toString() {
-		return name + "=" + value;
+		return name + "=" + value + " useDefault = " +this.getUseDefault();
 	}
 
 	@Override

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Macro.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Macro.java
@@ -110,6 +110,7 @@ public class Macro extends ModelObject {
 	 * @param pattern Regex pattern macro value should follow
 	 * @param defaultValue the default value of the macro
 	 * @param hasDefault if the macro has a default, does not, or unknown
+	 * @param useDefault if the default value is to be used, or over-written
 	 */
 	public Macro(String name, String value, String description, String pattern, String defaultValue, HasDefault hasDefault, boolean useDefault) {
 		this.name = name;
@@ -191,7 +192,7 @@ public class Macro extends ModelObject {
 
 	@Override
 	public String toString() {
-		return name + "=" + value + " useDefault = " +this.getUseDefault();
+		return name + "=" + value;
 	}
 
 	@Override

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/tests/TempIocTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/iocs/tests/TempIocTest.java
@@ -166,7 +166,7 @@ public class TempIocTest {
     @Test
     public void GIVEN_ioc_set_WHEN_changing_macros_THEN_macros_do_not_write_through_to_underlying_ioc_until_saved() {
         var testMacros = List.of(
-            new Macro("name_ignored", "inital_value", "", "", "", HasDefault.NO)
+            new Macro("name_ignored", "inital_value", "", "", "", HasDefault.NO, false)
         );
         
         var underlyingIoc = new EditableIoc(new Ioc(""), "");

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/tests/MacroValueValidatorTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/tests/MacroValueValidatorTest.java
@@ -68,9 +68,9 @@ public class MacroValueValidatorTest {
 		mockNameIsValidListener = mock(PropertyChangeListener.class);
 		showWarningIconListener = mock(PropertyChangeListener.class);
 		
-		macro = new Macro("name", "value", "description", PATTERN, "", null);
+		macro = new Macro("name", "value", "description", PATTERN, "", null, false);
 		macroViewModel = new MacroViewModel(macro);
-		macroWithInvalidPattern = new Macro("name", "value", "description", INVALID_PATTERN, "", null);
+		macroWithInvalidPattern = new Macro("name", "value", "description", INVALID_PATTERN, "", null, false);
 		macroWithInvalidPatternViewModel = new MacroViewModel(macroWithInvalidPattern);
 	}
 	

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/tests/MacroViewModelTest.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver.tests/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/tests/MacroViewModelTest.java
@@ -31,7 +31,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_default_WHEN_get_default_display_THEN_default_returned() {
-        Macro m = new Macro("name", "value", "description", "pattern", "defaultValue", HasDefault.YES);
+        Macro m = new Macro("name", "value", "description", "pattern", "defaultValue", HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         String defaultText = macroViewModel.getDisplayDefault();
@@ -41,7 +41,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_empty_string_default_WHEN_get_default_display_THEN_empty_string_message_returned() {
-        Macro m = new Macro("name", "value", "description", "pattern", "", HasDefault.YES);
+        Macro m = new Macro("name", "value", "description", "pattern", "", HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         String defaultText = macroViewModel.getDisplayDefault();
@@ -51,7 +51,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_no_default_WHEN_get_default_display_THEN_no_default_message_returned() {
-        Macro m = new Macro("name", "value", "description", "pattern", null, HasDefault.NO);
+        Macro m = new Macro("name", "value", "description", "pattern", null, HasDefault.NO, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         String defaultText = macroViewModel.getDisplayDefault();
@@ -61,7 +61,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_unknown_default_WHEN_get_default_display_THEN_unknown_default_message_returned() {
-        Macro m = new Macro("name", "value", "description", "pattern", null, HasDefault.UNKNOWN);
+        Macro m = new Macro("name", "value", "description", "pattern", null, HasDefault.UNKNOWN, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         String defaultText = macroViewModel.getDisplayDefault();
@@ -71,7 +71,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_value_of_null_WHEN_view_model_created_THEN_display_value_is_default() {
-    	Macro m = new Macro("name", null, "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", null, "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         String defaultText = macroViewModel.getDisplayValue();
@@ -81,7 +81,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_value_of_null_WHEN_view_model_created_THEN_use_default_is_true() {
-    	Macro m = new Macro("name", null, "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", null, "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         boolean useDefault = macroViewModel.getUseDefault();
@@ -91,7 +91,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_value_of_empty_string_WHEN_view_model_created_THEN_use_default_is_false() {
-    	Macro m = new Macro("name", "", "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", "", "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         boolean useDefault = macroViewModel.getUseDefault();
@@ -101,7 +101,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_value_WHEN_view_model_created_THEN_use_default_is_false() {
-    	Macro m = new Macro("name", "A_VALUE", "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", "A_VALUE", "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         boolean useDefault = macroViewModel.getUseDefault();
@@ -112,7 +112,7 @@ public class MacroViewModelTest {
     @Test
     public void test_GIVEN_macro_with_value_WHEN_view_model_created_THEN_display_value_is_value() {
     	String expectedMacroValue = "A_VALUE";
-    	Macro m = new Macro("name", expectedMacroValue, "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", expectedMacroValue, "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         String macroValue = macroViewModel.getDisplayValue();
@@ -122,7 +122,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_value_WHEN_use_default_set_THEN_macro_value_set_to_null() {
-    	Macro m = new Macro("name", "value", "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", "value", "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         macroViewModel.setUseDefault(true);
@@ -133,7 +133,7 @@ public class MacroViewModelTest {
     @Test
     public void test_GIVEN_macro_with_value_WHEN_use_default_set_false_THEN_macro_value_unchanged() {
     	String expectedMacroValue = "A_VALUE";
-    	Macro m = new Macro("name", expectedMacroValue, "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", expectedMacroValue, "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         macroViewModel.setUseDefault(false);
@@ -143,7 +143,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_value_of_null_WHEN_use_default_set_false_THEN_macro_value_set_to_empty_string() {
-    	Macro m = new Macro("name", null, "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", null, "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         macroViewModel.setUseDefault(false);
@@ -153,7 +153,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_value_of_null_WHEN_use_default_set_true_THEN_macro_value_still_null() {
-    	Macro m = new Macro("name", null, "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", null, "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         macroViewModel.setUseDefault(true);
@@ -163,7 +163,7 @@ public class MacroViewModelTest {
     
     @Test
     public void test_GIVEN_macro_with_value_of_null_WHEN_value_text_box_entered_THEN_macro_value_set_to_empty_string_and_use_default_enabled() {
-    	Macro m = new Macro("name", "value", "description", "pattern", null, HasDefault.YES);
+    	Macro m = new Macro("name", "value", "description", "pattern", null, HasDefault.YES, true);
         MacroViewModel macroViewModel = new MacroViewModel(m);
         
         macroViewModel.setUseDefault(true);

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroPanel.java
@@ -133,6 +133,7 @@ public class MacroPanel extends Composite implements IIocDependentPanel {
 			for (final Macro setMacro : setMacros) {
 				if (setMacro.getName().equals(availableMacro.getName())) {
 					displayMacro.setValue(setMacro.getValue());
+					displayMacro.setUseDefault(setMacro.getUseDefault());
 				}
 			}
 
@@ -152,6 +153,7 @@ public class MacroPanel extends Composite implements IIocDependentPanel {
 			    if (existingMacro.isPresent()) {
 			        if (displayMacro.getValue() != null) {
 			            existingMacro.get().setValue(displayMacro.getValue());
+			            existingMacro.get().setUseDefault(displayMacro.getUseDefault());
 			        } else {
 			            setMacros.remove(existingMacro.get());
 			        }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/macros/MacroViewModel.java
@@ -10,10 +10,6 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
 public class MacroViewModel extends ModelObject {
 	private final Macro macro;
 
-	/**
-	 * Whether the default value should be used or not.
-	 */
-	private boolean useDefault;
 
 	/**
 	 * Constructor. Sets the use default based on provided macro.
@@ -67,7 +63,7 @@ public class MacroViewModel extends ModelObject {
 	 * @return whether the default value should be used or not
 	 */
 	public boolean getUseDefault() {
-		return useDefault;
+		return macro.getUseDefault();
 	}
 
 	/**
@@ -81,7 +77,7 @@ public class MacroViewModel extends ModelObject {
 		if (useDefault) {
 			macro.setValue("");
 		}
-		firePropertyChange("useDefault", this.useDefault, this.useDefault = useDefault);
+		macro.setUseDefault(useDefault);
 	}
 
 	/**


### PR DESCRIPTION
### Description of work
Made it so `useDefault` from the ioc macro dialogue is passed to the blockserver.

### Ticket

[*Link to Ticket*](https://github.com/ISISComputingGroup/IBEX/issues/8445)

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

### Unit tests

*Give an overview of unit tests you have added or modified, if applicable. The aim is provide information to help the reviewer*

### System tests

*Mention any automated tests or manual tests that you have added or modified, if applicable. The aim is provide information to help the reviewer*

### Documentation
*Highlight and provide a link to any additions or changes to the documentation, if applicable. The aim is provide information to help the reviewer*

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

