### PR TITLE
Reorganised Script Generator buttons to fix scaling issue

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
+++ b/base/uk.ac.stfc.isis.ibex.e4.client.product/ibex.product
@@ -62,6 +62,7 @@
       <plugin id="org.eclipse.osgi" autoStart="true" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.activemq" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.alarm" autoStart="false" startLevel="0" />
+      <plugin id="uk.ac.stfc.isis.ibex.alerts" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.banner" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.beamstatus" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.configserver" autoStart="false" startLevel="0" />
@@ -93,6 +94,7 @@
       <plugin id="uk.ac.stfc.isis.ibex.targets" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.ui" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.ui.alarm" autoStart="false" startLevel="0" />
+      <plugin id="uk.ac.stfc.isis.ibex.ui.alerts" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.ui.banner" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.ui.beamstatus" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.ui.blocks" autoStart="false" startLevel="0" />
@@ -119,8 +121,6 @@
       <plugin id="uk.ac.stfc.isis.ibex.ui.weblinks" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.ui.widgets" autoStart="false" startLevel="0" />
       <plugin id="uk.ac.stfc.isis.ibex.validators" autoStart="false" startLevel="0" />
-      <plugin id="uk.ac.stfc.isis.ibex.alerts" autoStart="false" startLevel="0" />
-      <plugin id="uk.ac.stfc.isis.ibex.ui.alerts" autoStart="false" startLevel="0" />
       <property name="osgi.splashPath" value="platform:/base/plugins/uk.ac.stfc.isis.ibex.e4.product" />
    </configurations>
 

--- a/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
+++ b/base/uk.ac.stfc.isis.ibex.e4.client/Application.e4xmi
@@ -535,7 +535,7 @@
       </children>
       <children xsi:type="basic:PartSashContainer" xmi:id="_iXy6F5IBEe-V38_cTZ3ImQ" elementId="uk.ac.stfc.isis.ibex.e4.client.partsashcontainer.14" containerData="70">
         <children xsi:type="basic:PartStack" xmi:id="_iXy6GJIBEe-V38_cTZ3ImQ" elementId="uk.ac.stfc.isis.ibex.e4.client.partstack.13" containerData="60">
-          <children xsi:type="basic:Part" xmi:id="_iXy6GZIBEe-V38_cTZ3ImQ" elementId="uk.ac.stfc.isis.ibex.e4.client.part.scriptcomposer" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.scriptgenerator/uk.ac.stfc.isis.ibex.ui.scriptgenerator.views.ScriptGeneratorView" label="Script Composer"/>
+          <children xsi:type="basic:Part" xmi:id="_iXy6GZIBEe-V38_cTZ3ImQ" elementId="uk.ac.stfc.isis.ibex.e4.client.part.scriptcomposer" containerData="" contributionURI="bundleclass://uk.ac.stfc.isis.ibex.ui.scriptgenerator/uk.ac.stfc.isis.ibex.ui.scriptgenerator.views.ScriptGeneratorView" label="Script Composer"/>
         </children>
       </children>
     </children>

--- a/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
+++ b/base/uk.ac.stfc.isis.ibex.e4.product/src/uk/ac/stfc/isis/ibex/e4/product/ApplicationWorkbenchWindowAdvisor.java
@@ -55,8 +55,8 @@ import uk.ac.stfc.isis.ibex.preferences.PreferenceSupplier;
  */
 public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
 
-    private static final int MIN_WINDOW_HEIGHT = 800;
-    private static final int MIN_WINDOW_WIDTH = 1100;
+    private static final int MIN_WINDOW_HEIGHT = 800; 
+    private static final int MIN_WINDOW_WIDTH = 1100; 
     
 	private static final String DIALOG_BOX_TITLE = "IBEX is already running.";
 	private static final String DIALOG_QUESTION = "It appears that IBEX client is already running. "

--- a/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.dashboard/src/uk/ac/stfc/isis/ibex/ui/dashboard/views/DashboardView.java
@@ -49,8 +49,8 @@ public class DashboardView {
 	 */
 	public static final String ID = "uk.ac.stfc.isis.ibex.ui.dashboard.views.DashboardView"; //$NON-NLS-1$
 			
-    private static final int FIXED_WIDTH = 580;
-    private static final int FIXED_HEIGHT = 225;
+    private static final int FIXED_WIDTH = 580; // 580
+    private static final int FIXED_HEIGHT = 225; // 225
 	
 	private final Font bannerTitleFont = SWTResourceManager.getFont("Arial", 24, SWT.BOLD);
 	private final Font bannerFont = SWTResourceManager.getFont("Arial", 14, SWT.NORMAL);

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/QueueScriptPreviewDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/dialogs/QueueScriptPreviewDialog.java
@@ -26,7 +26,7 @@ public class QueueScriptPreviewDialog extends TitleAreaDialog {
 	 */
 	public QueueScriptPreviewDialog(Shell parentShell, String generatedScript) {
 		super(parentShell);
-		setShellStyle(getShellStyle() | SWT.RESIZE | SWT.MAX);
+		setShellStyle(getShellStyle() | SWT.RESIZE | SWT.MAX); 
 		this.generatedScript = generatedScript;
 		this.parentShell = parentShell;
 	}

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/Constants.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/Constants.java
@@ -28,13 +28,13 @@ import org.eclipse.wb.swt.ResourceManager;
  * Constants used on the script generator page.
  */
 final class Constants {
-	protected static final String BUTTON_TITLE_SAVE = "Save Script";
-	protected static final String BUTTON_TITLE_SAVE_AS = "Save Script As";
-	protected static final String BUTTON_TITLE_LOAD = "Load Script";
+	protected static final String BUTTON_TITLE_SAVE = "Save"; // Save Script
+	protected static final String BUTTON_TITLE_SAVE_AS = "Save As"; // Save Script As
+	protected static final String BUTTON_TITLE_LOAD = "Load"; // Load Script
 
-	protected static final String BUTTON_TITLE_ADD_ROW_TO_END = "Add Row to End";
-	protected static final String BUTTON_TITLE_INSERT_ROW_BELOW = "Insert Row Below";
-	protected static final String BUTTON_TITLE_DELETE_ROWS = "Clear All Rows";
+	protected static final String BUTTON_TITLE_ADD_ROW_TO_END = "Add to End"; // Add Row to End
+	protected static final String BUTTON_TITLE_INSERT_ROW_BELOW = "Insert Below"; // Insert Row Below
+	protected static final String BUTTON_TITLE_DELETE_ROWS = "Clear All"; // Clear All Rows
 
 	protected static final String CHECKBOX_TITLE_PARAM_TRANSFER = "Transfer Compatible Parameters";
 	protected static final String CHECKBOX_TITLE_INVALID_PAUSE = "Invalid Actions are Paused on";

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorView.java
@@ -51,6 +51,7 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.widgets.Group;
 
 import uk.ac.stfc.isis.ibex.preferences.PreferenceSupplier;
 import uk.ac.stfc.isis.ibex.scriptgenerator.ScriptGeneratorProperties;
@@ -100,7 +101,7 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 	 * Denotes whether script definitions have been loaded once.
 	 */
 	private boolean scriptDefinitionsLoadedOnce = false;
-
+	
 	private ActionsViewTable table;
 	private Button btnMoveActionUp;
 	private Button btnMoveActionDown;
@@ -135,7 +136,7 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 		scriptGeneratorViewModel.setScriptGeneratorViewModelDelegate(this);
 
 		GridData gdQueueContainer = new GridData(SWT.FILL, SWT.FILL, true, false, 1, 1);
-		gdQueueContainer.heightHint = 300;
+		gdQueueContainer.heightHint = 300; 
 		parent.setLayoutData(gdQueueContainer);
 		parent.setLayout(new GridLayout());
 
@@ -269,16 +270,16 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 
 				globalParamComposite = new Composite(mainParent, SWT.NONE);
 				globalParamComposite.setLayout(new GridLayout(24, false));
-				globalParamComposite.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false));
-
+				globalParamComposite.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false)); 
+				
 				// Composite to split the middle into bigger left and smaller right section
 				Composite middleComposite = makeGrid(mainParent, 2, false, 0);
-				middleComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+				middleComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true)); 
 
 				makeTableAndUpDownButtons(middleComposite);
 
 				// The composite to contain the buttons on the right to the table
-				Composite buttonContainerComposite = makeGrid(middleComposite, 1, false, 0);
+				Composite buttonContainerComposite = makeGrid(middleComposite, 1, false, 0); 
 				buttonContainerComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, true));
 
 				makeControlButtons(buttonContainerComposite);
@@ -286,15 +287,19 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 				// Composite for the row containing the parameter file location and total
 				// estimated run time
 				Composite scriptInfoGrp = new Composite(mainParent, SWT.NONE);
-				scriptInfoGrp.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false, 1, 1));
-				GridLayout scriptInfoLayout = new GridLayout(3, true);
-				scriptInfoLayout.marginRight = 40;
+				scriptInfoGrp.setLayoutData(new GridData(SWT.FILL, SWT.NONE, true, false, 1, 1)); 
+				GridLayout scriptInfoLayout = new GridLayout(3, true); 
+				scriptInfoLayout.marginRight = 40; 
 				scriptInfoGrp.setLayout(scriptInfoLayout);
+				
+				Composite bottomComposite = makeGrid(mainParent, 2, false, 0);
+				bottomComposite.setLayoutData(new GridData(SWT.END, SWT.FILL, false, true));
 
 				// Label for Location of Saved Parameters File
 				parametersFileText = new Label(scriptInfoGrp, SWT.LEFT);
 				parametersFileText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 				parametersFileText.setText("Current Script: <new file>");
+				
 
 				scriptGenerationTimeText = new Label(scriptInfoGrp, SWT.LEFT);
 				scriptGenerationTimeText.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
@@ -317,7 +322,7 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 			if (!scriptDefinitionLoadErrors.isEmpty()) {
 				setUpScriptDefinitionLoadErrorTable(mainParent, scriptDefinitionLoadErrors);
 			}
-
+			
 			mainParent.layout();
 		});
 	}
@@ -330,7 +335,7 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 	 * @param columns number of columns
 	 * @param equal   whether or not to make the columns equal width
 	 * @param margin  margin around all four sides
-	 * @return the new COmposite instance
+	 * @return the new Composite instance
 	 */
 	private Composite makeGrid(Composite parent, int columns, boolean equal, int margin) {
 		Composite group = new Composite(parent, SWT.NONE);
@@ -344,7 +349,8 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 
 	private void makeToggleParameterTransfer(Composite parent) {
 		Composite actionsControlsGrp = makeGrid(parent, 1, true, 10);
-
+		actionsControlsGrp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+		
 		new IBEXButton(actionsControlsGrp, SWT.CHECK, event -> {
 			boolean enabled = ((Button) event.widget).getSelection();
 			scriptGeneratorViewModel.setParameterTransferEnabled(enabled);
@@ -356,7 +362,8 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 	
 	private void makeToggleInvalidPauseSkip(Composite parent) {
 		Composite actionsControlsGrp = makeGrid(parent, 1, true, 10);
-
+		actionsControlsGrp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+		
 		// Pause
 		new IBEXButton(actionsControlsGrp, SWT.RADIO, event -> {
 			ScriptGeneratorSettingsSingleton.getInstance().setSkipEnabled(false); //sets skipEnabled to false, causing Pause on invalid actions during run of script
@@ -375,16 +382,20 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 	}
 
 	/**
-	 * Creates a column containing three buttons for table row modifications.
+	 * Creates a row containing three buttons for table row modifications.
 	 * 
 	 * @param parent the containing Composite
 	 */
 	private void makeTableRowControlButtons(Composite parent) {
-		// Composite for laying out new/delete/duplicate action buttons
-		Composite actionsControlsGrp = makeGrid(parent, 1, true, 10);
-
+		// Group for laying out new/delete/duplicate action buttons
+		Group actionsControlsGrp = new Group(parent, SWT.NONE); 
+		actionsControlsGrp.setText("Row Operations");
+		actionsControlsGrp.setLayout(new GridLayout(3, false));
+		actionsControlsGrp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+		
 		// Make buttons for insert new/delete/duplicate actions
-		btnAddAction = new IBEXButton(actionsControlsGrp, SWT.NONE, event -> {
+		
+		btnAddAction = new IBEXButton(actionsControlsGrp, SWT.NONE, event -> { 
 			scriptGeneratorViewModel.addEmptyAction();
 		})
 				.text(Constants.BUTTON_TITLE_ADD_ROW_TO_END)
@@ -401,20 +412,24 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 		new IBEXButton(actionsControlsGrp, SWT.NONE, event -> {
 			scriptGeneratorViewModel.clearAction();
 		})
-		.text(Constants.BUTTON_TITLE_DELETE_ROWS)
-		.tooltip(Constants.BUTTON_TOOLTIP_DELETE_ROWS)
-		.layoutData(IBEXButton.expandingGrid);
+				.text(Constants.BUTTON_TITLE_DELETE_ROWS)
+				.tooltip(Constants.BUTTON_TOOLTIP_DELETE_ROWS)
+				.layoutData(IBEXButton.expandingGrid);
 	}
-
+	
+	
 	/**
-	 * Creates a column containing three buttons for save, save as, and load script.
+	 * Creates a row containing three buttons for save, save as, and load script.
 	 * 
 	 * @param parent the containing Composite
 	 */
 	private void makeScriptSaveLoadButtons(Composite parent) {
-		// Composite for generate buttons
-		Composite generateButtonsGrp = makeGrid(parent, 1, true, 10);
-
+		// Group for script operation buttons
+		Group generateButtonsGrp = new Group(parent, SWT.NONE); 
+		generateButtonsGrp.setText("Script Operations");
+        generateButtonsGrp.setLayout(new GridLayout(3, false));
+		generateButtonsGrp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+		
 		// Buttons to generate a script
 		generateScriptButton = new IBEXButton(generateButtonsGrp, SWT.NONE, event -> {
 			scriptGeneratorViewModel.generateScriptToCurrentFilepath();
@@ -446,35 +461,37 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 	 */
 	private void makeDynamicScriptingControlButtons(Composite parent) {
 		errorLabel = new Label(parent, SWT.NONE);
-		errorLabel.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, true));
-		errorLabel.setForeground(new Color(255, 0, 0));
-
-		// Composite for generate buttons
-		Composite dynamicScriptingButtonsGrp = makeGrid(parent, 3, true, 10);
-
+		errorLabel.setLayoutData(new GridData(SWT.CENTER, SWT.FILL, true, true)); 
+		errorLabel.setForeground(new Color(255, 0, 0)); 
+		// Group for dynamic scripting buttons
+		Group dynamicScriptingButtonsGrp = new Group(parent, SWT.NONE); 
+		dynamicScriptingButtonsGrp.setText("Run Operations");
+		dynamicScriptingButtonsGrp.setLayout(new GridLayout(3, false));
+		dynamicScriptingButtonsGrp.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+		
 		// Button to run/pause/stop script in nicos
 		runButton = new IBEXButton(dynamicScriptingButtonsGrp, SWT.NONE)
 				.image(Constants.IMAGE_RUN)
 				.tooltip("Run")
-				.layoutData(IBEXButton.expandingGrid)
+				.layoutData(IBEXButton.expandingGrid) 
 				.get();
 		pauseButton = new IBEXButton(dynamicScriptingButtonsGrp, SWT.NONE)
 				.image(Constants.IMAGE_PAUSE)
 				.tooltip("Pause")
-				.layoutData(IBEXButton.expandingGrid)
+				.layoutData(IBEXButton.expandingGrid) 
 				.get();
 		stopButton = new IBEXButton(dynamicScriptingButtonsGrp, SWT.NONE)
 				.image(Constants.IMAGE_STOP)
 				.tooltip("Stop")
-				.layoutData(IBEXButton.expandingGrid)
+				.layoutData(IBEXButton.expandingGrid) 
 				.get();
 		nicosViewModel.bindControls(runButton, pauseButton, stopButton);
 	}
 
 	private void makeRunAndFinishTime(Composite parent) {
 		// Composite for the row containing total estimated run time
-		Composite scriptTimeGrp = makeGrid(parent, 1, true, 10);
-		scriptTimeGrp.setLayoutData(new GridData(SWT.END, SWT.NONE, true, false));
+		Composite scriptTimeGrp = makeGrid(parent, 1, true, 10); 
+		scriptTimeGrp.setLayoutData(new GridData(SWT.END, SWT.NONE, true, false)); 
 
 		// Label for the total estimated run time
 		estimateText = new Label(scriptTimeGrp, SWT.TOP);
@@ -504,8 +521,8 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 	private void makeTableAndUpDownButtons(Composite parent) {
 		// The composite to contain the UI table
 		Composite tableContainerComposite = new Composite(parent, SWT.NONE);
-		tableContainerComposite.setLayout(new GridLayout(2, false));
-		tableContainerComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+		tableContainerComposite.setLayout(new GridLayout(2, false)); 
+		tableContainerComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1)); 
 
 		// The UI table
 		table = new ActionsViewTable(tableContainerComposite, SWT.NONE, SWT.MULTI | SWT.V_SCROLL | SWT.FULL_SELECTION,
@@ -516,7 +533,7 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 		// Composite for move action up/down buttons
 		Composite moveComposite = new Composite(tableContainerComposite, SWT.NONE);
 		moveComposite.setLayout(new GridLayout());
-		moveComposite.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false));
+		moveComposite.setLayoutData(new GridData(SWT.CENTER, SWT.CENTER, false, false)); 
 
 		// Make buttons to move an action up and down the list
 		btnMoveActionUp = new IBEXButton(moveComposite, SWT.NONE, event -> {
@@ -584,9 +601,10 @@ public class ScriptGeneratorView implements ScriptGeneratorViewModelDelegate {
 	private void setUpScriptDefinitionLoadErrorTable(Composite parent, Map<String, String> scriptDefinitionLoadErrors) {
 		if (!preferences.hideScriptGenScriptDefinitionErrorTable()) {
 			// A composite to contain the script definition load errors
-			Composite scriptDefinitionErrorComposite = makeGrid(parent, 1, false, 5);
-			scriptDefinitionErrorComposite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false));
-
+			Composite scriptDefinitionErrorComposite = makeGrid(parent, 1, false, 5); 
+			scriptDefinitionErrorComposite.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, false, false)); 
+			
+			
 			Label errorLabel = new Label(scriptDefinitionErrorComposite, SWT.NONE);
 			errorLabel.setText("Errors:");
 

--- a/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.scriptgenerator/src/uk/ac/stfc/isis/ibex/ui/scriptgenerator/views/ScriptGeneratorViewModel.java
@@ -79,7 +79,7 @@ import uk.ac.stfc.isis.ibex.ui.tables.DataboundCellLabelProvider;
  * The ViewModel for the ScriptGeneratorView.
  */
 public class ScriptGeneratorViewModel extends ModelObject {
-
+	
 	private static final Logger LOG = IsisLog.getLogger(ScriptGeneratorViewModel.class);
 
 	private static final String TAB = "\t";

--- a/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
+++ b/base/uk.ac.stfc.isis.ibex.ui/src/uk/ac/stfc/isis/ibex/ui/dialogs/BasicSelectionDialog.java
@@ -75,7 +75,7 @@ public abstract class BasicSelectionDialog extends Dialog {
 
     @Override
     protected Point getInitialSize() {
-        return new Point(450, 300);
+        return new Point(450, 300); 
     }
 
     @Override


### PR DESCRIPTION
### Description of work

Reorganised script generator buttons so they take up less space, and ensured they don't resize when the window is resized.

### Ticket

https://github.com/ISISComputingGroup/IBEX/issues/8826

### Acceptance criteria

- [ ] Varying screen height in the script generator view of the GUI does not shrink the buttons 

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

