### PR TITLE
Remove CodeQL 'quality' linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,5 +73,4 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.buildmode }}
-          queries: +security-and-quality
       - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
In https://github.com/ISISComputingGroup/ibex_gui/pull/1781 we turned on CodeQL "quality" linting as an experiment, alongside the existing checkstyle checks.

The java linting by CodeQL is not proving to be particularly useful; the "quality" lints are covered by checkstyle anyway.

Leave the CodeQL security linting in place ("default" codeql group) but turn off "code quality" linting.