### PR TITLE
Stop randomizing order of moxas every 30s

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServer.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServer.java
@@ -21,8 +21,8 @@ package uk.ac.stfc.isis.ibex.configserver;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Function;
 
 import uk.ac.stfc.isis.ibex.alarm.AlarmReloadManager;
@@ -363,7 +363,7 @@ public class ConfigServer extends Closer {
 	 * 
 	 * @return the map of hostname and ip addresses to moxa port mappings
 	 */
-	public ForwardingObservable<HashMap<String, ArrayList<ArrayList<String>>>> moxaMappings() {
+	public ForwardingObservable<TreeMap<String, ArrayList<ArrayList<String>>>> moxaMappings() {
 		return variables.moxaMappings;
 	}
 

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServerVariables.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/ConfigServerVariables.java
@@ -21,8 +21,8 @@ package uk.ac.stfc.isis.ibex.configserver;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Locale;
+import java.util.TreeMap;
 
 import org.apache.logging.log4j.Logger;
 
@@ -125,7 +125,7 @@ public class ConfigServerVariables extends Closer {
 	/** Provides the description for the spangle banner. */
 	public final ForwardingObservable<CustomBannerData> bannerDescription;
 	/** Provides the details for the Moxa port mappings. */
-	public final ForwardingObservable<HashMap<String, ArrayList<ArrayList<String>>>> moxaMappings;
+	public final ForwardingObservable<TreeMap<String, ArrayList<ArrayList<String>>>> moxaMappings;
 
 	/**
 	 * Default Constructor.

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/Configurations.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/Configurations.java
@@ -21,8 +21,8 @@ package uk.ac.stfc.isis.ibex.configserver;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
+import java.util.TreeMap;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
@@ -59,7 +59,7 @@ public class Configurations extends Closer implements BundleActivator {
 	private final Displaying displaying;
 	private final Editing editing;
 	private final IocControl iocControl;
-	private final UpdatedObservableAdapter<HashMap<String, ArrayList<ArrayList<String>>>> moxaMappings;
+	private final UpdatedObservableAdapter<TreeMap<String, ArrayList<ArrayList<String>>>> moxaMappings;
 	private final RecentConfigList recent;
 
 	private final ConfigServerVariables variables;
@@ -140,7 +140,7 @@ public class Configurations extends Closer implements BundleActivator {
 	/**
 	 * @return Moxa mapping information
 	 */
-	public UpdatedObservableAdapter<HashMap<String, ArrayList<ArrayList<String>>>> moxaMappings() { 
+	public UpdatedObservableAdapter<TreeMap<String, ArrayList<ArrayList<String>>>> moxaMappings() { 
 		return moxaMappings;
 	}
 	/**
@@ -212,6 +212,6 @@ public class Configurations extends Closer implements BundleActivator {
 	private void addLogging() {
 		loggingSubscriptions.add(variables.currentConfig.subscribe(new LoggingConfigurationObserver(LOG, "Current config")));
 		loggingSubscriptions.add(variables.serverStatus.subscribe(new LoggingObserver<ServerStatus>(LOG, "Server status")));
-		loggingSubscriptions.add(variables.moxaMappings.subscribe(new LoggingObserver<HashMap<String, ArrayList<ArrayList<String>>>>(LOG, "Moxa status", Level.DEBUG)));
+		loggingSubscriptions.add(variables.moxaMappings.subscribe(new LoggingObserver<TreeMap<String, ArrayList<ArrayList<String>>>>(LOG, "Moxa status", Level.DEBUG)));
 		}
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/Converters.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/internal/Converters.java
@@ -21,7 +21,7 @@ package uk.ac.stfc.isis.ibex.configserver.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.function.Function;
 
 import uk.ac.stfc.isis.ibex.configserver.BlockRules;
@@ -118,5 +118,5 @@ public interface Converters {
     /**
      * @return Converter for the moxa mapping information.
      */
-    Function<String, HashMap<String, ArrayList<ArrayList<String>>>> toMoxaMappings();
+    Function<String, TreeMap<String, ArrayList<ArrayList<String>>>> toMoxaMappings();
 }

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/json/JsonConverters.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/json/JsonConverters.java
@@ -21,8 +21,8 @@ package uk.ac.stfc.isis.ibex.configserver.json;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.Collection;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -189,7 +189,7 @@ public class JsonConverters implements Converters {
     }
 	
 	@Override 
-	public Function<String, HashMap<String, ArrayList<ArrayList<String>>>> toMoxaMappings() {
+	public Function<String, TreeMap<String, ArrayList<ArrayList<String>>>> toMoxaMappings() {
 		return new JsonDeserialisingConverter<>(Map.class).andThen(new MoxaMappingsConverter());
 		
 	}

--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/json/MoxaMappingsConverter.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/json/MoxaMappingsConverter.java
@@ -20,8 +20,8 @@
 package uk.ac.stfc.isis.ibex.configserver.json;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.Function;
 
 import uk.ac.stfc.isis.ibex.epics.conversion.ConversionException;
@@ -30,14 +30,13 @@ import uk.ac.stfc.isis.ibex.epics.conversion.ConversionException;
  * Converts a JSON representation of a PV into a java object representation.
  */
 @SuppressWarnings({ "checkstyle:magicnumber", "rawtypes", "unchecked" })
-public class MoxaMappingsConverter implements Function<Map, HashMap<String, ArrayList<ArrayList<String>>>> {
+public class MoxaMappingsConverter implements Function<Map, TreeMap<String, ArrayList<ArrayList<String>>>> {
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public HashMap<String, ArrayList<ArrayList<String>>> apply(Map value) throws ConversionException {
-		HashMap<String, ArrayList<ArrayList<String>>> namesToPorts = new HashMap<String, ArrayList<ArrayList<String>>>(value);
-		return namesToPorts;
+	public TreeMap<String, ArrayList<ArrayList<String>>> apply(Map value) throws ConversionException {
+		return new TreeMap<String, ArrayList<ArrayList<String>>>(value);
 	}
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaTableContentProvider.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxaTableContentProvider.java
@@ -1,7 +1,7 @@
 package uk.ac.stfc.isis.ibex.ui.moxas.views;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.TreeMap;
 
 import org.eclipse.jface.viewers.ITreeContentProvider;
 
@@ -11,7 +11,7 @@ import org.eclipse.jface.viewers.ITreeContentProvider;
 public class MoxaTableContentProvider implements ITreeContentProvider {
 	@Override
 	public Object[] getElements(Object inputElement) {
-		return HashMap.class.cast(inputElement).values().toArray();
+		return TreeMap.class.cast(inputElement).values().toArray();
 	}
 
 	@Override

--- a/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxasViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.moxas/src/uk/ac/stfc/isis/ibex/ui/moxas/views/MoxasViewModel.java
@@ -33,10 +33,11 @@ import java.beans.PropertyChangeListener;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import uk.ac.stfc.isis.ibex.configserver.Configurations;
@@ -51,7 +52,7 @@ import uk.ac.stfc.isis.ibex.model.ModelObject;
  */
 public class MoxasViewModel extends ModelObject {
 
-	private HashMap<String, MoxaList> moxaPorts = new HashMap<String, MoxaList>();
+	private Map<String, MoxaList> moxaPorts = new TreeMap<String, MoxaList>();
 	private final Configurations control;
 	private final UpdatedObservableAdapter<Configuration> currentConfig;
 	private static final String MIB_DELIM = "::";
@@ -66,11 +67,11 @@ public class MoxasViewModel extends ModelObject {
 	 * 
 	 * @return a map of Moxa port to serial port mappings by Moxa device
 	 */
-	public HashMap<String, MoxaList> getMoxaPorts() {
-		HashMap<String, MoxaList> map = new HashMap<String, MoxaList>();
+	public Map<String, MoxaList> getMoxaPorts() {
+		var map = new TreeMap<String, MoxaList>();
 		Collection<Ioc> iocsInConfig = getIocsInConfig();
 
-		HashMap<String, ArrayList<ArrayList<String>>> ret = control.moxaMappings().getValue();
+		var ret = control.moxaMappings().getValue();
 		if (ret != null) {
 			ret.forEach((key, value) -> {
 				MoxaList list = new MoxaList(key);


### PR DESCRIPTION
### Description of work

Stop randomizing the order of moxas every 30 seconds.

### Ticket

Support issue

### Acceptance criteria

- Moxa order is predictable (sorted by name)
- Expanded moxas don't collapse while you're looking at them

### Release notes

https://github.com/ISISComputingGroup/IBEX/pull/8962

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

