### PR TITLE
Use bundled jdk to compile

### DIFF
--- a/build/build.bat
+++ b/build/build.bat
@@ -23,7 +23,8 @@ if %errcode% GEQ 4 (
 
 call copy_in_maven.bat
 if %errorlevel% neq 0 exit /b %errorlevel%
-set "M2=%~dp0maven\bin"
+set "M2_HOME=%~dp0maven"
+set "M2=%M2_HOME%\bin"
 set "PATH=%M2%;%PATH%"
 
 SET "JAVA_HOME=%LOCAL_JRE_LOCATION%"

--- a/build/build.bat
+++ b/build/build.bat
@@ -23,9 +23,11 @@ if %errcode% GEQ 4 (
 
 call copy_in_maven.bat
 if %errorlevel% neq 0 exit /b %errorlevel%
-set "PATH=%PATH%;%~dp0maven\bin"
+set "M2=%~dp0maven\bin"
+set "PATH=%M2%;%PATH%"
 
-SET "JAVA_HOME=%~dp0jdk"
+SET "JAVA_HOME=%LOCAL_JRE_LOCATION%"
+set "PATH=%JAVA_HOME%\bin;%PATH%"
 
 REM temporarily disable checks as workaround for JDK CEN header issue
 set "JAVA_TOOL_OPTIONS=-Djdk.util.zip.disableZip64ExtraFieldValidation=true"

--- a/build/build_script_generator.bat
+++ b/build/build_script_generator.bat
@@ -19,7 +19,8 @@ if %errcode% GEQ 4 (
 
 call copy_in_maven.bat
 if %errorlevel% neq 0 exit /b %errorlevel%
-set "M2=%~dp0maven\bin"
+set "M2_HOME=%~dp0maven"
+set "M2=%M2_HOME%\bin"
 set "PATH=%M2%;%PATH%"
 
 SET "JAVA_HOME=%LOCAL_JRE_LOCATION%"

--- a/build/build_script_generator.bat
+++ b/build/build_script_generator.bat
@@ -19,9 +19,11 @@ if %errcode% GEQ 4 (
 
 call copy_in_maven.bat
 if %errorlevel% neq 0 exit /b %errorlevel%
-set "PATH=%PATH%;%~dp0maven\bin"
+set "M2=%~dp0maven\bin"
+set "PATH=%M2%;%PATH%"
 
 SET "JAVA_HOME=%LOCAL_JRE_LOCATION%"
+set "PATH=%JAVA_HOME%\bin;%PATH%"
 
 REM temporarily disable checks as workaround for JDK CEN header issue
 set "JAVA_TOOL_OPTIONS=-Djdk.util.zip.disableZip64ExtraFieldValidation=true"

--- a/build/jenkins_build.bat
+++ b/build/jenkins_build.bat
@@ -3,11 +3,8 @@ setlocal enabledelayedexpansion
 
 set BASEDIR=%~dp0
 
-set M2=%MAVEN%bin
 set PYTHON3=%WORKSPACE%\Python3\python.exe
 set PYTHON_HOME=%WORKSPACE%\Python3
-
-set PATH=%M2%;%JAVA_HOME%;%PATH%
 
 if "%IS_E4%" == "YES" (
     set BUILT_CLIENT_DIR=base\uk.ac.stfc.isis.ibex.e4.client.product\target\products\ibex.product\win32\win32\x86_64

--- a/build/jenkins_build_script_generator.bat
+++ b/build/jenkins_build_script_generator.bat
@@ -3,11 +3,8 @@ setlocal enabledelayedexpansion
 
 set BASEDIR=%~dp0
 
-set M2=%MAVEN%bin
 set PYTHON3=%WORKSPACE%\Python3\python.exe
 set PYTHON_HOME=%WORKSPACE%\Python3
-
-set PATH=%M2%;%PATH%
 
 set TARGET_DIR=script_generator
 set MSINAME=ibex_script_generator


### PR DESCRIPTION
### Description of work

Use bundled JDK to compile client - previously it was picking up whatever java was in system PATH. Using bundled jdk ensures correct version is always used and also consistency across build servers

### Acceptance criteria

* PR built in jenkins

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

