### PR TITLE
ticket 7986

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlockDetailsPanel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlockDetailsPanel.java
@@ -31,6 +31,9 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.custom.StyleRange;
 
 import uk.ac.stfc.isis.ibex.ui.widgets.buttons.IBEXButton;
 
@@ -42,11 +45,14 @@ import uk.ac.stfc.isis.ibex.ui.widgets.buttons.IBEXButton;
 public class BlockDetailsPanel extends Composite {
 	
 	private final Text name;
-	private final Text pvAddress;
+	private final StyledText pvAddress;
 	private final Button visible;
 	private final Button local;
 	private final Button btnPickPV;
 
+	private final Color prefixColor = new Color(getDisplay(), 166,28,0);
+	private final Color prefixHighlight = new Color(getDisplay(), 244, 204, 204);
+	
 	/**
      * Standard constructor.
      * 
@@ -85,10 +91,13 @@ public class BlockDetailsPanel extends Composite {
 		lblPvAddress.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, false, false, 1, 1));
 		lblPvAddress.setText("PV address:");
 		
-		pvAddress = new Text(grpBlock, SWT.BORDER);
+		pvAddress = new StyledText(grpBlock, SWT.BORDER);
 		GridData gdPvAddress = new GridData(SWT.CENTER, SWT.CENTER, true, false, 2, 1);
 		gdPvAddress.minimumWidth = 380;
 		pvAddress.setLayoutData(gdPvAddress);
+		pvAddress.addExtendedModifyListener(e->updateStyle(viewModel.getPrefix()));
+				
+		
 		
 		btnPickPV = new IBEXButton(grpBlock, SWT.NONE, _ -> viewModel.openPvDialog())
 				.layoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 1, 1))
@@ -97,6 +106,21 @@ public class BlockDetailsPanel extends Composite {
 		
 		setModel(viewModel);
 	}
+	
+	
+	
+	private void updateStyle(String prefix) {
+		StyleRange prefixStyle = new StyleRange();
+		prefixStyle.start = 0;
+		prefixStyle.length = prefix.length();
+		prefixStyle.foreground = prefixColor;
+		prefixStyle.fontStyle = SWT.ITALIC;
+		prefixStyle.background = prefixHighlight;
+		if (pvAddress.getText().startsWith(prefix)){
+			pvAddress.setStyleRange(prefixStyle);
+		}
+	}
+	
 	
 	private void setModel(BlockDetailsViewModel viewModel) {
 		DataBindingContext bindingContext = new DataBindingContext();
@@ -122,4 +146,5 @@ public class BlockDetailsPanel extends Composite {
                 BeanProperties.value("visible").observe(viewModel));
         
 	}
+	
 }

--- a/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlockDetailsViewModel.java
+++ b/base/uk.ac.stfc.isis.ibex.ui.configserver/src/uk/ac/stfc/isis/ibex/ui/configserver/editing/blocks/BlockDetailsViewModel.java
@@ -29,6 +29,7 @@ import uk.ac.stfc.isis.ibex.configserver.configuration.Block;
 import uk.ac.stfc.isis.ibex.configserver.editing.BlockNameValidator;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableBlock;
 import uk.ac.stfc.isis.ibex.configserver.editing.EditableConfiguration;
+import uk.ac.stfc.isis.ibex.instrument.Instrument;
 import uk.ac.stfc.isis.ibex.ui.configserver.dialogs.PvSelectorDialog;
 import uk.ac.stfc.isis.ibex.validators.ErrorMessageProvider;
 import uk.ac.stfc.isis.ibex.validators.PvValidator;
@@ -48,6 +49,8 @@ public class BlockDetailsViewModel extends ErrorMessageProvider {
     private final EditableConfiguration config;
     
     private final List<String> facilityPvList;
+    
+    
 
     /**
      * Constructor.
@@ -150,8 +153,26 @@ public class BlockDetailsViewModel extends ErrorMessageProvider {
      * @param local true for local
      */
 	public void setLocal(boolean local) {
+		String prefix = Instrument.getInstance().getPvPrefix();
+		String pvAddress1 = pvAddress;
+		if (local) {
+			if (!pvAddress.startsWith(prefix)) {
+				pvAddress = prefix + pvAddress;
+			}
+		}else {
+			if (pvAddress.startsWith(prefix)) {
+				pvAddress = pvAddress.substring(prefix.length());
+			}
+		}
 		firePropertyChange("local", this.local, this.local = local);
+		firePropertyChange("pvAddress", pvAddress1, pvAddress);
 	}
+	
+	public String getPrefix() {
+		return Instrument.getInstance().getPvPrefix();
+	}
+
+	
     
     /**
      * Open the PV dialog window.
@@ -169,7 +190,6 @@ public class BlockDetailsViewModel extends ErrorMessageProvider {
     public void updateBlock() {
     	editingBlock.setName(name);
     	editingBlock.setPV(pvAddress);
-
     	editingBlock.setIsLocal(local);
     	editingBlock.setIsVisible(visible);
     }


### PR DESCRIPTION
### Description of work
Added italics text color change and highlight of prefix to local checkbox

### Ticket
[ISSISComputingGroup/IBEX#7986](https://github.com/ISISComputingGroup/IBEX/issues/7986)

### Acceptance criteria

*List the acceptance criteria for the PR. The aim is provide information to help the reviewer*

**Acceptance criteria**
- [ ] When a user selects local when adding a block, the prefix is appended in the textbox for "PV address" and some indication is given that the local box is influencing this (be it highlighting, coloured text etc.)
- [ ] When a user unticks the "local" box, if there is a prefix which matches the instrument prefix, this is removed from the "PV address" textbox
- [ ] Squish tests are added for both cases

### System tests
No tests have been implemented with Squish. Have tried and tested it in ibex.

### Documentation
-

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

