### PR TITLE
Add check for missing test modules in pom.xml

### DIFF
--- a/build/4473.py
+++ b/build/4473.py
@@ -1,0 +1,40 @@
+import os
+import xml.etree.ElementTree as ET
+import sys
+
+fail=False
+filetype=".tests"
+
+pathsxml = r"C:\Instrument\dev\ibex_gui\base\uk.ac.stfc.isis.ibex.client.tycho.parent\pom.xml"
+pathsfolder = r"C:\Instrument\dev\ibex_gui\base"
+
+folderFiles = os.listdir(pathsfolder)
+testFiles = []
+for file in folderFiles:
+    if file[-(len(filetype)):] == filetype:
+        testFiles.append(file)
+  
+tree = ET.parse(pathsxml)
+root = tree.getroot()
+xmlmodules=[]
+for module in root.iter("{http://maven.apache.org/POM/4.0.0}module"):
+    xmlmodules.append(module.text)
+
+xmlmodulenames = []
+for name in xmlmodules:
+    if name[-(len(filetype)):] == filetype:
+        xmlmodulenames.append(name[3:])
+        
+missingtests=[]
+for testfile in testFiles:
+    if testfile not in xmlmodulenames:
+        fail = True
+        missingtests.append(testfile)
+
+if fail == True:
+    print(f".test files in base/ not found in pom.xml")
+    print(f"Missing files: {missingtests}")
+    print(f"To fix this: add missing files to the list in client.tycho.parent/pom.xml")
+    sys.exit(1)
+else:
+    sys.exit(0)

--- a/build/build.bat
+++ b/build/build.bat
@@ -44,6 +44,9 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 %PYTHON3% .\check_build.py ..\base\
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+%PYTHON3% .\check_tests.py ..\base\
+if %errorlevel% neq 0 exit /b %errorlevel%
+
 if "%BUILD_NUMBER%" == "" SET BUILD_NUMBER=SNAPSHOT
 
 set mvnErr=

--- a/build/check_tests.py
+++ b/build/check_tests.py
@@ -1,0 +1,51 @@
+import os
+import xml.etree.ElementTree as ET
+import sys
+
+SUCCESS = 0
+INCORRECT_ARGS = 1
+TESTS_NOT_IN_POM = 2
+fileType=".tests"
+
+def check_tests_in_pom(build_root_path):
+    pathsxml = build_root_path + r"uk.ac.stfc.isis.ibex.client.tycho.parent\pom.xml"
+    
+    folderFiles = os.listdir(build_root_path)
+    testFiles = [name for name in folderFiles if name.endswith(fileType)]
+    
+    tree = ET.parse(pathsxml)
+    root = tree.getroot()
+    xmlmodulenames = []
+    for module in root.iter():
+        if module.tag.endswith("module"):
+            name = module.text[3:]
+            if name.endswith(fileType):
+                xmlmodulenames.append(name)
+    missingtests = [file for file in testFiles if file not in xmlmodulenames]
+    
+    if missingtests:
+        print(f".test files in base/ not found in pom.xml")
+        print(f"Missing files: {missingtests}")
+        print(f"To fix this: add missing files to the list in client.tycho.parent/pom.xml")
+        return False
+    else:
+        return True
+
+def main(build_root_path):
+    try:
+        os.chdir(build_root_path)
+    except Exception as e:
+        return INCORRECT_ARGS
+    if not check_tests_in_pom(build_root_path):
+        return TESTS_NOT_IN_POM
+        print("check_tests: all test modules in pom.xml")
+    return SUCCESS
+
+if __name__ == '__main__':
+    success = SUCCESS
+    if len(sys.argv) != 2:
+        print("Incorrect arguments, expected path to build base directory")
+        success = INCORRECT_ARGS
+    else:
+        success = main(sys.argv[1])
+    sys.exit(success)


### PR DESCRIPTION
### Description of work

Add check for missing test modules in pom.xml
### Ticket

[*Link to Ticket*]
(https://github.com/ISISComputingGroup/ibex/issues/4473)
### Acceptance criteria

- [ ] GUI build fails if any test module is not listed in client.tycho.parent/pom.xml
- [ ] GUI build is running all tests & therefore passes

### Unit tests

tested in command prompt by running my script by itself

### System tests
tested in command prompt by running my script by itself

### Documentation
---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

