### PR TITLE
Sets the default flag correctly for already present macros

### DIFF
--- a/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Configuration.java
+++ b/base/uk.ac.stfc.isis.ibex.configserver/src/uk/ac/stfc/isis/ibex/configserver/configuration/Configuration.java
@@ -134,6 +134,7 @@ public class Configuration extends ModelObject {
 				other.getComponents(), other.getHistory(), other.isProtected, other.isDynamic,
 				other.configuresBlockGWAndArchiver, other.getGlobalmacros());
 		this.pv = other.pv;
+		this.iocs.forEach(ioc -> ioc.getMacros().forEach(macro -> macro.setUseDefault(false)));
 	}
 
 	/**


### PR DESCRIPTION
### Description of work

The change is to fix a bug due to which repeated edits of a macro in the configured IOC was was erasing the previous details.

### Ticket

[8950](https://github.com/ISISComputingGroup/IBEX/issues/8950)

### Acceptance criteria
It should save the macro edits while retaining old value that haven't been removed the current edit.

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] If the change is to an OPI, does the `check_opi_format.py` script in [C:\Instrument\Dev\ibex_gui\base\uk.ac.stfc.isis.ibex.opis](https://github.com/ISISComputingGroup/ibex_gui/blob/master/base/uk.ac.stfc.isis.ibex.opis/check_opi_format.py) pass?
- [ ] Do the changes function as described and is it robust?
- [ ] Is there associated PR for the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)?

### Final Steps
- [ ] Reviewer has also merged the [release notes](https://github.com/ISISComputingGroup/IBEX/blob/master/release_notes/ReleaseNotes_Upcoming.md)

